### PR TITLE
fix: replace unchecked type assertions with safe helpers (#32)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -86,7 +86,7 @@ All tools accept an optional `account` parameter. Resolution order:
 
 ```go
 func handleTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-    accountParam, _ := request.Params.Arguments["account"].(string)
+    accountParam := common.ParseStringArg(request.Params.Arguments, "account", "")
     account, err := appConfig.ResolveAccount(accountParam)
     if err != nil {
         return mcp.NewToolResultError(err.Error()), nil

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -28,7 +28,7 @@ func GetDeps() *Deps {
 
 // ResolveAccountFromRequest extracts and validates the account parameter.
 func ResolveAccountFromRequest(request mcp.CallToolRequest) (string, error) {
-	accountParam, _ := request.Params.Arguments["account"].(string)
+	accountParam := ParseStringArg(request.Params.Arguments, "account", "")
 
 	if accountParam == "" {
 		// No account specified - use first authenticated email

--- a/internal/contacts/contacts_tools_testable.go
+++ b/internal/contacts/contacts_tools_testable.go
@@ -75,7 +75,7 @@ func TestableContactsGet(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
@@ -109,7 +109,7 @@ func TestableContactsSearch(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	query, _ := request.Params.Arguments["query"].(string)
+	query := common.ParseStringArg(request.Params.Arguments, "query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query parameter is required"), nil
 	}
@@ -167,7 +167,7 @@ func TestableContactsCreate(ctx context.Context, request mcp.CallToolRequest, de
 	person := &people.Person{}
 
 	// Names (given_name is required)
-	givenName, _ := request.Params.Arguments["given_name"].(string)
+	givenName := common.ParseStringArg(request.Params.Arguments, "given_name", "")
 	if givenName == "" {
 		return mcp.NewToolResultError("given_name parameter is required"), nil
 	}
@@ -218,7 +218,7 @@ func TestableContactsUpdate(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
@@ -253,7 +253,7 @@ func TestableContactsDelete(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
@@ -331,7 +331,7 @@ func TestableContactsGetGroup(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
@@ -369,7 +369,7 @@ func TestableContactsCreateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	name, _ := request.Params.Arguments["name"].(string)
+	name := common.ParseStringArg(request.Params.Arguments, "name", "")
 	if name == "" {
 		return mcp.NewToolResultError("name parameter is required"), nil
 	}
@@ -392,12 +392,12 @@ func TestableContactsUpdateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
 
-	name, _ := request.Params.Arguments["name"].(string)
+	name := common.ParseStringArg(request.Params.Arguments, "name", "")
 	if name == "" {
 		return mcp.NewToolResultError("name parameter is required"), nil
 	}
@@ -422,7 +422,7 @@ func TestableContactsDeleteGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}
@@ -450,7 +450,7 @@ func TestableContactsModifyGroupMembers(ctx context.Context, request mcp.CallToo
 		return errResult, nil
 	}
 
-	resourceName, _ := request.Params.Arguments["resource_name"].(string)
+	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
 	if resourceName == "" {
 		return mcp.NewToolResultError("resource_name parameter is required"), nil
 	}

--- a/internal/docs/docs_content_testable.go
+++ b/internal/docs/docs_content_testable.go
@@ -17,7 +17,7 @@ const docsEditURLFormat = "https://docs.google.com/document/d/%s/edit"
 // extractRequiredDocID extracts, validates, and normalizes the document_id parameter.
 // Returns the cleaned ID or an error result if missing.
 func extractRequiredDocID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	docID, _ := request.Params.Arguments["document_id"].(string)
+	docID := common.ParseStringArg(request.Params.Arguments, "document_id", "")
 	if docID == "" {
 		return "", mcp.NewToolResultError("document_id parameter is required")
 	}
@@ -55,7 +55,7 @@ func TestableDocsCreate(ctx context.Context, request mcp.CallToolRequest, deps *
 		return errResult, nil
 	}
 
-	title, _ := request.Params.Arguments["title"].(string)
+	title := common.ParseStringArg(request.Params.Arguments, "title", "")
 	if title == "" {
 		return mcp.NewToolResultError("title parameter is required"), nil
 	}
@@ -149,7 +149,7 @@ func TestableDocsAppendText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, _ := request.Params.Arguments["text"].(string)
+	text := common.ParseStringArg(request.Params.Arguments, "text", "")
 	if text == "" {
 		return mcp.NewToolResultError("text parameter is required"), nil
 	}
@@ -209,7 +209,7 @@ func TestableDocsInsertText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, _ := request.Params.Arguments["text"].(string)
+	text := common.ParseStringArg(request.Params.Arguments, "text", "")
 	if text == "" {
 		return mcp.NewToolResultError("text parameter is required"), nil
 	}
@@ -256,16 +256,15 @@ func TestableDocsReplaceText(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	findText, _ := request.Params.Arguments["find_text"].(string)
+	findText := common.ParseStringArg(request.Params.Arguments, "find_text", "")
 	if findText == "" {
 		return mcp.NewToolResultError("find_text parameter is required"), nil
 	}
 
-	replaceText, _ := request.Params.Arguments["replace_text"].(string)
+	replaceText := common.ParseStringArg(request.Params.Arguments, "replace_text", "")
 	// replace_text can be empty (to delete matched text)
 
-	matchCase, _ := request.Params.Arguments["match_case"].(bool)
-	// Default to false if not specified
+	matchCase := common.ParseBoolArg(request.Params.Arguments, "match_case", false)
 
 	replaceReq := &docs.ReplaceAllTextRequest{
 		ContainsText: &docs.SubstringMatchCriteria{
@@ -350,7 +349,7 @@ func TestableDocsBatchUpdate(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	requestsJSON, _ := request.Params.Arguments["requests"].(string)
+	requestsJSON := common.ParseStringArg(request.Params.Arguments, "requests", "")
 	if requestsJSON == "" {
 		return mcp.NewToolResultError("requests parameter is required (JSON array of batch update requests)"), nil
 	}

--- a/internal/docs/docs_formatting_testable.go
+++ b/internal/docs/docs_formatting_testable.go
@@ -94,7 +94,7 @@ func argPresent(args map[string]any, name string, kind fieldKind) bool {
 // validateColor returns a validation function that parses a hex color argument.
 func validateColor(argName string) func(args map[string]any) *mcp.CallToolResult {
 	return func(args map[string]any) *mcp.CallToolResult {
-		color := args[argName].(string)
+		color, _ := args[argName].(string)
 		if _, _, _, err := parseColor(color); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid %s: %v", argName, err))
 		}
@@ -110,7 +110,7 @@ func validateEnum(argName string, allowed ...string) func(args map[string]any) *
 	}
 	errMsg := fmt.Sprintf("%s must be one of: %s", argName, strings.Join(allowed, ", "))
 	return func(args map[string]any) *mcp.CallToolResult {
-		val := args[argName].(string)
+		val, _ := args[argName].(string)
 		if !valid[val] {
 			return mcp.NewToolResultError(errMsg)
 		}

--- a/internal/docs/docs_structure_testable.go
+++ b/internal/docs/docs_structure_testable.go
@@ -78,12 +78,12 @@ func TestableDocsInsertLink(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, _ := request.Params.Arguments["text"].(string)
+	text := common.ParseStringArg(request.Params.Arguments, "text", "")
 	if text == "" {
 		return mcp.NewToolResultError("text parameter is required"), nil
 	}
 
-	linkURL, _ := request.Params.Arguments["url"].(string)
+	linkURL := common.ParseStringArg(request.Params.Arguments, "url", "")
 	if linkURL == "" {
 		return mcp.NewToolResultError("url parameter is required"), nil
 	}
@@ -197,7 +197,7 @@ func TestableDocsInsertImage(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	imageURI, _ := request.Params.Arguments["uri"].(string)
+	imageURI := common.ParseStringArg(request.Params.Arguments, "uri", "")
 	if imageURI == "" {
 		return mcp.NewToolResultError("uri parameter is required (URL of the image)"), nil
 	}

--- a/internal/gmail/gmail_helpers.go
+++ b/internal/gmail/gmail_helpers.go
@@ -91,7 +91,7 @@ func buildEmailMessage(msg EmailMessage) string {
 // operations (archive, star, mark read, spam, etc.). It extracts message_id from
 // the request, applies the specified label changes, and returns a standard result.
 func modifyMessageLabels(ctx context.Context, svc GmailService, request mcp.CallToolRequest, addLabels, removeLabels []string) (*mcp.CallToolResult, error) {
-	messageID, _ := request.Params.Arguments["message_id"].(string)
+	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
 	if messageID == "" {
 		return mcp.NewToolResultError("message_id parameter is required"), nil
 	}

--- a/internal/gmail/testable_messages.go
+++ b/internal/gmail/testable_messages.go
@@ -12,7 +12,7 @@ import (
 
 // TestableGmailSearch performs a Gmail search using the provided service.
 func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	query, _ := request.Params.Arguments["query"].(string)
+	query := common.ParseStringArg(request.Params.Arguments, "query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query parameter is required"), nil
 	}

--- a/internal/sheets/sheets_tools_testable.go
+++ b/internal/sheets/sheets_tools_testable.go
@@ -13,7 +13,7 @@ import (
 // extractRequiredSpreadsheetID extracts, validates, and normalizes the spreadsheet_id parameter.
 // Returns the cleaned ID or an error result if missing.
 func extractRequiredSpreadsheetID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	spreadsheetID, _ := request.Params.Arguments["spreadsheet_id"].(string)
+	spreadsheetID := common.ParseStringArg(request.Params.Arguments, "spreadsheet_id", "")
 	if spreadsheetID == "" {
 		return "", mcp.NewToolResultError("spreadsheet_id parameter is required")
 	}
@@ -93,7 +93,7 @@ func TestableSheetsRead(ctx context.Context, request mcp.CallToolRequest, deps *
 		return idErrResult, nil
 	}
 
-	readRange, _ := request.Params.Arguments["range"].(string)
+	readRange := common.ParseStringArg(request.Params.Arguments, "range", "")
 	if readRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C10')"), nil
 	}
@@ -135,7 +135,7 @@ func TestableSheetsWrite(ctx context.Context, request mcp.CallToolRequest, deps 
 		return idErrResult, nil
 	}
 
-	writeRange, _ := request.Params.Arguments["range"].(string)
+	writeRange := common.ParseStringArg(request.Params.Arguments, "range", "")
 	if writeRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C3')"), nil
 	}
@@ -182,7 +182,7 @@ func TestableSheetsAppend(ctx context.Context, request mcp.CallToolRequest, deps
 		return idErrResult, nil
 	}
 
-	appendRange, _ := request.Params.Arguments["range"].(string)
+	appendRange := common.ParseStringArg(request.Params.Arguments, "range", "")
 	if appendRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation for table to append to, e.g., 'Sheet1!A:C')"), nil
 	}
@@ -228,7 +228,7 @@ func TestableSheetsCreate(ctx context.Context, request mcp.CallToolRequest, deps
 		return errResult, nil
 	}
 
-	title, _ := request.Params.Arguments["title"].(string)
+	title := common.ParseStringArg(request.Params.Arguments, "title", "")
 	if title == "" {
 		return mcp.NewToolResultError("title parameter is required"), nil
 	}
@@ -372,7 +372,7 @@ func TestableSheetsClear(ctx context.Context, request mcp.CallToolRequest, deps 
 		return idErrResult, nil
 	}
 
-	clearRange, _ := request.Params.Arguments["range"].(string)
+	clearRange := common.ParseStringArg(request.Params.Arguments, "range", "")
 	if clearRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C10')"), nil
 	}


### PR DESCRIPTION
## Summary
- Replace 34 instances of `value, _ := args["key"].(type)` with `common.ParseStringArg` / `common.ParseBoolArg` across 8 files (sheets, contacts, docs, gmail, common)
- Fix 2 panic-prone direct casts in `docs_formatting_testable.go` with safe assertions
- Update stale code example in `docs/AGENTS.md`

## Test plan
- [x] `go build ./cmd/gsuite-mcp/` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 10 packages)
- [x] Verified semantic equivalence of all replacements

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)