### PR TITLE
refactor: remove dead code across common/ and service packages

### DIFF
--- a/internal/calendar/calendar_handlers.go
+++ b/internal/calendar/calendar_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/option"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type CalendarHandlerDeps = common.HandlerDeps[CalendarService]
-type CalendarServiceFactory = common.ServiceFactory[CalendarService]
-type MockCalendarServiceFactory = common.MockServiceFactory[CalendarService]
 
 // NewCalendarService creates a CalendarService from an authenticated HTTP client.
 func NewCalendarService(ctx context.Context, client *http.Client) (CalendarService, error) {

--- a/internal/calendar/calendar_tools.go
+++ b/internal/calendar/calendar_tools.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
-	"google.golang.org/api/calendar/v3"
 )
 
 // Calendar API field constants for optimized responses.
@@ -41,6 +40,3 @@ var (
 	HandleCalendarListInstances  = common.WrapHandler[CalendarService](TestableCalendarListInstances)
 	HandleCalendarUpdateInstance = common.WrapHandler[CalendarService](TestableCalendarUpdateInstance)
 )
-
-// Suppressing unused import/variable warnings
-var _ = calendar.Event{}

--- a/internal/common/args.go
+++ b/internal/common/args.go
@@ -9,15 +9,6 @@ func ParseStringArg(args map[string]any, key string, defaultVal string) string {
 	return defaultVal
 }
 
