### PR TITLE
feat(drive): add folder path to search, get, and list results

### DIFF
--- a/internal/drive/drive_path.go
+++ b/internal/drive/drive_path.go
@@ -1,0 +1,100 @@
+package drive
+
+import (
+	"context"
+	"strings"
+)
+
+const maxPathDepth = 20
+
+// PathResolver resolves the folder path for Drive files.
+// It caches folder lookups to avoid redundant API calls when
+// multiple files share the same parent chain.
+type PathResolver struct {
+	srv        DriveService
+	folderPath map[string]string // folderID → full path
+	driveName  map[string]string // driveID → drive name
+}
+
+// NewPathResolver creates a PathResolver backed by the given DriveService.
+func NewPathResolver(srv DriveService) *PathResolver {
+	return &PathResolver{
+		srv:        srv,
+		folderPath: make(map[string]string),
+		driveName:  make(map[string]string),
+	}
+}
+
+// ResolvePath returns the folder path for a file (e.g. "My Drive/Projects/2025").
+// Returns "" if the file has no parents or resolution fails.
+func (r *PathResolver) ResolvePath(ctx context.Context, parents []string) string {
+	if len(parents) == 0 {
+		return ""
+	}
+	return r.resolveParentPath(ctx, parents[0], 0)
+}
+
+// resolveParentPath recursively walks up the parent chain to build the full path.
+func (r *PathResolver) resolveParentPath(ctx context.Context, folderID string, depth int) string {
+	if depth >= maxPathDepth {
+		return ""
+	}
+
+	if cached, ok := r.folderPath[folderID]; ok {
+		return cached
+	}
+
+	parent, err := r.srv.GetFile(ctx, folderID, "id,name,parents,driveId")
+	if err != nil {
+		return ""
+	}
+
+	// Root folder: no parents
+	if len(parent.Parents) == 0 {
+		var name string
+		if parent.DriveId != "" {
+			name = r.resolveDriveName(ctx, parent.DriveId)
+		} else {
+			name = parent.Name
+		}
+		r.folderPath[folderID] = name
+		return name
+	}
+
+	// Recurse up the chain
+	parentPath := r.resolveParentPath(ctx, parent.Parents[0], depth+1)
+	var path string
+	if parentPath != "" {
+		path = parentPath + "/" + parent.Name
+	} else {
+		path = parent.Name
+	}
+
+	r.folderPath[folderID] = path
+	return path
+}
+
+// resolveDriveName returns the display name for a shared drive, falling back to the raw ID.
+func (r *PathResolver) resolveDriveName(ctx context.Context, driveID string) string {
+	if driveID == "" {
+		return ""
+	}
+
+	if cached, ok := r.driveName[driveID]; ok {
+		return cached
+	}
+
+	d, err := r.srv.GetDrive(ctx, driveID)
+	if err != nil {
+		r.driveName[driveID] = driveID
+		return driveID
+	}
+
+	name := strings.TrimSpace(d.Name)
+	if name == "" {
+		name = driveID
+	}
+
+	r.driveName[driveID] = name
+	return name
+}

