### PR TITLE
feat(auth): persistent HTTP auth endpoint for browser-based re-auth

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -187,6 +187,8 @@ Re-run the auth command:
 gsuite-mcp auth
 ```
 
+Or, if gsuite-mcp is running as an MCP server, open `http://localhost:8100/auth` in your browser to re-authenticate without restarting the server. Error messages from tools will include this URL when the auth server is running.
+
 ### API Not Enabled
 
 Run `gsuite-mcp check` to see which APIs are disabled — it provides direct enable links.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ The default OAuth callback port is **8100**. Override it in `config.json`:
 
 Or via environment variable: `GSUITE_MCP_OAUTH_PORT=9000`
 
+### HTTP Auth Endpoint (MCP Server Mode)
+
+When running as an MCP server, gsuite-mcp starts a persistent HTTP server on the OAuth port so agents and users can trigger re-authentication from a browser:
+
+- **`http://localhost:8100/auth`** — starts OAuth flow (opens Google consent screen)
+- **`http://localhost:8100/auth?account=user@gmail.com`** — pre-selects the Google account
+
+When a tool encounters missing credentials, the error message includes a clickable auth URL. If the port is unavailable, the MCP server continues without the auth endpoint.
+
 ## Development
 
 ```bash

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aliwatters/gsuite-mcp/internal/auth"
 	"github.com/aliwatters/gsuite-mcp/internal/calendar"
@@ -52,6 +53,16 @@ func main() {
 	if err := initializeApp(); err != nil {
 		fmt.Fprintf(os.Stderr, "Initialization error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Start persistent HTTP auth server (non-fatal if port is unavailable)
+	authSrv := startAuthServer()
+	if authSrv != nil {
+		defer func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			authSrv.Shutdown(ctx)
+		}()
 	}
 
 	s := server.NewMCPServer(serverName, serverVersion)
@@ -180,4 +191,27 @@ func runAccounts() {
 		fmt.Printf("  %s\n", email)
 	}
 	fmt.Printf("\nRun '%s auth' to add another account.\n", serverName)
+}
+
+// startAuthServer starts a persistent HTTP auth server for browser-based re-authentication.
+// Returns nil if the port cannot be bound (non-fatal — MCP server continues without it).
+func startAuthServer() *auth.AuthServer {
+	port, _, err := auth.ResolveOAuthPort()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not resolve OAuth port: %v\n", err)
+		return nil
+	}
+
+	d := common.GetDeps()
+	srv := auth.NewAuthServer(d.AuthManager, port)
+	if err := srv.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: auth server not started: %v\n", err)
+		return nil
+	}
+
+	authURL := fmt.Sprintf("http://localhost:%d/auth", port)
+	d.AuthManager.AuthServerURL = authURL
+	fmt.Fprintf(os.Stderr, "auth server listening on %s\n", authURL)
+
+	return srv
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -140,6 +140,10 @@ if err != nil {
 
 **Reference**: `internal/auth/auth.go:78-110`
 
+#### HTTP Auth Endpoint
+
+When running as an MCP server, gsuite-mcp starts a persistent HTTP auth server on the OAuth port. If a tool encounters missing credentials, the error message includes a clickable URL (e.g., `http://localhost:8100/auth?account=user@gmail.com`). Agents should surface this URL to the user rather than suggesting CLI commands.
+
 ### 4. Error Handling
 
 Return user-friendly errors via MCP:

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -119,6 +120,8 @@ type Manager struct {
 	oauthConfig *oauth2.Config
 	// authMu prevents concurrent authentication attempts
 	authMu sync.Mutex
+	// AuthServerURL is set when the HTTP auth server is running (e.g. "http://localhost:8100/auth").
+	AuthServerURL string
 }
 
 // OAuthConfig returns the OAuth2 configuration (needed for reading ClientID).
@@ -356,6 +359,9 @@ func (m *Manager) GetClientOrAuthenticate(ctx context.Context, email string, int
 		}
 		// No credentials for specified email
 		if !interactive {
+			if m.AuthServerURL != "" {
+				return nil, fmt.Errorf("no credentials for %s; open %s?account=%s to authenticate", email, m.AuthServerURL, url.QueryEscape(email))
+			}
 			return nil, fmt.Errorf("no credentials for %s; run 'gsuite-mcp auth' and sign in with that account", email)
 		}
 		// Trigger authentication
