### PR TITLE
refactor(calendar): extract setNewEventTimes from TestableCalendarCreateEvent

### DIFF
--- a/internal/calendar/calendar_tools.go
+++ b/internal/calendar/calendar_tools.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -55,6 +56,56 @@ func updateEventTimes(event *calendar.Event, args map[string]any) *mcp.CallToolR
 			event.End = &calendar.EventDateTime{DateTime: endTime}
 		}
 	}
+	return nil
+}
+
+// setNewEventTimes sets start/end times on a new event from request arguments.
+// Requires start_time. Branches on all_day: all-day uses Date fields with same-day default,
+// timed uses DateTime fields with +1 hour default. Applies timezone to both Start and End.
+func setNewEventTimes(event *calendar.Event, args map[string]any) *mcp.CallToolResult {
+	startTime := common.ParseStringArg(args, "start_time", "")
+	if startTime == "" {
+		return mcp.NewToolResultError("start_time parameter is required (RFC3339 format, e.g., 2024-01-15T09:00:00-08:00)")
+	}
+
+	allDay := common.ParseBoolArg(args, "all_day", false)
+
+	if allDay {
+		startDate, err := extractDateFromDateTime(startTime)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid start_time for all-day event: %v", err))
+		}
+		event.Start = &calendar.EventDateTime{Date: startDate}
+
+		endTime := common.ParseStringArg(args, "end_time", "")
+		if endTime != "" {
+			endDate, err := extractDateFromDateTime(endTime)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Invalid end_time for all-day event: %v", err))
+			}
+			event.End = &calendar.EventDateTime{Date: endDate}
+		} else {
+			event.End = &calendar.EventDateTime{Date: startDate}
+		}
+	} else {
+		event.Start = &calendar.EventDateTime{DateTime: startTime}
+		endTime := common.ParseStringArg(args, "end_time", "")
+		if endTime != "" {
+			event.End = &calendar.EventDateTime{DateTime: endTime}
+		} else {
+			t, err := time.Parse(time.RFC3339, startTime)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Invalid start_time format: %v", err))
+			}
+			event.End = &calendar.EventDateTime{DateTime: t.Add(time.Hour).Format(time.RFC3339)}
+		}
+	}
+
+	if tz := common.ParseStringArg(args, "timezone", ""); tz != "" {
+		event.Start.TimeZone = tz
+		event.End.TimeZone = tz
+	}
+
 	return nil
 }
 

--- a/internal/calendar/calendar_tools_test.go
+++ b/internal/calendar/calendar_tools_test.go
@@ -638,6 +638,146 @@ func TestCalendarDeleteEvent(t *testing.T) {
 }
 
 // ============================================================================
+// setNewEventTimes tests
+// ============================================================================
+
+func TestSetNewEventTimes(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		wantErr    bool
+		errContain string
+		validate   func(t *testing.T, event *calendar.Event)
+	}{
+		{
+			name: "timed event with explicit end",
+			args: map[string]any{
+				"start_time": "2024-03-01T10:00:00-08:00",
+				"end_time":   "2024-03-01T11:00:00-08:00",
+			},
+			validate: func(t *testing.T, event *calendar.Event) {
+				if event.Start.DateTime != "2024-03-01T10:00:00-08:00" {
+					t.Errorf("expected start DateTime, got %v", event.Start.DateTime)
+				}
+				if event.End.DateTime != "2024-03-01T11:00:00-08:00" {
+					t.Errorf("expected end DateTime, got %v", event.End.DateTime)
+				}
+			},
+		},
+		{
+			name: "timed event defaults end to start plus 1 hour",
+			args: map[string]any{
+				"start_time": "2024-03-01T14:00:00-08:00",
+			},
+			validate: func(t *testing.T, event *calendar.Event) {
+				if event.Start.DateTime != "2024-03-01T14:00:00-08:00" {
+					t.Errorf("expected start DateTime, got %v", event.Start.DateTime)
+				}
+				if event.End.DateTime != "2024-03-01T15:00:00-08:00" {
+					t.Errorf("expected end DateTime +1hr, got %v", event.End.DateTime)
+				}
+			},
+		},
+		{
+			name: "all-day event with explicit end",
+			args: map[string]any{
+				"start_time": "2024-03-15",
+				"end_time":   "2024-03-17",
+				"all_day":    true,
+			},
+			validate: func(t *testing.T, event *calendar.Event) {
+				if event.Start.Date != "2024-03-15" {
+					t.Errorf("expected start Date '2024-03-15', got %v", event.Start.Date)
+				}
+				if event.End.Date != "2024-03-17" {
+					t.Errorf("expected end Date '2024-03-17', got %v", event.End.Date)
+				}
+			},
+		},
+		{
+			name: "all-day event defaults end to start date",
+			args: map[string]any{
+				"start_time": "2024-03-15",
+				"all_day":    true,
+			},
+			validate: func(t *testing.T, event *calendar.Event) {
+				if event.Start.Date != "2024-03-15" {
+					t.Errorf("expected start Date, got %v", event.Start.Date)
+				}
+				if event.End.Date != "2024-03-15" {
+					t.Errorf("expected end Date same as start, got %v", event.End.Date)
+				}
+			},
+		},
+		{
+			name: "timezone applied to both start and end",
+			args: map[string]any{
+				"start_time": "2024-03-01T10:00:00-08:00",
+				"end_time":   "2024-03-01T11:00:00-08:00",
+				"timezone":   "America/New_York",
+			},
+			validate: func(t *testing.T, event *calendar.Event) {
+				if event.Start.TimeZone != "America/New_York" {
+					t.Errorf("expected start timezone, got %v", event.Start.TimeZone)
+				}
+				if event.End.TimeZone != "America/New_York" {
+					t.Errorf("expected end timezone, got %v", event.End.TimeZone)
+				}
+			},
+		},
+		{
+			name:       "missing start_time returns error",
+			args:       map[string]any{},
+			wantErr:    true,
+			errContain: "start_time parameter is required",
+		},
+		{
+			name: "invalid start_time format returns error",
+			args: map[string]any{
+				"start_time": "not-a-date",
+			},
+			wantErr:    true,
+			errContain: "Invalid start_time format",
+		},
+		{
+			name: "all-day with too-short start_time returns error",
+			args: map[string]any{
+				"start_time": "2024",
+				"all_day":    true,
+			},
+			wantErr:    true,
+			errContain: "Invalid start_time for all-day event",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &calendar.Event{}
+			result := setNewEventTimes(event, tt.args)
+
+			if tt.wantErr {
+				if result == nil {
+					t.Fatal("expected error result, got nil")
+				}
+				content := getCalendarTextContent(result)
+				if tt.errContain != "" && !strings.Contains(content, tt.errContain) {
+					t.Errorf("expected error containing %q, got %q", tt.errContain, content)
+				}
+				return
+			}
+
+			if result != nil {
+				t.Fatalf("unexpected error: %v", getCalendarTextContent(result))
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, event)
+			}
+		})
+	}
+}
+
+// ============================================================================
 // Helper function tests
 // ============================================================================
 