--- a/internal/drive/drive_path_test.go
+++ b/internal/drive/drive_path_test.go
@@ -1,0 +1,331 @@
+package drive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/drive/v3"
+)
+
+// parseResult unmarshals the JSON text from a tool result into a map.
+func parseResult(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in result")
+	}
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	return data
+}
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		parents   []string
+		setupMock func(mock *MockDriveService)
+		want      string
+	}{
+		{
+			name:    "no parents returns empty",
+			parents: nil,
+			want:    "",
+		},
+		{
+			name:    "file in My Drive root",
+			parents: []string{"root1"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					if fileID == "root1" {
+						return &drive.File{Id: "root1", Name: "My Drive"}, nil
+					}
+					return nil, fmt.Errorf("unexpected file: %s", fileID)
+				}
+			},
+			want: "My Drive",
+		},
+		{
+			name:    "nested folders in My Drive",
+			parents: []string{"folder2"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					switch fileID {
+					case "folder2":
+						return &drive.File{Id: "folder2", Name: "2025", Parents: []string{"folder1"}}, nil
+					case "folder1":
+						return &drive.File{Id: "folder1", Name: "Projects", Parents: []string{"root1"}}, nil
+					case "root1":
+						return &drive.File{Id: "root1", Name: "My Drive"}, nil
+					default:
+						return nil, fmt.Errorf("unexpected file: %s", fileID)
+					}
+				}
+			},
+			want: "My Drive/Projects/2025",
+		},
+		{
+			name:    "shared drive root folder",
+			parents: []string{"sdroot"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					if fileID == "sdroot" {
+						return &drive.File{Id: "sdroot", Name: "sdroot", DriveId: "drive1"}, nil
+					}
+					return nil, fmt.Errorf("unexpected file: %s", fileID)
+				}
+				mock.GetDriveFunc = func(_ context.Context, driveID string) (*drive.Drive, error) {
+					return &drive.Drive{Id: "drive1", Name: "Team Drive"}, nil
+				}
+			},
+			want: "Team Drive",
+		},
+		{
+			name:    "shared drive nested folder",
+			parents: []string{"subfolder"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					switch fileID {
+					case "subfolder":
+						return &drive.File{Id: "subfolder", Name: "Folder", Parents: []string{"sdroot"}, DriveId: "drive1"}, nil
+					case "sdroot":
+						return &drive.File{Id: "sdroot", Name: "sdroot", DriveId: "drive1"}, nil
+					default:
+						return nil, fmt.Errorf("unexpected file: %s", fileID)
+					}
+				}
+				mock.GetDriveFunc = func(_ context.Context, driveID string) (*drive.Drive, error) {
+					return &drive.Drive{Id: "drive1", Name: "Team Drive"}, nil
+				}
+			},
+			want: "Team Drive/Folder",
+		},
+		{
+			name:    "API error returns empty",
+			parents: []string{"folder1"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					return nil, fmt.Errorf("API error")
+				}
+			},
+			want: "",
+		},
+		{
+			name:    "GetDrive error falls back to drive ID",
+			parents: []string{"sdroot"},
+			setupMock: func(mock *MockDriveService) {
+				mock.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+					if fileID == "sdroot" {
+						return &drive.File{Id: "sdroot", Name: "sdroot", DriveId: "drive1"}, nil
+					}
+					return nil, fmt.Errorf("unexpected file: %s", fileID)
+				}
+				mock.GetDriveFunc = func(_ context.Context, driveID string) (*drive.Drive, error) {
+					return nil, fmt.Errorf("forbidden")
+				}
+			},
+			want: "drive1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockDriveService{}
+			if tt.setupMock != nil {
+				tt.setupMock(mock)
+			}
+
+			resolver := NewPathResolver(mock)
+			got := resolver.ResolvePath(context.Background(), tt.parents)
+			if got != tt.want {
+				t.Errorf("ResolvePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathResolverCache(t *testing.T) {
+	getFileCalls := 0
+	mock := &MockDriveService{
+		GetFileFunc: func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+			getFileCalls++
+			switch fileID {
+			case "shared_parent":
+				return &drive.File{Id: "shared_parent", Name: "Shared Folder", Parents: []string{"root1"}}, nil
+			case "root1":
+				return &drive.File{Id: "root1", Name: "My Drive"}, nil
+			default:
+				return nil, fmt.Errorf("unexpected file: %s", fileID)
+			}
+		},
+	}
+
+	resolver := NewPathResolver(mock)
+	ctx := context.Background()
+
+	got1 := resolver.ResolvePath(ctx, []string{"shared_parent"})
+	if got1 != "My Drive/Shared Folder" {
+		t.Errorf("first resolve = %q, want %q", got1, "My Drive/Shared Folder")
+	}
+	firstCallCount := getFileCalls
+
+	// Second resolve with same parent should hit cache
+	got2 := resolver.ResolvePath(ctx, []string{"shared_parent"})
+	if got2 != "My Drive/Shared Folder" {
+		t.Errorf("second resolve = %q, want %q", got2, "My Drive/Shared Folder")
+	}
+
+	if getFileCalls != firstCallCount {
+		t.Errorf("expected cache hit: GetFile called %d times after second resolve, want %d", getFileCalls, firstCallCount)
+	}
+}
+
+func TestPathResolverMaxDepth(t *testing.T) {
+	callCount := 0
+	mock := &MockDriveService{
+		GetFileFunc: func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+			callCount++
+			return &drive.File{
+				Id:      fileID,
+				Name:    "Folder",
+				Parents: []string{"parent_of_" + fileID},
+			}, nil
+		},
+	}
+
+	resolver := NewPathResolver(mock)
+	got := resolver.ResolvePath(context.Background(), []string{"start"})
+
+	if callCount > maxPathDepth {
+		t.Errorf("GetFile called %d times, want at most %d", callCount, maxPathDepth)
+	}
+
+	if got != "" {
+		segments := strings.Count(got, "/") + 1
+		if segments > maxPathDepth {
+			t.Errorf("path has %d segments, want at most %d", segments, maxPathDepth)
+		}
+	}
+}
+
+// TestDriveGetIncludesPath verifies TestableDriveGet includes the path field.
+func TestDriveGetIncludesPath(t *testing.T) {
+	fixtures := NewDriveTestFixtures()
+
+	fixtures.MockService.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+		switch fileID {
+		case "file001":
+			f := createTestFile("file001", "Document.docx", "application/vnd.google-apps.document", 1024)
+			f.Parents = []string{"folder001"}
+			return f, nil
+		case "folder001":
+			return &drive.File{Id: "folder001", Name: "My Drive"}, nil
+		default:
+			return createTestFile(fileID, "Unknown", "application/octet-stream", 0), nil
+		}
+	}
+
+	request := common.CreateMCPRequest(map[string]any{"file_id": "file001"})
+	result, err := TestableDriveGet(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := parseResult(t, result)
+	path, ok := data["path"]
+	if !ok {
+		t.Fatal("expected 'path' field in result, got none")
+	}
+	if path != "My Drive" {
+		t.Errorf("got path %q, want %q", path, "My Drive")
+	}
+}
+
+// TestDriveSearchIncludesPath verifies TestableDriveSearch includes path per file.
+func TestDriveSearchIncludesPath(t *testing.T) {
+	fixtures := NewDriveTestFixtures()
+
+	fixtures.MockService.ListFilesFunc = func(_ context.Context, _ *ListFilesOptions) (*drive.FileList, error) {
+		f := createTestFile("file001", "Report.docx", "application/vnd.google-apps.document", 1024)
+		f.Parents = []string{"folder001"}
+		return &drive.FileList{Files: []*drive.File{f}}, nil
+	}
+	fixtures.MockService.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+		if fileID == "folder001" {
+			return &drive.File{Id: "folder001", Name: "My Drive"}, nil
+		}
+		return nil, fmt.Errorf("unexpected file: %s", fileID)
+	}
+
+	request := common.CreateMCPRequest(map[string]any{"query": "name contains 'Report'"})
+	result, err := TestableDriveSearch(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := parseResult(t, result)
+	files := data["files"].([]any)
+	if len(files) == 0 {
+		t.Fatal("expected at least one file")
+	}
+
+	file := files[0].(map[string]any)
+	path, ok := file["path"]
+	if !ok {
+		t.Fatal("expected 'path' field in search result file, got none")
+	}
+	if path != "My Drive" {
+		t.Errorf("got path %q, want %q", path, "My Drive")
+	}
+}
+
+// TestDriveListIncludesPath verifies TestableDriveList includes path per file.
+func TestDriveListIncludesPath(t *testing.T) {
+	fixtures := NewDriveTestFixtures()
+
+	fixtures.MockService.ListFilesFunc = func(_ context.Context, _ *ListFilesOptions) (*drive.FileList, error) {
+		f := createTestFile("file001", "Notes.txt", "text/plain", 512)
+		f.Parents = []string{"subfolder"}
+		return &drive.FileList{Files: []*drive.File{f}}, nil
+	}
+	fixtures.MockService.GetFileFunc = func(_ context.Context, fileID string, _ string) (*drive.File, error) {
+		switch fileID {
+		case "subfolder":
+			return &drive.File{Id: "subfolder", Name: "Projects", Parents: []string{"root1"}}, nil
+		case "root1":
+			return &drive.File{Id: "root1", Name: "My Drive"}, nil
+		default:
+			return nil, fmt.Errorf("unexpected file: %s", fileID)
+		}
+	}
+
+	request := common.CreateMCPRequest(map[string]any{"folder_id": "subfolder"})
+	result, err := TestableDriveList(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := parseResult(t, result)
+	files := data["files"].([]any)
+	if len(files) == 0 {
+		t.Fatal("expected at least one file")
+	}
+
+	file := files[0].(map[string]any)
+	path, ok := file["path"]
+	if !ok {
+		t.Fatal("expected 'path' field in list result file, got none")
+	}
+	if path != "My Drive/Projects" {
+		t.Errorf("got path %q, want %q", path, "My Drive/Projects")
+	}
+}

--- a/internal/drive/drive_service.go
+++ b/internal/drive/drive_service.go
@@ -22,6 +22,9 @@ type DriveService interface {
 	DownloadFile(ctx context.Context, fileID string) (io.ReadCloser, error)
 	ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error)
 
+	// Drives
+	GetDrive(ctx context.Context, driveID string) (*drive.Drive, error)
+
 	// Permissions
 	ListPermissions(ctx context.Context, fileID string) (*drive.PermissionList, error)
 	CreatePermission(ctx context.Context, fileID string, permission *drive.Permission, sendNotification bool) (*drive.Permission, error)
@@ -144,6 +147,11 @@ func (s *RealDriveService) ExportFile(ctx context.Context, fileID string, mimeTy
 		return nil, err
 	}
 	return resp.Body, nil
+}
+
+// GetDrive gets a shared drive by ID.
+func (s *RealDriveService) GetDrive(ctx context.Context, driveID string) (*drive.Drive, error) {
+	return s.service.Drives.Get(driveID).Context(ctx).Fields("id,name").Do()
 }
 
 // ListPermissions lists a file's permissions.

--- a/internal/drive/drive_service_mock.go
+++ b/internal/drive/drive_service_mock.go
@@ -20,6 +20,9 @@ type MockDriveService struct {
 	DownloadFileFunc func(ctx context.Context, fileID string) (io.ReadCloser, error)
 	ExportFileFunc   func(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error)
 
+	// Drives
+	GetDriveFunc func(ctx context.Context, driveID string) (*drive.Drive, error)
+
 	// Permissions
 	ListPermissionsFunc  func(ctx context.Context, fileID string) (*drive.PermissionList, error)
 	CreatePermissionFunc func(ctx context.Context, fileID string, permission *drive.Permission, sendNotification bool) (*drive.Permission, error)
@@ -89,6 +92,15 @@ func (m *MockDriveService) ExportFile(ctx context.Context, fileID string, mimeTy
 		return m.ExportFileFunc(ctx, fileID, mimeType)
 	}
 	return nil, nil
+}
+
+// Drive methods
+
+func (m *MockDriveService) GetDrive(ctx context.Context, driveID string) (*drive.Drive, error) {
+	if m.GetDriveFunc != nil {
+		return m.GetDriveFunc(ctx, driveID)
+	}
+	return &drive.Drive{}, nil
 }
 
 // Permission methods

--- a/internal/drive/drive_test_helpers.go
+++ b/internal/drive/drive_test_helpers.go
@@ -131,6 +131,11 @@ func setupDefaultDriveMockData(mock *MockDriveService) {
 	mock.DeletePermissionFunc = func(_ context.Context, fileID string, permissionID string) error {
 		return nil
 	}
+
+	// Set up GetDrive to return a shared drive
+	mock.GetDriveFunc = func(_ context.Context, driveID string) (*drive.Drive, error) {
+		return &drive.Drive{Id: driveID, Name: "Shared Drive"}, nil
+	}
 }
 
 // createTestFile creates a File with standard fields.

--- a/internal/drive/drive_tools.go
+++ b/internal/drive/drive_tools.go
@@ -11,9 +11,9 @@ import (
 // These reduce response payload size by only requesting needed fields.
 const (
 	// DriveFileListFields contains fields for file listings (search, list)
-	DriveFileListFields = "nextPageToken,files(id,name,mimeType,size,createdTime,modifiedTime,parents,webViewLink)"
+	DriveFileListFields = "nextPageToken,files(id,name,mimeType,size,createdTime,modifiedTime,parents,driveId,webViewLink)"
 	// DriveFileGetFields contains fields for single file retrieval (full metadata)
-	DriveFileGetFields = "id,name,mimeType,size,createdTime,modifiedTime,parents,webViewLink,webContentLink,description,starred,trashed,owners,permissions"
+	DriveFileGetFields = "id,name,mimeType,size,createdTime,modifiedTime,parents,driveId,webViewLink,webContentLink,description,starred,trashed,owners,permissions"
 	// DriveFileDownloadFields contains minimal fields for download operations
 	DriveFileDownloadFields = "id,name,mimeType,size"
 	// DriveFileCreateFields contains fields for file creation responses

--- a/internal/drive/drive_tools_testable.go
+++ b/internal/drive/drive_tools_testable.go
@@ -106,9 +106,14 @@ func TestableDriveSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 		return mcp.NewToolResultError(fmt.Sprintf("Drive API error: %v", err)), nil
 	}
 
+	resolver := NewPathResolver(srv)
 	files := make([]map[string]any, 0, len(resp.Files))
 	for _, f := range resp.Files {
-		files = append(files, formatFile(f))
+		fm := formatFile(f)
+		if path := resolver.ResolvePath(ctx, f.Parents); path != "" {
+			fm["path"] = path
+		}
+		files = append(files, fm)
 	}
 
 	result := map[string]any{
@@ -137,7 +142,13 @@ func TestableDriveGet(ctx context.Context, request mcp.CallToolRequest, deps *Dr
 		return mcp.NewToolResultError(fmt.Sprintf("Drive API error: %v", err)), nil
 	}
 
-	return common.MarshalToolResult(formatFileFull(file))
+	result := formatFileFull(file)
+	resolver := NewPathResolver(srv)
+	if path := resolver.ResolvePath(ctx, file.Parents); path != "" {
+		result["path"] = path
+	}
+
+	return common.MarshalToolResult(result)
 }
 
 // TestableDriveDownload downloads file content.
@@ -291,9 +302,14 @@ func TestableDriveList(ctx context.Context, request mcp.CallToolRequest, deps *D
 		return mcp.NewToolResultError(fmt.Sprintf("Drive API error: %v", err)), nil
 	}
 
+	resolver := NewPathResolver(srv)
 	files := make([]map[string]any, 0, len(resp.Files))
 	for _, f := range resp.Files {
-		files = append(files, formatFile(f))
+		fm := formatFile(f)
+		if path := resolver.ResolvePath(ctx, f.Parents); path != "" {
+			fm["path"] = path
+		}
+		files = append(files, fm)
 	}
 
 	result := map[string]any{


### PR DESCRIPTION
## Summary

- Add `path` field to `drive_get`, `drive_search`, and `drive_list` results showing the full folder path (e.g. `"My Drive/Projects/2025"` or `"Team Drive/Commercial/Q3"`)
- New `PathResolver` walks parent chains with per-request caching to minimize API calls when files share folders
- New `GetDrive` service method resolves shared drive display names, falling back to raw ID on error
- Add `driveId` to field constants so the API returns shared drive membership

## Details

**New files:**
- `drive_path.go` — `PathResolver` with folder cache, drive name cache, max-depth guard (20 levels)
- `drive_path_test.go` — 12 tests: unit (resolver), integration (handler output), cache verification, max depth

**Modified files:**
- `drive_service.go` — `GetDrive` on interface + `RealDriveService`
- `drive_service_mock.go` — `GetDriveFunc` + method
- `drive_tools.go` — `driveId` added to `DriveFileListFields` and `DriveFileGetFields`
- `drive_tools_testable.go` — `TestableDriveGet`, `TestableDriveSearch`, `TestableDriveList` resolve and include `path`
- `drive_test_helpers.go` — default `GetDriveFunc` mock

**Note:** This branch includes the commits from #42 (shared drive support) which must merge first.

## Test plan

- [x] `go build ./cmd/gsuite-mcp/` compiles
- [x] `go vet ./...` passes
- [x] `go test ./...` — all tests pass
- [x] Unit tests cover: My Drive root, nested folders, shared drive root, shared drive nested, API errors, GetDrive fallback, cache hits, max depth
- [x] Integration tests verify `path` field appears in `drive_get`, `drive_search`, `drive_list` JSON output

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)