### PR TITLE
refactor: extract DRY helpers and reduce exported surface

### DIFF
--- a/internal/common/handler_deps.go
+++ b/internal/common/handler_deps.go
@@ -21,8 +21,8 @@ type HandlerDeps[S any] struct {
 	ServiceFactory ServiceFactory[S]
 }
 
-// GetServiceWithDeps resolves the email from the request and creates a service.
-func GetServiceWithDeps[S any](ctx context.Context, request mcp.CallToolRequest, deps *HandlerDeps[S], defaultDeps *HandlerDeps[S]) (S, error) {
+// getServiceWithDeps resolves the email from the request and creates a service.
+func getServiceWithDeps[S any](ctx context.Context, request mcp.CallToolRequest, deps *HandlerDeps[S], defaultDeps *HandlerDeps[S]) (S, error) {
 	if deps == nil {
 		deps = defaultDeps
 	}
@@ -84,7 +84,7 @@ func (f *lazyServiceFactory[S]) CreateService(ctx context.Context, email string)
 // an MCP error result if resolution fails. Returns (service, nil, true) on success
 // or (zero, errorResult, false) on failure.
 func ResolveServiceOrError[S any](ctx context.Context, request mcp.CallToolRequest, deps *HandlerDeps[S], defaultDeps *HandlerDeps[S]) (S, *mcp.CallToolResult, bool) {
-	svc, err := GetServiceWithDeps(ctx, request, deps, defaultDeps)
+	svc, err := getServiceWithDeps(ctx, request, deps, defaultDeps)
 	if err != nil {
 		var zero S
 		return zero, mcp.NewToolResultError(err.Error()), false
@@ -102,12 +102,12 @@ func (f *MockServiceFactory[S]) CreateService(ctx context.Context, email string)
 	return f.MockService, nil
 }
 
-// TestableFunc is a handler function that accepts deps for dependency injection.
-type TestableFunc[S any] func(ctx context.Context, request mcp.CallToolRequest, deps *HandlerDeps[S]) (*mcp.CallToolResult, error)
+// testableFunc is a handler function that accepts deps for dependency injection.
+type testableFunc[S any] func(ctx context.Context, request mcp.CallToolRequest, deps *HandlerDeps[S]) (*mcp.CallToolResult, error)
 
-// WrapHandler wraps a TestableFunc into a standard MCP handler by passing nil deps,
+// WrapHandler wraps a testableFunc into a standard MCP handler by passing nil deps,
 // which causes the testable function to resolve production dependencies.
-func WrapHandler[S any](fn TestableFunc[S]) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func WrapHandler[S any](fn testableFunc[S]) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return fn(ctx, request, nil)
 	}

--- a/internal/docs/docs_content_test.go
+++ b/internal/docs/docs_content_test.go
@@ -57,7 +57,7 @@ func TestHandleDocsCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsCreate(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -151,7 +151,7 @@ func TestHandleDocsGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsGet(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -226,7 +226,7 @@ func TestHandleDocsGetMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsGetMetadata(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -307,7 +307,7 @@ func TestHandleDocsAppendText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsAppendText(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -393,7 +393,7 @@ func TestHandleDocsInsertText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsInsertText(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -467,7 +467,7 @@ func TestDocsServiceErrors(t *testing.T) {
 		fixtures.MockService.Errors.Create = errors.New("API quota exceeded")
 		defer func() { fixtures.MockService.Errors.Create = nil }()
 
-		request := MakeDocsRequest(map[string]any{
+		request := common.CreateMCPRequest(map[string]any{
 			"title": "Test Doc",
 		})
 		result, err := testableDocsCreate(context.Background(), request, fixtures.Deps)
@@ -490,7 +490,7 @@ func TestDocsServiceErrors(t *testing.T) {
 		fixtures.MockService.Errors.GetDocument = errors.New("permission denied")
 		defer func() { fixtures.MockService.Errors.GetDocument = nil }()
 
-		request := MakeDocsRequest(map[string]any{
+		request := common.CreateMCPRequest(map[string]any{
 			"document_id": "test-doc-1",
 		})
 		result, err := testableDocsGet(context.Background(), request, fixtures.Deps)
@@ -576,7 +576,7 @@ func TestHandleDocsReplaceText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsReplaceText(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -681,7 +681,7 @@ func TestHandleDocsDeleteText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsDeleteText(context.Background(), request, fixtures.Deps)
 
 			if err != nil {

--- a/internal/docs/docs_formatting_testable.go
+++ b/internal/docs/docs_formatting_testable.go
@@ -125,17 +125,15 @@ func TestableDocsFormatText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
-	}
-
-	startIndex, endIndex, errResult := extractIndexRange(request)
+	docID, errResult := extractRequiredDocID(request)
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	docID = common.ExtractGoogleResourceID(docID)
+	startIndex, endIndex, idxErrResult := extractIndexRange(request)
+	if idxErrResult != nil {
+		return idxErrResult, nil
+	}
 
 	fields, validationErr := collectFields(request.Params.Arguments, textFormatFields)
 	if validationErr != nil {
@@ -179,17 +177,15 @@ func TestableDocsClearFormatting(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
-	}
-
-	startIndex, endIndex, errResult := extractIndexRange(request)
+	docID, errResult := extractRequiredDocID(request)
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	docID = common.ExtractGoogleResourceID(docID)
+	startIndex, endIndex, idxErrResult := extractIndexRange(request)
+	if idxErrResult != nil {
+		return idxErrResult, nil
+	}
 
 	requests := []*docs.Request{{
 		UpdateTextStyle: &docs.UpdateTextStyleRequest{
@@ -223,17 +219,15 @@ func TestableDocsSetParagraphStyle(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
-	}
-
-	startIndex, endIndex, errResult := extractIndexRange(request)
+	docID, errResult := extractRequiredDocID(request)
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	docID = common.ExtractGoogleResourceID(docID)
+	startIndex, endIndex, idxErrResult := extractIndexRange(request)
+	if idxErrResult != nil {
+		return idxErrResult, nil
+	}
 
 	fields, validationErr := collectFields(request.Params.Arguments, paragraphStyleFields)
 	if validationErr != nil {
@@ -277,14 +271,14 @@ func TestableDocsCreateList(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
-	}
-
-	startIndex, endIndex, errResult := extractIndexRange(request)
+	docID, errResult := extractRequiredDocID(request)
 	if errResult != nil {
 		return errResult, nil
+	}
+
+	startIndex, endIndex, idxErrResult := extractIndexRange(request)
+	if idxErrResult != nil {
+		return idxErrResult, nil
 	}
 
 	bulletPreset := "BULLET_DISC_CIRCLE_SQUARE"
@@ -311,8 +305,6 @@ func TestableDocsCreateList(ctx context.Context, request mcp.CallToolRequest, de
 		}
 		bulletPreset = preset
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	requests := []*docs.Request{{
 		CreateParagraphBullets: &docs.CreateParagraphBulletsRequest{
@@ -352,17 +344,15 @@ func TestableDocsRemoveList(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
-	}
-
-	startIndex, endIndex, errResult := extractIndexRange(request)
+	docID, errResult := extractRequiredDocID(request)
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	docID = common.ExtractGoogleResourceID(docID)
+	startIndex, endIndex, idxErrResult := extractIndexRange(request)
+	if idxErrResult != nil {
+		return idxErrResult, nil
+	}
 
 	requests := []*docs.Request{{
 		DeleteParagraphBullets: &docs.DeleteParagraphBulletsRequest{

--- a/internal/docs/docs_structure_test.go
+++ b/internal/docs/docs_structure_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
 )
 
 func TestHandleDocsInsertTable(t *testing.T) {
@@ -90,7 +92,7 @@ func TestHandleDocsInsertTable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsInsertTable(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -190,7 +192,7 @@ func TestHandleDocsInsertLink(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsInsertLink(context.Background(), request, fixtures.Deps)
 
 			if err != nil {
@@ -294,7 +296,7 @@ func TestHandleDocsBatchUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := MakeDocsRequest(tt.args)
+			request := common.CreateMCPRequest(tt.args)
 			result, err := testableDocsBatchUpdate(context.Background(), request, fixtures.Deps)
 
 			if err != nil {

--- a/internal/docs/docs_structure_testable.go
+++ b/internal/docs/docs_structure_testable.go
@@ -16,9 +16,9 @@ func TestableDocsInsertTable(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
+	docID, errResult := extractRequiredDocID(request)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	rowsFloat, ok := request.Params.Arguments["rows"].(float64)
@@ -41,8 +41,6 @@ func TestableDocsInsertTable(ctx context.Context, request mcp.CallToolRequest, d
 			return mcp.NewToolResultError("index must be at least 1"), nil
 		}
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	requests := []*docs.Request{{
 		InsertTable: &docs.InsertTableRequest{
@@ -75,9 +73,9 @@ func TestableDocsInsertLink(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
+	docID, errResult := extractRequiredDocID(request)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	text, _ := request.Params.Arguments["text"].(string)
@@ -98,8 +96,6 @@ func TestableDocsInsertLink(ctx context.Context, request mcp.CallToolRequest, de
 	if index < 1 {
 		return mcp.NewToolResultError("index must be at least 1"), nil
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	// Calculate text length in UTF-16 code units (Google Docs uses UTF-16 indexing)
 	textLen := int64(0)
@@ -155,9 +151,9 @@ func TestableDocsInsertPageBreak(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
+	docID, errResult := extractRequiredDocID(request)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	indexFloat, ok := request.Params.Arguments["index"].(float64)
@@ -168,8 +164,6 @@ func TestableDocsInsertPageBreak(ctx context.Context, request mcp.CallToolReques
 	if index < 1 {
 		return mcp.NewToolResultError("index must be at least 1"), nil
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	requests := []*docs.Request{{
 		InsertPageBreak: &docs.InsertPageBreakRequest{
@@ -198,9 +192,9 @@ func TestableDocsInsertImage(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
+	docID, errResult := extractRequiredDocID(request)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	imageURI, _ := request.Params.Arguments["uri"].(string)
@@ -216,8 +210,6 @@ func TestableDocsInsertImage(ctx context.Context, request mcp.CallToolRequest, d
 	if index < 1 {
 		return mcp.NewToolResultError("index must be at least 1"), nil
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	requests := []*docs.Request{{
 		InsertInlineImage: &docs.InsertInlineImageRequest{
@@ -259,12 +251,10 @@ func handleDocsCreateHeaderOrFooter(ctx context.Context, request mcp.CallToolReq
 		return errResult, nil
 	}
 
-	docID, _ := request.Params.Arguments["document_id"].(string)
-	if docID == "" {
-		return mcp.NewToolResultError("document_id parameter is required"), nil
+	docID, docErrResult := extractRequiredDocID(request)
+	if docErrResult != nil {
+		return docErrResult, nil
 	}
-
-	docID = common.ExtractGoogleResourceID(docID)
 
 	var createRequests []*docs.Request
 	switch sectionType {

--- a/internal/docs/docs_test_helpers.go
+++ b/internal/docs/docs_test_helpers.go
@@ -50,21 +50,6 @@ func NewDocsTestFixtures() *DocsTestFixtures {
 	}
 }
 
-// MakeDocsRequest creates a CallToolRequest with the given arguments.
-func MakeDocsRequest(args map[string]any) mcp.CallToolRequest {
-	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
-			Arguments: args,
-		},
-	}
-}
-
 // AddTestDocument adds a test document to the mock service.
 func (f *DocsTestFixtures) AddTestDocument(id, title, content string) {
 	f.MockService.Documents[id] = &docs.Document{


### PR DESCRIPTION
## Summary
- Unexport `GetServiceWithDeps` and `TestableFunc` in `common/handler_deps.go` (only used internally)
- Replace duplicate `MakeDocsRequest` with `common.CreateMCPRequest` in docs tests
- Extract `parseValueInputOption` helper in sheets (replaces 3 identical 6-line blocks)
- Extract `extractRequiredMessageIDs` helper in gmail (replaces 3 identical blocks)
- Extract `extractRequiredDocID` helper in docs (replaces 16 inline blocks across 3 files)
- Extract `extractRequiredSpreadsheetID` helper in sheets (replaces 7 inline blocks)

Net result: **-43 lines** across 9 files, with no behavior changes.

Closes #15, closes #14, closes #10

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 10 packages)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean