### PR TITLE
refactor: consolidate contacts field parsing and resource name handling

### DIFF
--- a/internal/contacts/contacts_tools.go
+++ b/internal/contacts/contacts_tools.go
@@ -1,9 +1,150 @@
 package contacts
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/aliwatters/gsuite-mcp/internal/common"
 	"google.golang.org/api/people/v1"
 )
+
+// Resource name prefix constants.
+const (
+	PeoplePrefix        = "people/"
+	ContactGroupsPrefix = "contactGroups/"
+)
+
+// ensurePrefix ensures a resource name has the given prefix.
+func ensurePrefix(name, prefix string) string {
+	if !strings.HasPrefix(name, prefix) {
+		return prefix + name
+	}
+	return name
+}
+
+// contactFieldEntry represents a parsed value+type pair from request arguments.
+type contactFieldEntry struct {
+	Value string
+	Type  string
+}
+
+// parseContactFields parses a list of value+type entries from request arguments.
+// It supports both singular (string) and plural (array of strings or {value, type} maps) forms.
+// Returns nil if no arguments are present; returns a non-nil (possibly empty) slice
+// if the plural key is present, to allow callers to distinguish "not provided" from "clear all".
+func parseContactFields(args map[string]any, pluralKey, singularKey string) []contactFieldEntry {
+	if raw, ok := args[pluralKey].([]any); ok {
+		entries := make([]contactFieldEntry, 0, len(raw))
+		for _, item := range raw {
+			if str, ok := item.(string); ok {
+				entries = append(entries, contactFieldEntry{Value: str})
+			} else if m, ok := item.(map[string]any); ok {
+				entry := contactFieldEntry{}
+				if v, ok := m["value"].(string); ok {
+					entry.Value = v
+				}
+				if t, ok := m["type"].(string); ok {
+					entry.Type = t
+				}
+				entries = append(entries, entry)
+			}
+		}
+		return entries
+	}
+	if val, ok := args[singularKey].(string); ok && val != "" {
+		return []contactFieldEntry{{Value: val}}
+	}
+	return nil
+}
+
+// parseEmailsFromRequest parses email addresses from request arguments.
+func parseEmailsFromRequest(args map[string]any) []*people.EmailAddress {
+	entries := parseContactFields(args, "emails", "email")
+	if entries == nil {
+		return nil
+	}
+	emails := make([]*people.EmailAddress, 0, len(entries))
+	for _, e := range entries {
+		emails = append(emails, &people.EmailAddress{Value: e.Value, Type: e.Type})
+	}
+	return emails
+}
+
+// parsePhonesFromRequest parses phone numbers from request arguments.
+func parsePhonesFromRequest(args map[string]any) []*people.PhoneNumber {
+	entries := parseContactFields(args, "phones", "phone")
+	if entries == nil {
+		return nil
+	}
+	phones := make([]*people.PhoneNumber, 0, len(entries))
+	for _, e := range entries {
+		phones = append(phones, &people.PhoneNumber{Value: e.Value, Type: e.Type})
+	}
+	return phones
+}
+
+// applyContactUpdates applies field updates from request arguments to an existing contact.
+// Returns the list of People API update field masks for the fields that were modified.
+func applyContactUpdates(existing *people.Person, args map[string]any) []string {
+	var updateFields []string
+
+	if givenName, ok := args["given_name"].(string); ok {
+		ensureNames(existing)
+		existing.Names[0].GivenName = givenName
+		updateFields = append(updateFields, "names")
+	}
+	if familyName, ok := args["family_name"].(string); ok {
+		ensureNames(existing)
+		existing.Names[0].FamilyName = familyName
+		if !slices.Contains(updateFields, "names") {
+			updateFields = append(updateFields, "names")
+		}
+	}
+
+	if emails := parseEmailsFromRequest(args); emails != nil {
+		existing.EmailAddresses = emails
+		updateFields = append(updateFields, "emailAddresses")
+	}
+
+	if phones := parsePhonesFromRequest(args); phones != nil {
+		existing.PhoneNumbers = phones
+		updateFields = append(updateFields, "phoneNumbers")
+	}
+
+	if company, ok := args["company"].(string); ok {
+		ensureOrganizations(existing)
+		existing.Organizations[0].Name = company
+		updateFields = append(updateFields, "organizations")
+	}
+	if title, ok := args["job_title"].(string); ok {
+		ensureOrganizations(existing)
+		existing.Organizations[0].Title = title
+		if !slices.Contains(updateFields, "organizations") {
+			updateFields = append(updateFields, "organizations")
+		}
+	}
+
+	if notes, ok := args["notes"].(string); ok {
+		existing.Biographies = []*people.Biography{{Value: notes}}
+		updateFields = append(updateFields, "biographies")
+	}
+
+	return updateFields
+}
+
+// ensureNames ensures the person has at least one Name entry.
+func ensureNames(p *people.Person) {
+	if len(p.Names) == 0 {
+		p.Names = []*people.Name{{}}
+	}
+}
+
+// ensureOrganizations ensures the person has at least one Organization entry.
+func ensureOrganizations(p *people.Person) {
+	if len(p.Organizations) == 0 {
+		p.Organizations = []*people.Organization{{}}
+	}
+}
 
 // === Handle functions - generated via WrapHandler ===
 


### PR DESCRIPTION
## Summary

- Extract `PeoplePrefix`/`ContactGroupsPrefix` constants and `ensurePrefix` helper, replacing ~14 magic string occurrences across 8 functions
- Unify `parseEmailsFromRequest`/`parsePhonesFromRequest` via shared `parseContactFields` generic parser
- Extract `applyContactUpdates` helper to decompose `TestableContactsUpdate` from 93 lines to 33 lines
- Add `ensureNames`/`ensureOrganizations` helpers for the repeated nil-guard pattern

## Test plan

- [x] All existing contacts tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `gofmt` applied

Closes #12