-// ParseInt64Arg extracts a number argument and converts it to int64.
-// Returns defaultVal if the argument is missing or invalid.
-func ParseInt64Arg(args map[string]any, key string, defaultVal int64) int64 {
-	if val, ok := args[key].(float64); ok {
-		return int64(val)
-	}
-	return defaultVal
-}
-
 // ParseBoolArg extracts a boolean argument.
 // Returns defaultVal if the argument is missing or invalid.
 func ParseBoolArg(args map[string]any, key string, defaultVal bool) bool {

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -1,9 +1,7 @@
 package common
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/auth"
 	"github.com/aliwatters/gsuite-mcp/internal/config"
@@ -26,20 +24,6 @@ func SetDeps(d *Deps) {
 // GetDeps returns the global dependencies.
 func GetDeps() *Deps {
 	return deps
-}
-
-// GetAuthenticatedClient resolves the account from the request and returns
-// an authenticated HTTP client ready for Google API calls.
-func GetAuthenticatedClient(ctx context.Context, request mcp.CallToolRequest) (*http.Client, error) {
-	email, err := ResolveAccountFromRequest(request)
-	if err != nil {
-		return nil, err
-	}
-	client, err := GetDeps().AuthManager.GetClientOrAuthenticate(ctx, email, false)
-	if err != nil {
-		return nil, fmt.Errorf("authentication error: %w", err)
-	}
-	return client, nil
 }
 
 // ResolveAccountFromRequest extracts and validates the account parameter.

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,18 +1,8 @@
 package common
 
 import (
-	"context"
-	"net/http"
-
 	"github.com/mark3labs/mcp-go/mcp"
 )
-
-// AuthManagerInterface defines the interface for auth.Manager.
-// This interface enables dependency injection for testing.
-type AuthManagerInterface interface {
-	GetClientForEmail(ctx context.Context, email string) (*http.Client, error)
-	GetClientOrAuthenticate(ctx context.Context, email string, interactive bool) (*http.Client, error)
-}
 
 // MethodCall records a method call for test verification.
 type MethodCall struct {

--- a/internal/contacts/contacts_handlers.go
+++ b/internal/contacts/contacts_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/people/v1"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type ContactsHandlerDeps = common.HandlerDeps[ContactsService]
-type ContactsServiceFactory = common.ServiceFactory[ContactsService]
-type MockContactsServiceFactory = common.MockServiceFactory[ContactsService]
 
 // NewContactsService creates a ContactsService from an authenticated HTTP client.
 func NewContactsService(ctx context.Context, client *http.Client) (ContactsService, error) {

--- a/internal/docs/docs_handlers.go
+++ b/internal/docs/docs_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/option"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type DocsHandlerDeps = common.HandlerDeps[DocsService]
-type DocsServiceFactory = common.ServiceFactory[DocsService]
-type MockDocsServiceFactory = common.MockServiceFactory[DocsService]
 
 // NewDocsService creates a DocsService from an authenticated HTTP client.
 func NewDocsService(ctx context.Context, client *http.Client) (DocsService, error) {

--- a/internal/drive/drive_handlers.go
+++ b/internal/drive/drive_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/option"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type DriveHandlerDeps = common.HandlerDeps[DriveService]
-type DriveServiceFactory = common.ServiceFactory[DriveService]
-type MockDriveServiceFactory = common.MockServiceFactory[DriveService]
 
 // NewDriveService creates a DriveService from an authenticated HTTP client.
 func NewDriveService(ctx context.Context, client *http.Client) (DriveService, error) {

--- a/internal/gmail/gmail_handlers.go
+++ b/internal/gmail/gmail_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/option"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type GmailHandlerDeps = common.HandlerDeps[GmailService]
-type GmailServiceFactory = common.ServiceFactory[GmailService]
-type MockGmailServiceFactory = common.MockServiceFactory[GmailService]
 
 // NewGmailService creates a GmailService from an authenticated HTTP client.
 func NewGmailService(ctx context.Context, client *http.Client) (GmailService, error) {

--- a/internal/gmail/gmail_tools.go
+++ b/internal/gmail/gmail_tools.go
@@ -8,15 +8,6 @@ import (
 	"google.golang.org/api/gmail/v1"
 )
 
-// Gmail API field constants for optimized responses.
-// These reduce response payload size by only requesting needed fields.
-const (
-	// GmailLabelListFields contains fields for label listings
-	GmailLabelListFields = "labels(id,name,type,messagesTotal,messagesUnread,threadsTotal,threadsUnread)"
-	// GmailMessageListFields contains fields for message listings (search results)
-	GmailMessageListFields = "nextPageToken,resultSizeEstimate,messages(id,threadId)"
-)
-
 // === Handle functions - generated via WrapHandler ===
 
 var (

--- a/internal/sheets/sheets_handlers.go
+++ b/internal/sheets/sheets_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type SheetsHandlerDeps = common.HandlerDeps[SheetsService]
-type SheetsServiceFactory = common.ServiceFactory[SheetsService]
-type MockSheetsServiceFactory = common.MockServiceFactory[SheetsService]
 
 // NewSheetsService creates a SheetsService from an authenticated HTTP client.
 func NewSheetsService(ctx context.Context, client *http.Client) (SheetsService, error) {

--- a/internal/tasks/tasks_handlers.go
+++ b/internal/tasks/tasks_handlers.go
@@ -10,10 +10,8 @@ import (
 	"google.golang.org/api/tasks/v1"
 )
 
-// Type aliases using generic types from common package.
+// Type alias using generic types from common package.
 type TasksHandlerDeps = common.HandlerDeps[TasksService]
-type TasksServiceFactory = common.ServiceFactory[TasksService]
-type MockTasksServiceFactory = common.MockServiceFactory[TasksService]
 
 // NewTasksService creates a TasksService from an authenticated HTTP client.
 func NewTasksService(ctx context.Context, client *http.Client) (TasksService, error) {

--- a/internal/tasks/tasks_service.go
+++ b/internal/tasks/tasks_service.go
@@ -34,18 +34,16 @@ type ListTaskListsOptions struct {
 
 // ListTasksOptions contains optional parameters for listing tasks.
 type ListTasksOptions struct {
-	MaxResults         int64
-	PageToken          string
-	ShowCompleted      bool
-	ShowHidden         bool
-	ShowDeleted        bool
-	DueMin             string // RFC 3339 timestamp
-	DueMax             string // RFC 3339 timestamp
-	CompletedMin       string // RFC 3339 timestamp
-	CompletedMax       string // RFC 3339 timestamp
-	UpdatedMin         string // RFC 3339 timestamp
-	ShowAssigned       bool
-	ShowOnlyAssignedMe bool
+	MaxResults    int64
+	PageToken     string
+	ShowCompleted bool
+	ShowHidden    bool
+	ShowDeleted   bool
+	DueMin        string // RFC 3339 timestamp
+	DueMax        string // RFC 3339 timestamp
+	CompletedMin  string // RFC 3339 timestamp
+	CompletedMax  string // RFC 3339 timestamp
+	UpdatedMin    string // RFC 3339 timestamp
 }
 
 // CreateTaskOptions contains optional parameters for creating a task.

--- a/internal/tasks/tasks_test_helpers.go
+++ b/internal/tasks/tasks_test_helpers.go
@@ -167,10 +167,3 @@ func createTestTask(id, title, notes, status, due, completed string) *tasks.Task
 
 	return task
 }
-
-// createTestTaskWithParent creates a Task with a parent (subtask).
-func createTestTaskWithParent(id, title, parentID string) *tasks.Task {
-	task := createTestTask(id, title, "", "needsAction", "", "")
-	task.Parent = parentID
-	return task
-}


### PR DESCRIPTION
## Summary

- Remove `GetAuthenticatedClient`, `AuthManagerInterface`, `ParseInt64Arg` from common/ (superseded by DI pattern or never used)
- Remove `GmailLabelListFields`, `GmailMessageListFields` constants (never referenced)
- Remove dummy `var _ = calendar.Event{}` and unused calendar/v3 import
- Remove `ShowAssigned`, `ShowOnlyAssignedMe` fields from `ListTasksOptions` (never read or set)
- Remove `createTestTaskWithParent` test helper (never called)
- Remove 14 unused type aliases (`XxxServiceFactory`, `MockXxxServiceFactory`) across all 7 handlers files

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 10 packages)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] Net -71 lines across 14 files

Closes #8