@@ -380,6 +386,9 @@ func (m *Manager) GetClientOrAuthenticate(ctx context.Context, email string, int
 
 	// No authenticated accounts
 	if !interactive {
+		if m.AuthServerURL != "" {
+			return nil, fmt.Errorf("no authenticated accounts; open %s to authenticate", m.AuthServerURL)
+		}
 		return nil, fmt.Errorf("no authenticated accounts; run 'gsuite-mcp auth' to authenticate")
 	}
 

--- a/internal/auth/server.go
+++ b/internal/auth/server.go
@@ -1,0 +1,207 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	// stateExpiry is how long an OAuth state token remains valid.
+	stateExpiry = 5 * time.Minute
+
+	// cleanupInterval is how often expired states are purged.
+	cleanupInterval = 1 * time.Minute
+)
+
+// pendingState tracks a single in-flight OAuth request.
+type pendingState struct {
+	loginHint string
+	expiresAt time.Time
+}
+
+// AuthServer is a persistent HTTP server that provides browser-based re-authentication
+// alongside the stdio MCP server. Agents can direct users to /auth to trigger OAuth.
+type AuthServer struct {
+	manager      *Manager
+	port         int
+	server       *http.Server
+	listener     net.Listener
+	states       sync.Map
+	stopCleanup  chan struct{}
+	shutdownOnce sync.Once
+}
+
+// NewAuthServer creates an auth server bound to the given manager and port.
+func NewAuthServer(manager *Manager, port int) *AuthServer {
+	return &AuthServer{
+		manager:     manager,
+		port:        port,
+		stopCleanup: make(chan struct{}),
+	}
+}
+
+// Start binds the port and begins serving /auth and /oauth2callback.
+// Returns an error if the port cannot be bound.
+func (s *AuthServer) Start() error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", s.port))
+	if err != nil {
+		return fmt.Errorf("binding port %d: %w", s.port, err)
+	}
+	s.listener = listener
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth", s.handleAuth)
+	mux.HandleFunc("/oauth2callback", s.handleCallback)
+
+	s.server = &http.Server{Handler: mux}
+
+	go s.server.Serve(listener) //nolint:errcheck // logged by caller; ErrServerClosed expected on shutdown
+
+	go s.cleanupExpiredStates()
+
+	return nil
+}
+
+// Shutdown gracefully stops the auth server. Safe to call multiple times.
+func (s *AuthServer) Shutdown(ctx context.Context) error {
+	s.shutdownOnce.Do(func() { close(s.stopCleanup) })
+	if s.server != nil {
+		return s.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+// handleAuth generates a CSRF state, stores it, and redirects to Google OAuth.
+func (s *AuthServer) handleAuth(w http.ResponseWriter, r *http.Request) {
+	stateBytes := make([]byte, oauthStateTokenSize)
+	if _, err := rand.Read(stateBytes); err != nil {
+		sendOAuthError(w, "Server Error", "Failed to generate security token")
+		return
+	}
+	state := hex.EncodeToString(stateBytes)
+
+	loginHint := r.URL.Query().Get("account")
+
+	s.states.Store(state, pendingState{
+		loginHint: loginHint,
+		expiresAt: time.Now().Add(stateExpiry),
+	})
+
+	oauthCfg := s.oauthConfigWithRedirect()
+
+	opts := []oauth2.AuthCodeOption{
+		oauth2.AccessTypeOffline,
+		oauth2.ApprovalForce,
+	}
+	if loginHint != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("login_hint", loginHint))
+	}
+
+	authURL := oauthCfg.AuthCodeURL(state, opts...)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// handleCallback validates the state, exchanges the code, saves the token, and renders the result.
+func (s *AuthServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	// Check for Google-reported errors first
+	if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+		errDesc := r.URL.Query().Get("error_description")
+		if errDesc == "" {
+			errDesc = errMsg
+		}
+		sendOAuthError(w, "Authentication Failed", errDesc)
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		sendOAuthError(w, "Authentication Error", "Missing state parameter")
+		return
+	}
+
+	// LoadAndDelete ensures each state token is used exactly once
+	val, ok := s.states.LoadAndDelete(state)
+	if !ok {
+		sendOAuthError(w, "Authentication Error", "Invalid or expired state token. Please start again from /auth")
+		return
+	}
+
+	ps := val.(pendingState)
+	if time.Now().After(ps.expiresAt) {
+		sendOAuthError(w, "Authentication Error", "This authentication link has expired. Please start again from /auth")
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		sendOAuthError(w, "Authentication Error", "No authorization code received from Google")
+		return
+	}
+
+	oauthCfg := s.oauthConfigWithRedirect()
+
+	token, err := oauthCfg.Exchange(r.Context(), code)
+	if err != nil {
+		sendOAuthError(w, "Authentication Error", fmt.Sprintf("Failed to exchange code: %v", err))
+		return
+	}
+
+	client := oauthCfg.Client(r.Context(), token)
+	email, err := getAuthenticatedEmail(r.Context(), client)
+	if err != nil {
+		sendOAuthError(w, "Authentication Error", fmt.Sprintf("Failed to get account email: %v", err))
+		return
+	}
+
+	if err := s.manager.saveTokenForEmail(email, token); err != nil {
+		sendOAuthError(w, "Authentication Error", fmt.Sprintf("Failed to save token: %v", err))
+		return
+	}
+
+	otherAccounts := getOtherAuthenticatedEmails(email)
+
+	w.Header().Set("Content-Type", "text/html")
+	if err := successTmpl.Execute(w, successPageData{
+		Email:         email,
+		OtherAccounts: otherAccounts,
+	}); err != nil {
+		http.Error(w, "Failed to render success page", http.StatusInternalServerError)
+	}
+}
+
+// oauthConfigWithRedirect returns a copy of the OAuth config with the redirect URL set to this server.
+func (s *AuthServer) oauthConfigWithRedirect() oauth2.Config {
+	cfg := *s.manager.oauthConfig
+	cfg.RedirectURL = fmt.Sprintf("http://localhost:%d/oauth2callback", s.port)
+	return cfg
+}
+
+// cleanupExpiredStates periodically removes expired state tokens.
+func (s *AuthServer) cleanupExpiredStates() {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			now := time.Now()
+			s.states.Range(func(key, value any) bool {
+				ps := value.(pendingState)
+				if now.After(ps.expiresAt) {
+					s.states.Delete(key)
+				}
+				return true
+			})
+		case <-s.stopCleanup:
+			return
+		}
+	}
+}

