### PR TITLE
docs: add OAuth re-auth instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,22 @@ See **[docs/AGENTS.md](docs/AGENTS.md)** for full development guidelines, archit
 | `go vet ./...` | Check for issues |
 | `gofmt -w .` | Format code |
 
+## Re-authenticating Accounts
+
+When an account token expires or gets revoked:
+
+```bash
+./gsuite-mcp auth <label>
+```
+
+This opens a browser for Google OAuth. Replace `<label>` with the account label (e.g., `personal`, `work`). Run once per account that needs re-auth.
+
+To check which accounts are authenticated:
+
+```bash
+./gsuite-mcp accounts
+```
+
 ## Documentation
 
 - [docs/AGENTS.md](docs/AGENTS.md) — Development guidelines and patterns


### PR DESCRIPTION
## Summary
- Adds "Re-authenticating Accounts" section to CLAUDE.md with `./gsuite-mcp auth <label>` and `./gsuite-mcp accounts` commands
- Tokens can expire/get revoked during sessions; this documents the quick fix

Closes #3

## Test plan
- [x] Instructions match actual CLI behavior
- [x] Verified commands work (`./gsuite-mcp auth`, `./gsuite-mcp accounts`)