### PR TITLE
refactor: add common.RequireStringArg to standardize required param checks (#33)

### DIFF
--- a/internal/calendar/testable_events.go
+++ b/internal/calendar/testable_events.go
@@ -77,9 +77,9 @@ func TestableCalendarGetEvent(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	eventID := common.ParseStringArg(request.Params.Arguments, "event_id", "")
-	if eventID == "" {
-		return mcp.NewToolResultError("event_id parameter is required"), nil
+	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
@@ -101,9 +101,9 @@ func TestableCalendarCreateEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	summary := common.ParseStringArg(request.Params.Arguments, "summary", "")
-	if summary == "" {
-		return mcp.NewToolResultError("summary parameter is required"), nil
+	summary, errResult := common.RequireStringArg(request.Params.Arguments, "summary")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
@@ -215,9 +215,9 @@ func TestableCalendarUpdateEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	eventID := common.ParseStringArg(request.Params.Arguments, "event_id", "")
-	if eventID == "" {
-		return mcp.NewToolResultError("event_id parameter is required"), nil
+	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
@@ -267,9 +267,9 @@ func TestableCalendarDeleteEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	eventID := common.ParseStringArg(request.Params.Arguments, "event_id", "")
-	if eventID == "" {
-		return mcp.NewToolResultError("event_id parameter is required"), nil
+	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
@@ -296,9 +296,9 @@ func TestableCalendarQuickAdd(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	text := common.ParseStringArg(request.Params.Arguments, "text", "")
-	if text == "" {
-		return mcp.NewToolResultError("text parameter is required"), nil
+	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)

--- a/internal/calendar/testable_lists.go
+++ b/internal/calendar/testable_lists.go
@@ -126,9 +126,9 @@ func TestableCalendarListInstances(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	eventID := common.ParseStringArg(request.Params.Arguments, "event_id", "")
-	if eventID == "" {
-		return mcp.NewToolResultError("event_id parameter is required"), nil
+	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
@@ -174,9 +174,9 @@ func TestableCalendarUpdateInstance(ctx context.Context, request mcp.CallToolReq
 		return errResult, nil
 	}
 
-	instanceID := common.ParseStringArg(request.Params.Arguments, "instance_id", "")
-	if instanceID == "" {
-		return mcp.NewToolResultError("instance_id parameter is required"), nil
+	instanceID, errResult := common.RequireStringArg(request.Params.Arguments, "instance_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)

--- a/internal/common/args.go
+++ b/internal/common/args.go
@@ -1,5 +1,16 @@
 package common
 
+import "github.com/mark3labs/mcp-go/mcp"
+
+// RequireStringArg extracts a required string argument from the request.
+// Returns the value and nil on success, or empty string and an error result if missing/empty.
+func RequireStringArg(args map[string]any, key string) (string, *mcp.CallToolResult) {
+	if val, ok := args[key].(string); ok && val != "" {
+		return val, nil
+	}
+	return "", mcp.NewToolResultError(key + " parameter is required")
+}
+
 // ParseStringArg extracts a string argument from the request.
 // Returns defaultVal if the argument is missing or empty.
 func ParseStringArg(args map[string]any, key string, defaultVal string) string {

--- a/internal/common/args_test.go
+++ b/internal/common/args_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestRequireStringArg(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      map[string]any
+		key       string
+		wantVal   string
+		wantError bool
+	}{
+		{
+			name:    "present and non-empty",
+			args:    map[string]any{"key": "value"},
+			key:     "key",
+			wantVal: "value",
+		},
+		{
+			name:      "missing key",
+			args:      map[string]any{},
+			key:       "key",
+			wantError: true,
+		},
+		{
+			name:      "empty string",
+			args:      map[string]any{"key": ""},
+			key:       "key",
+			wantError: true,
+		},
+		{
+			name:      "wrong type",
+			args:      map[string]any{"key": 123},
+			key:       "key",
+			wantError: true,
+		},
+		{
+			name:      "nil args",
+			args:      nil,
+			key:       "key",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, errResult := RequireStringArg(tt.args, tt.key)
+			if tt.wantError {
+				if errResult == nil {
+					t.Error("expected error result, got nil")
+				}
+				if val != "" {
+					t.Errorf("expected empty string on error, got %q", val)
+				}
+			} else {
+				if errResult != nil {
+					t.Errorf("unexpected error result: %v", errResult)
+				}
+				if val != tt.wantVal {
+					t.Errorf("got %q, want %q", val, tt.wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestParseStringArg(t *testing.T) {
+	args := map[string]any{"name": "alice", "empty": ""}
+	if got := ParseStringArg(args, "name", "default"); got != "alice" {
+		t.Errorf("got %q, want %q", got, "alice")
+	}
+	if got := ParseStringArg(args, "missing", "default"); got != "default" {
+		t.Errorf("got %q, want %q", got, "default")
+	}
+	if got := ParseStringArg(args, "empty", "default"); got != "default" {
+		t.Errorf("got %q, want %q", got, "default")
+	}
+}
+
+func TestParseBoolArg(t *testing.T) {
+	args := map[string]any{"flag": true}
+	if got := ParseBoolArg(args, "flag", false); got != true {
+		t.Errorf("got %v, want true", got)
+	}
+	if got := ParseBoolArg(args, "missing", true); got != true {
+		t.Errorf("got %v, want true", got)
+	}
+}
+
+func TestParseMaxResults(t *testing.T) {
+	args := map[string]any{"max_results": float64(50)}
+	if got := ParseMaxResults(args, 10, 100); got != 50 {
+		t.Errorf("got %d, want 50", got)
+	}
+	if got := ParseMaxResults(args, 10, 30); got != 30 {
+		t.Errorf("got %d, want 30 (capped)", got)
+	}
+	if got := ParseMaxResults(map[string]any{}, 10, 100); got != 10 {
+		t.Errorf("got %d, want 10 (default)", got)
+	}
+}

--- a/internal/contacts/contacts_tools_testable.go
+++ b/internal/contacts/contacts_tools_testable.go
@@ -75,9 +75,9 @@ func TestableContactsGet(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, PeoplePrefix)
@@ -109,9 +109,9 @@ func TestableContactsSearch(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	query := common.ParseStringArg(request.Params.Arguments, "query", "")
-	if query == "" {
-		return mcp.NewToolResultError("query parameter is required"), nil
+	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	opts := &SearchContactsOptions{}
@@ -167,9 +167,9 @@ func TestableContactsCreate(ctx context.Context, request mcp.CallToolRequest, de
 	person := &people.Person{}
 
 	// Names (given_name is required)
-	givenName := common.ParseStringArg(request.Params.Arguments, "given_name", "")
-	if givenName == "" {
-		return mcp.NewToolResultError("given_name parameter is required"), nil
+	givenName, errResult := common.RequireStringArg(request.Params.Arguments, "given_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 	person.Names = []*people.Name{{GivenName: givenName}}
 	if familyName, ok := request.Params.Arguments["family_name"].(string); ok && familyName != "" {
@@ -218,9 +218,9 @@ func TestableContactsUpdate(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, PeoplePrefix)
@@ -253,9 +253,9 @@ func TestableContactsDelete(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, PeoplePrefix)
@@ -331,9 +331,9 @@ func TestableContactsGetGroup(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, ContactGroupsPrefix)
@@ -369,9 +369,9 @@ func TestableContactsCreateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
-	if name == "" {
-		return mcp.NewToolResultError("name parameter is required"), nil
+	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	group, err := srv.CreateContactGroup(ctx, name)
@@ -392,14 +392,14 @@ func TestableContactsUpdateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
-	if name == "" {
-		return mcp.NewToolResultError("name parameter is required"), nil
+	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, ContactGroupsPrefix)
@@ -422,9 +422,9 @@ func TestableContactsDeleteGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, ContactGroupsPrefix)
@@ -450,9 +450,9 @@ func TestableContactsModifyGroupMembers(ctx context.Context, request mcp.CallToo
 		return errResult, nil
 	}
 
-	resourceName := common.ParseStringArg(request.Params.Arguments, "resource_name", "")
-	if resourceName == "" {
-		return mcp.NewToolResultError("resource_name parameter is required"), nil
+	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	resourceName = ensurePrefix(resourceName, ContactGroupsPrefix)

--- a/internal/docs/docs_content_testable.go
+++ b/internal/docs/docs_content_testable.go
@@ -55,9 +55,9 @@ func TestableDocsCreate(ctx context.Context, request mcp.CallToolRequest, deps *
 		return errResult, nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
-	if title == "" {
-		return mcp.NewToolResultError("title parameter is required"), nil
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	created, err := srv.CreateDocument(ctx, title)
@@ -149,9 +149,9 @@ func TestableDocsAppendText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text := common.ParseStringArg(request.Params.Arguments, "text", "")
-	if text == "" {
-		return mcp.NewToolResultError("text parameter is required"), nil
+	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	// First get the document to find the end index
@@ -209,9 +209,9 @@ func TestableDocsInsertText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text := common.ParseStringArg(request.Params.Arguments, "text", "")
-	if text == "" {
-		return mcp.NewToolResultError("text parameter is required"), nil
+	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	indexFloat, ok := request.Params.Arguments["index"].(float64)
@@ -256,9 +256,9 @@ func TestableDocsReplaceText(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	findText := common.ParseStringArg(request.Params.Arguments, "find_text", "")
-	if findText == "" {
-		return mcp.NewToolResultError("find_text parameter is required"), nil
+	findText, errResult := common.RequireStringArg(request.Params.Arguments, "find_text")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	replaceText := common.ParseStringArg(request.Params.Arguments, "replace_text", "")

--- a/internal/docs/docs_structure_testable.go
+++ b/internal/docs/docs_structure_testable.go
@@ -78,14 +78,14 @@ func TestableDocsInsertLink(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text := common.ParseStringArg(request.Params.Arguments, "text", "")
-	if text == "" {
-		return mcp.NewToolResultError("text parameter is required"), nil
+	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	linkURL := common.ParseStringArg(request.Params.Arguments, "url", "")
-	if linkURL == "" {
-		return mcp.NewToolResultError("url parameter is required"), nil
+	linkURL, errResult := common.RequireStringArg(request.Params.Arguments, "url")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	indexFloat, ok := request.Params.Arguments["index"].(float64)

--- a/internal/drive/drive_tools_testable.go
+++ b/internal/drive/drive_tools_testable.go
@@ -86,9 +86,9 @@ func TestableDriveSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	query := common.ParseStringArg(request.Params.Arguments, "query", "")
-	if query == "" {
-		return mcp.NewToolResultError("query parameter is required"), nil
+	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
@@ -208,14 +208,14 @@ func TestableDriveUpload(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
-	if name == "" {
-		return mcp.NewToolResultError("name parameter is required"), nil
+	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	contentStr := common.ParseStringArg(request.Params.Arguments, "content", "")
-	if contentStr == "" {
-		return mcp.NewToolResultError("content parameter is required"), nil
+	contentStr, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	// Reject obviously oversized content before decoding
@@ -329,9 +329,9 @@ func TestableDriveCreateFolder(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
-	if name == "" {
-		return mcp.NewToolResultError("name parameter is required"), nil
+	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	folder := &drive.File{
@@ -374,9 +374,9 @@ func TestableDriveMove(ctx context.Context, request mcp.CallToolRequest, deps *D
 		return idErrResult, nil
 	}
 
-	newParentID := common.ParseStringArg(request.Params.Arguments, "new_parent_id", "")
-	if newParentID == "" {
-		return mcp.NewToolResultError("new_parent_id parameter is required"), nil
+	newParentID, errResult := common.RequireStringArg(request.Params.Arguments, "new_parent_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 	newParentID = common.ExtractGoogleResourceID(newParentID)
 
@@ -511,9 +511,9 @@ func TestableDriveShare(ctx context.Context, request mcp.CallToolRequest, deps *
 		return idErrResult, nil
 	}
 
-	email := common.ParseStringArg(request.Params.Arguments, "email", "")
-	if email == "" {
-		return mcp.NewToolResultError("email parameter is required"), nil
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "email")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	role := common.ParseStringArg(request.Params.Arguments, "role", "reader")

--- a/internal/gmail/gmail_helpers.go
+++ b/internal/gmail/gmail_helpers.go
@@ -91,9 +91,9 @@ func buildEmailMessage(msg EmailMessage) string {
 // operations (archive, star, mark read, spam, etc.). It extracts message_id from
 // the request, applies the specified label changes, and returns a standard result.
 func modifyMessageLabels(ctx context.Context, svc GmailService, request mcp.CallToolRequest, addLabels, removeLabels []string) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	modifyRequest := &gmail.ModifyMessageRequest{

--- a/internal/gmail/testable_drafts.go
+++ b/internal/gmail/testable_drafts.go
@@ -53,9 +53,9 @@ func TestableGmailListDrafts(ctx context.Context, request mcp.CallToolRequest, d
 
 // TestableGmailGetDraft retrieves a draft by ID.
 func TestableGmailGetDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID := common.ParseStringArg(request.Params.Arguments, "draft_id", "")
-	if draftID == "" {
-		return mcp.NewToolResultError("draft_id parameter is required"), nil
+	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -83,9 +83,9 @@ func TestableGmailGetDraft(ctx context.Context, request mcp.CallToolRequest, dep
 
 // TestableGmailUpdateDraft updates an existing draft.
 func TestableGmailUpdateDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID := common.ParseStringArg(request.Params.Arguments, "draft_id", "")
-	if draftID == "" {
-		return mcp.NewToolResultError("draft_id parameter is required"), nil
+	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -115,9 +115,9 @@ func TestableGmailUpdateDraft(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailDeleteDraft deletes a draft.
 func TestableGmailDeleteDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID := common.ParseStringArg(request.Params.Arguments, "draft_id", "")
-	if draftID == "" {
-		return mcp.NewToolResultError("draft_id parameter is required"), nil
+	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -140,9 +140,9 @@ func TestableGmailDeleteDraft(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailSendDraft sends a draft.
 func TestableGmailSendDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID := common.ParseStringArg(request.Params.Arguments, "draft_id", "")
-	if draftID == "" {
-		return mcp.NewToolResultError("draft_id parameter is required"), nil
+	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)

--- a/internal/gmail/testable_filters.go
+++ b/internal/gmail/testable_filters.go
@@ -134,9 +134,9 @@ func TestableGmailCreateFilter(ctx context.Context, request mcp.CallToolRequest,
 
 // TestableGmailDeleteFilter deletes a filter.
 func TestableGmailDeleteFilter(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	filterID := common.ParseStringArg(request.Params.Arguments, "filter_id", "")
-	if filterID == "" {
-		return mcp.NewToolResultError("filter_id parameter is required"), nil
+	filterID, errResult := common.RequireStringArg(request.Params.Arguments, "filter_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)

--- a/internal/gmail/testable_labels.go
+++ b/internal/gmail/testable_labels.go
@@ -83,9 +83,9 @@ func TestableGmailListLabels(ctx context.Context, request mcp.CallToolRequest, d
 
 // TestableGmailCreateLabel creates a new label.
 func TestableGmailCreateLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
-	if name == "" {
-		return mcp.NewToolResultError("name parameter is required"), nil
+	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -120,9 +120,9 @@ func TestableGmailCreateLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailDeleteLabel deletes a label.
 func TestableGmailDeleteLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	labelID := common.ParseStringArg(request.Params.Arguments, "label_id", "")
-	if labelID == "" {
-		return mcp.NewToolResultError("label_id parameter is required"), nil
+	labelID, errResult := common.RequireStringArg(request.Params.Arguments, "label_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -145,9 +145,9 @@ func TestableGmailDeleteLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailUpdateLabel updates a label.
 func TestableGmailUpdateLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	labelID := common.ParseStringArg(request.Params.Arguments, "label_id", "")
-	if labelID == "" {
-		return mcp.NewToolResultError("label_id parameter is required"), nil
+	labelID, errResult := common.RequireStringArg(request.Params.Arguments, "label_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -185,9 +185,8 @@ func TestableGmailUpdateLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailModifyMessage modifies labels on a message.
 func TestableGmailModifyMessage(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	if _, errResult := common.RequireStringArg(request.Params.Arguments, "message_id"); errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -201,9 +200,9 @@ func TestableGmailModifyMessage(ctx context.Context, request mcp.CallToolRequest
 
 // TestableGmailModifyThread modifies labels on a thread.
 func TestableGmailModifyThread(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", "")
-	if threadID == "" {
-		return mcp.NewToolResultError("thread_id parameter is required"), nil
+	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)

--- a/internal/gmail/testable_messages.go
+++ b/internal/gmail/testable_messages.go
@@ -12,9 +12,9 @@ import (
 
 // TestableGmailSearch performs a Gmail search using the provided service.
 func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	query := common.ParseStringArg(request.Params.Arguments, "query", "")
-	if query == "" {
-		return mcp.NewToolResultError("query parameter is required"), nil
+	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -54,9 +54,9 @@ func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 
 // TestableGmailGetMessage retrieves a single message using the provided service.
 func TestableGmailGetMessage(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -125,9 +125,8 @@ func TestableGmailGetMessages(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailSend sends a new email using the provided service.
 func TestableGmailSend(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	to := common.ParseStringArg(request.Params.Arguments, "to", "")
-	if to == "" {
-		return mcp.NewToolResultError("to parameter is required"), nil
+	if _, errResult := common.RequireStringArg(request.Params.Arguments, "to"); errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -158,9 +157,9 @@ func TestableGmailReply(ctx context.Context, request mcp.CallToolRequest, deps *
 		return mcp.NewToolResultError("message_id parameter is required (the message you're replying to)"), nil
 	}
 
-	body := common.ParseStringArg(request.Params.Arguments, "body", "")
-	if body == "" {
-		return mcp.NewToolResultError("body parameter is required"), nil
+	body, bodyErr := common.RequireStringArg(request.Params.Arguments, "body")
+	if bodyErr != nil {
+		return bodyErr, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -278,9 +277,9 @@ func TestableGmailNotSpam(ctx context.Context, request mcp.CallToolRequest, deps
 
 // TestableGmailTrash moves a message to trash.
 func TestableGmailTrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -304,9 +303,9 @@ func TestableGmailTrash(ctx context.Context, request mcp.CallToolRequest, deps *
 
 // TestableGmailUntrash removes a message from trash.
 func TestableGmailUntrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -330,14 +329,14 @@ func TestableGmailUntrash(ctx context.Context, request mcp.CallToolRequest, deps
 
 // TestableGmailGetAttachment downloads an attachment.
 func TestableGmailGetAttachment(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
-	if messageID == "" {
-		return mcp.NewToolResultError("message_id parameter is required"), nil
+	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	attachmentID := common.ParseStringArg(request.Params.Arguments, "attachment_id", "")
-	if attachmentID == "" {
-		return mcp.NewToolResultError("attachment_id parameter is required"), nil
+	attachmentID, errResult := common.RequireStringArg(request.Params.Arguments, "attachment_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)

--- a/internal/gmail/testable_threads.go
+++ b/internal/gmail/testable_threads.go
@@ -11,9 +11,9 @@ import (
 
 // TestableGmailGetThread retrieves a thread using the provided service.
 func TestableGmailGetThread(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", "")
-	if threadID == "" {
-		return mcp.NewToolResultError("thread_id parameter is required"), nil
+	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -45,9 +45,9 @@ func TestableGmailGetThread(ctx context.Context, request mcp.CallToolRequest, de
 
 // TestableGmailThreadArchive archives all messages in a thread (removes INBOX label).
 func TestableGmailThreadArchive(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", "")
-	if threadID == "" {
-		return mcp.NewToolResultError("thread_id parameter is required"), nil
+	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -69,9 +69,9 @@ func TestableGmailThreadArchive(ctx context.Context, request mcp.CallToolRequest
 
 // TestableGmailThreadTrash moves an entire thread to trash.
 func TestableGmailThreadTrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", "")
-	if threadID == "" {
-		return mcp.NewToolResultError("thread_id parameter is required"), nil
+	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
@@ -89,9 +89,9 @@ func TestableGmailThreadTrash(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailThreadUntrash restores an entire thread from trash.
 func TestableGmailThreadUntrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", "")
-	if threadID == "" {
-		return mcp.NewToolResultError("thread_id parameter is required"), nil
+	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)

--- a/internal/sheets/sheets_tools_testable.go
+++ b/internal/sheets/sheets_tools_testable.go
@@ -228,9 +228,9 @@ func TestableSheetsCreate(ctx context.Context, request mcp.CallToolRequest, deps
 		return errResult, nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
-	if title == "" {
-		return mcp.NewToolResultError("title parameter is required"), nil
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	created, err := srv.CreateSpreadsheet(ctx, title)

--- a/internal/tasks/tasks_tools_testable.go
+++ b/internal/tasks/tasks_tools_testable.go
@@ -88,9 +88,9 @@ func TestableTasksGet(ctx context.Context, request mcp.CallToolRequest, deps *Ta
 		return errResult, nil
 	}
 
-	taskID := common.ParseStringArg(request.Params.Arguments, "task_id", "")
-	if taskID == "" {
-		return mcp.NewToolResultError("task_id parameter is required"), nil
+	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
@@ -112,9 +112,9 @@ func TestableTasksCreate(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
-	if title == "" {
-		return mcp.NewToolResultError("title parameter is required"), nil
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
@@ -153,9 +153,9 @@ func TestableTasksUpdate(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	taskID := common.ParseStringArg(request.Params.Arguments, "task_id", "")
-	if taskID == "" {
-		return mcp.NewToolResultError("task_id parameter is required"), nil
+	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
@@ -208,9 +208,9 @@ func TestableTasksComplete(ctx context.Context, request mcp.CallToolRequest, dep
 		return errResult, nil
 	}
 
-	taskID := common.ParseStringArg(request.Params.Arguments, "task_id", "")
-	if taskID == "" {
-		return mcp.NewToolResultError("task_id parameter is required"), nil
+	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
@@ -242,9 +242,9 @@ func TestableTasksDelete(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	taskID := common.ParseStringArg(request.Params.Arguments, "task_id", "")
-	if taskID == "" {
-		return mcp.NewToolResultError("task_id parameter is required"), nil
+	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
@@ -273,9 +273,9 @@ func TestableTasksCreateTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
-	if title == "" {
-		return mcp.NewToolResultError("title parameter is required"), nil
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskList := &tasks.TaskList{
@@ -304,14 +304,14 @@ func TestableTasksUpdateTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", "")
-	if taskListID == "" {
-		return mcp.NewToolResultError("tasklist_id parameter is required"), nil
+	taskListID, errResult := common.RequireStringArg(request.Params.Arguments, "tasklist_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
-	if title == "" {
-		return mcp.NewToolResultError("title parameter is required"), nil
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	// Get the existing task list
@@ -345,9 +345,9 @@ func TestableTasksDeleteTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", "")
-	if taskListID == "" {
-		return mcp.NewToolResultError("tasklist_id parameter is required"), nil
+	taskListID, errResult := common.RequireStringArg(request.Params.Arguments, "tasklist_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	err := srv.DeleteTaskList(ctx, taskListID)
@@ -373,9 +373,9 @@ func TestableTasksMove(ctx context.Context, request mcp.CallToolRequest, deps *T
 		return errResult, nil
 	}
 
-	taskID := common.ParseStringArg(request.Params.Arguments, "task_id", "")
-	if taskID == "" {
-		return mcp.NewToolResultError("task_id parameter is required"), nil
+	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)


### PR DESCRIPTION
## Summary
- Adds `common.RequireStringArg(args, key)` helper that extracts a required string arg and returns an MCP error result if missing/empty
- Replaces 64 instances of the 3-line `ParseStringArg` + empty check + `NewToolResultError` boilerplate across 8 packages (contacts, tasks, gmail, calendar, drive, docs, sheets)
- Adds `args_test.go` with tests for `RequireStringArg`, `ParseStringArg`, `ParseBoolArg`, and `ParseMaxResults`
- Preserves custom error messages with extra context (A1 notation hints, RFC3339 format, etc.) and existing `extractRequired*` helpers that do URL normalization

## Test plan
- [x] `go build ./cmd/gsuite-mcp/` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 10 packages pass
- [x] Verified 64 conversions across 14 files via `grep -c RequireStringArg`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)