--- a/internal/auth/server_test.go
+++ b/internal/auth/server_test.go
@@ -1,0 +1,256 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// newTestAuthServer creates an AuthServer with a fake oauth2 config for testing.
+func newTestAuthServer() *AuthServer {
+	mgr := &Manager{
+		oauthConfig: &oauth2.Config{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+				TokenURL: "https://oauth2.googleapis.com/token",
+			},
+			Scopes: []string{"openid", "email"},
+		},
+	}
+	return NewAuthServer(mgr, 8100)
+}
+
+func TestHandleAuth_RedirectsToGoogle(t *testing.T) {
+	s := newTestAuthServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth", nil)
+	w := httptest.NewRecorder()
+
+	s.handleAuth(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 redirect, got %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		t.Fatal("expected Location header")
+	}
+
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("invalid redirect URL: %v", err)
+	}
+
+	if u.Host != "accounts.google.com" {
+		t.Errorf("expected redirect to accounts.google.com, got %s", u.Host)
+	}
+
+	state := u.Query().Get("state")
+	if state == "" {
+		t.Error("expected state parameter in redirect URL")
+	}
+
+	// Verify state was stored
+	if _, ok := s.states.Load(state); !ok {
+		t.Error("state was not stored in map")
+	}
+
+	// Should not have login_hint
+	if u.Query().Get("login_hint") != "" {
+		t.Error("did not expect login_hint without account param")
+	}
+}
+
+func TestHandleAuth_WithAccountParam(t *testing.T) {
+	s := newTestAuthServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth?account=user@gmail.com", nil)
+	w := httptest.NewRecorder()
+
+	s.handleAuth(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("invalid redirect URL: %v", err)
+	}
+
+	if hint := u.Query().Get("login_hint"); hint != "user@gmail.com" {
+		t.Errorf("expected login_hint=user@gmail.com, got %q", hint)
+	}
+}
+
+func TestHandleCallback_UnknownState(t *testing.T) {
+	s := newTestAuthServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?state=bogus&code=abc", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Invalid or expired state token") {
+		t.Errorf("expected error about invalid state, got: %s", body)
+	}
+}
+
+func TestHandleCallback_ExpiredState(t *testing.T) {
+	s := newTestAuthServer()
+
+	// Store a state that already expired
+	s.states.Store("expired-state", pendingState{
+		expiresAt: time.Now().Add(-1 * time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?state=expired-state&code=abc", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "expired") {
+		t.Errorf("expected error about expiry, got: %s", body)
+	}
+}
+
+func TestHandleCallback_MissingCode(t *testing.T) {
+	s := newTestAuthServer()
+
+	s.states.Store("valid-state", pendingState{
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?state=valid-state", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "No authorization code") {
+		t.Errorf("expected error about missing code, got: %s", body)
+	}
+}
+
+func TestHandleCallback_GoogleError(t *testing.T) {
+	s := newTestAuthServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?error=access_denied&error_description=User+denied+access", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "User denied access") {
+		t.Errorf("expected Google error description, got: %s", body)
+	}
+}
+
+func TestHandleCallback_MissingState(t *testing.T) {
+	s := newTestAuthServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?code=abc", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCallback(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Missing state") {
+		t.Errorf("expected error about missing state, got: %s", body)
+	}
+}
+
+func TestCleanupExpiredStates(t *testing.T) {
+	s := newTestAuthServer()
+
+	// Add an expired state and a valid state
+	s.states.Store("expired", pendingState{
+		expiresAt: time.Now().Add(-1 * time.Minute),
+	})
+	s.states.Store("valid", pendingState{
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	// Run cleanup manually (simulate one tick)
+	now := time.Now()
+	s.states.Range(func(key, value any) bool {
+		ps := value.(pendingState)
+		if now.After(ps.expiresAt) {
+			s.states.Delete(key)
+		}
+		return true
+	})
+
+	// Expired should be gone
+	if _, ok := s.states.Load("expired"); ok {
+		t.Error("expected expired state to be cleaned up")
+	}
+
+	// Valid should remain
+	if _, ok := s.states.Load("valid"); !ok {
+		t.Error("expected valid state to still exist")
+	}
+}
+
+func TestHandleCallback_StateUsedOnce(t *testing.T) {
+	s := newTestAuthServer()
+
+	s.states.Store("one-time", pendingState{
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	// First call consumes the state (will fail at code exchange, but state is consumed)
+	req := httptest.NewRequest(http.MethodGet, "/oauth2callback?state=one-time&code=fake", nil)
+	w := httptest.NewRecorder()
+	s.handleCallback(w, req)
+
+	// Second call with same state should fail with invalid state
+	req2 := httptest.NewRequest(http.MethodGet, "/oauth2callback?state=one-time&code=fake", nil)
+	w2 := httptest.NewRecorder()
+	s.handleCallback(w2, req2)
+
+	if w2.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 on reuse, got %d", w2.Result().StatusCode)
+	}
+	if !strings.Contains(w2.Body.String(), "Invalid or expired state token") {
+		t.Error("expected invalid state error on reuse")
+	}
+}

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/aliwatters/gsuite-mcp/internal/auth"
 	"github.com/aliwatters/gsuite-mcp/internal/config"
@@ -34,6 +35,9 @@ func ResolveAccountFromRequest(request mcp.CallToolRequest) (string, error) {
 		// No account specified - use first authenticated email
 		email := config.GetDefaultEmail()
 		if email == "" {
+			if deps != nil && deps.AuthManager.AuthServerURL != "" {
+				return "", fmt.Errorf("no authenticated accounts found; open %s to authenticate", deps.AuthManager.AuthServerURL)
+			}
 			return "", fmt.Errorf("no authenticated accounts found; run 'gsuite-mcp auth' to authenticate")
 		}
 		return email, nil
@@ -44,5 +48,8 @@ func ResolveAccountFromRequest(request mcp.CallToolRequest) (string, error) {
 		return accountParam, nil
 	}
 
+	if deps != nil && deps.AuthManager.AuthServerURL != "" {
+		return "", fmt.Errorf("no credentials for %s; open %s?account=%s to authenticate", accountParam, deps.AuthManager.AuthServerURL, url.QueryEscape(accountParam))
+	}
 	return "", fmt.Errorf("no credentials for %s; run 'gsuite-mcp auth' and sign in with that account", accountParam)
 }


### PR DESCRIPTION
## Summary

- Adds a persistent HTTP auth server (`/auth` and `/oauth2callback`) that runs alongside the MCP stdio server on the configured OAuth port
- Error messages from tools now include clickable `http://localhost:8100/auth` URLs when credentials are missing, so agents can surface them directly
- Supports `?account=user@gmail.com` parameter to pre-select the Google account in the OAuth flow
- Non-fatal startup — if the port is unavailable, the MCP server continues without the auth endpoint

Closes #29

## Test plan

- `go test ./...` — all pass, 8 new tests covering redirects, CSRF state validation, expiry, replay protection, and cleanup
- `go build ./cmd/gsuite-mcp/ && go vet ./...` — clean
- Manual: start MCP server, open `http://localhost:8100/auth` in browser, verify Google OAuth redirect