### PR TITLE
fix: rename gmail_get_message to gmail_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Contact management: list, search, create, update, delete, contact groups.
 | Tool | Description |
 |------|-------------|
 | `gmail_search` | Search messages with Gmail query syntax |
-| `gmail_get_message` | Get single message with full content |
+| `gmail_get` | Get single message with full content |
+| `gmail_get_message` | Alias for `gmail_get` |
 | `gmail_get_messages` | Batch get messages (max 25) |
 | `gmail_get_thread` | Get full conversation thread |
 | `gmail_send` | Send new email |
@@ -199,7 +200,7 @@ All tools accept an optional `account` parameter:
 
 ```
 1. gmail_search({"query": "is:unread", "account": "support"})
-2. gmail_get_messages({"message_ids": [...], "account": "support"})
+2. gmail_get({"message_id": "...", "account": "support"})
 3. gmail_reply({"message_id": "...", "body": "Thanks for reaching out..."})
 4. gmail_batch_archive({"message_ids": [...]})
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,7 +56,8 @@ Go-based Gmail, Google Calendar, Google Docs, Google Tasks, and Google Drive MCP
 | Tool | Description | Status |
 |------|-------------|--------|
 | `gmail_search` | Search with Gmail query syntax | ✅ Complete |
-| `gmail_get_message` | Get full message content | ✅ Complete |
+| `gmail_get` | Get full message content | ✅ Complete |
+| `gmail_get_message` | Alias for `gmail_get` | ✅ Complete |
 | `gmail_get_messages` | Batch retrieve messages | ✅ Complete |
 | `gmail_get_thread` | Get full conversation | ✅ Complete |
 | `gmail_send` | Send emails with attachments | ✅ Complete |

--- a/internal/gmail/register.go
+++ b/internal/gmail/register.go
@@ -12,16 +12,25 @@ func RegisterTools(s *server.MCPServer) {
 
 	// gmail_search - Search messages with query
 	s.AddTool(mcp.NewTool("gmail_search",
-		mcp.WithDescription("Search Gmail messages with query. Returns message IDs for use with gmail_get_message/gmail_get_messages."),
+		mcp.WithDescription("Search Gmail messages with query. Returns message IDs for use with gmail_get/gmail_get_messages."),
 		mcp.WithString("query", mcp.Required(), mcp.Description("Gmail search query (e.g., 'is:unread', 'from:amazon newer_than:7d')")),
 		mcp.WithNumber("max_results", mcp.Description("Maximum results to return (1-100, default 20)")),
 		common.WithPageToken(),
 		common.WithAccountParam(),
 	), HandleGmailSearch)
 
-	// gmail_get_message - Read single message
-	s.AddTool(mcp.NewTool("gmail_get_message",
+	// gmail_get - Read single message (primary name, matches convention of other services)
+	s.AddTool(mcp.NewTool("gmail_get",
 		mcp.WithDescription("Get a single Gmail message by ID. Returns full message with headers and body."),
+		mcp.WithString("message_id", mcp.Required(), mcp.Description("Gmail message ID")),
+		mcp.WithString("format", mcp.Description("Response format: full (default), metadata, minimal, raw")),
+		mcp.WithString("body_format", mcp.Description("Body content format: text (default, plain text for reduced tokens), html (full HTML), full (both text and html)")),
+		common.WithAccountParam(),
+	), HandleGmailGetMessage)
+
+	// gmail_get_message - Alias for gmail_get (backward compatibility)
+	s.AddTool(mcp.NewTool("gmail_get_message",
+		mcp.WithDescription("Alias for gmail_get. Get a single Gmail message by ID."),
 		mcp.WithString("message_id", mcp.Required(), mcp.Description("Gmail message ID")),
 		mcp.WithString("format", mcp.Description("Response format: full (default), metadata, minimal, raw")),
 		mcp.WithString("body_format", mcp.Description("Body content format: text (default, plain text for reduced tokens), html (full HTML), full (both text and html)")),


### PR DESCRIPTION
## Summary

- Renames `gmail_get_message` → `gmail_get` as the primary tool name, matching the convention used by all other services (`drive_get`, `docs_get`, `contacts_get`, `sheets_get`, `tasks_get`)
- Keeps `gmail_get_message` as a backward-compatible alias pointing to the same handler
- Updates `gmail_search` description and docs to reference `gmail_get`

## Test plan

- [x] `go build` succeeds
- [x] `go test ./...` all pass
- [ ] Verify `gmail_get` works via MCP client
- [ ] Verify `gmail_get_message` alias still works

Closes #1