--- a/internal/calendar/testable_events.go
+++ b/internal/calendar/testable_events.go
@@ -120,54 +120,9 @@ func TestableCalendarCreateEvent(ctx context.Context, request mcp.CallToolReques
 		event.Location = loc
 	}
 
-	// Start time - required
-	startTime := common.ParseStringArg(request.Params.Arguments, "start_time", "")
-	if startTime == "" {
-		return mcp.NewToolResultError("start_time parameter is required (RFC3339 format, e.g., 2024-01-15T09:00:00-08:00)"), nil
-	}
-
-	// Check if all-day event (date only, no time component)
-	allDay := common.ParseBoolArg(request.Params.Arguments, "all_day", false)
-
-	if allDay {
-		// All-day events use Date field (YYYY-MM-DD format)
-		startDate, err := extractDateFromDateTime(startTime)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Invalid start_time for all-day event: %v", err)), nil
-		}
-		event.Start = &calendar.EventDateTime{Date: startDate}
-
-		endTime := common.ParseStringArg(request.Params.Arguments, "end_time", "")
-		if endTime != "" {
-			endDate, err := extractDateFromDateTime(endTime)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("Invalid end_time for all-day event: %v", err)), nil
-			}
-			event.End = &calendar.EventDateTime{Date: endDate}
-		} else {
-			// Default to same day
-			event.End = &calendar.EventDateTime{Date: startDate}
-		}
-	} else {
-		// Timed events use DateTime field
-		event.Start = &calendar.EventDateTime{DateTime: startTime}
-		endTime := common.ParseStringArg(request.Params.Arguments, "end_time", "")
-		if endTime != "" {
-			event.End = &calendar.EventDateTime{DateTime: endTime}
-		} else {
-			// Default to 1 hour duration
-			t, err := time.Parse(time.RFC3339, startTime)
-			if err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("Invalid start_time format: %v", err)), nil
-			}
-			event.End = &calendar.EventDateTime{DateTime: t.Add(time.Hour).Format(time.RFC3339)}
-		}
-	}
-
-	// Time zone
-	if tz := common.ParseStringArg(request.Params.Arguments, "timezone", ""); tz != "" {
-		event.Start.TimeZone = tz
-		event.End.TimeZone = tz
+	// Set start/end times (required start_time, optional end_time/all_day/timezone)
+	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+		return errResult, nil
 	}
 
 	// Attendees
@@ -184,6 +139,7 @@ func TestableCalendarCreateEvent(ctx context.Context, request mcp.CallToolReques
 	addConferencing := common.ParseBoolArg(request.Params.Arguments, "add_conferencing", false)
 
 	if addConferencing {
+		startTime := common.ParseStringArg(request.Params.Arguments, "start_time", "")
 		event.ConferenceData = buildConferenceData(calendarID, startTime, summary)
 	}
 


### PR DESCRIPTION
## Summary
- Extract `setNewEventTimes()` helper into `calendar_tools.go` to handle creation-specific time logic (all-day vs timed branching, default end-time, timezone)
- Reduce `TestableCalendarCreateEvent` from ~112 to ~68 lines of orchestration
- Add 8 unit tests for the new helper covering all branches and error paths

## Test plan
- [x] `go build ./cmd/gsuite-mcp/` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — all tests pass (existing + 8 new)

Closes #34