### PR TITLE
feat(calendar): Focus Time, OOO, conference data, and free/busy queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gsuite-mcp auth personal
 ### Gmail (36 tools)
 Full inbox management: search, read, send, reply, archive, trash, labels, filters, drafts, threads, batch operations, vacation responder.
 
-### Calendar (10 tools)
+### Calendar (12 tools)
 Complete calendar control: list events, create/update/delete, recurring events, free/busy queries, Google Meet integration.
 
 ### Drive (23 tools)
@@ -110,16 +110,18 @@ Contact management: list, search, create, update, delete, contact groups.
 #### Calendar
 | Tool | Description |
 |------|-------------|
-| `calendar_list_events` | List events with filtering |
-| `calendar_get_event` | Get event details |
+| `calendar_list_events` | List events with filtering (supports event_types filter) |
+| `calendar_get_event` | Get event details (includes conference data) |
 | `calendar_create_event` | Create event (with optional Google Meet) |
 | `calendar_update_event` | Update event |
 | `calendar_delete_event` | Delete event |
 | `calendar_list_calendars` | List available calendars |
 | `calendar_quick_add` | Create from natural language |
-| `calendar_free_busy` | Query availability |
+| `calendar_free_busy` | Query availability across calendars |
 | `calendar_list_instances` | List recurring event instances |
 | `calendar_update_instance` | Update single recurrence |
+| `calendar_create_focus_time` | Create Focus Time with auto-decline |
+| `calendar_create_out_of_office` | Create Out of Office with auto-decline |
 
 #### Drive
 | Tool | Description |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,7 +24,7 @@ This document provides AI agents with project-specific context and guidelines fo
 
 ### Services Supported
 - Gmail (36 tools)
-- Google Calendar (10 tools)
+- Google Calendar (12 tools)
 - Google Drive (23 tools) — includes shared drive support, comments, revisions
 - Google Docs (16 tools)
 - Google Tasks (10 tools)

--- a/internal/calendar/calendar_service.go
+++ b/internal/calendar/calendar_service.go
@@ -38,8 +38,9 @@ type ListEventsOptions struct {
 	OrderBy      string // "startTime" or "updated"
 	Query        string // Free text search
 	ShowDeleted  bool
-	UpdatedMin   string // RFC3339 timestamp
-	Fields       string // Selector specifying which fields to include in a partial response
+	UpdatedMin   string   // RFC3339 timestamp
+	Fields       string   // Selector specifying which fields to include in a partial response
+	EventTypes   []string // Filter by event types (e.g., "default", "focusTime", "outOfOffice")
 }
 
 // ListInstancesOptions contains optional parameters for listing recurring event instances.
@@ -104,6 +105,9 @@ func (s *RealCalendarService) ListEvents(ctx context.Context, calendarID string,
 		}
 		if opts.Fields != "" {
 			call = call.Fields(googleapi.Field(opts.Fields))
+		}
+		if len(opts.EventTypes) > 0 {
+			call = call.EventTypes(opts.EventTypes...)
 		}
 	}
 

--- a/internal/calendar/calendar_tools.go
+++ b/internal/calendar/calendar_tools.go
@@ -15,9 +15,9 @@ import (
 // These reduce response payload size by only requesting needed fields.
 const (
 	// CalendarEventListFields contains fields for event listings (compact format)
-	CalendarEventListFields = "nextPageToken,items(id,summary,status,start,end,location,htmlLink,hangoutLink)"
+	CalendarEventListFields = "nextPageToken,items(id,summary,status,start,end,location,htmlLink,hangoutLink,eventType)"
 	// CalendarEventGetFields contains fields for single event retrieval (full format)
-	CalendarEventGetFields = "id,summary,status,description,location,start,end,htmlLink,created,updated,creator,organizer,attendees,reminders,recurrence,recurringEventId,hangoutLink,conferenceData"
+	CalendarEventGetFields = "id,summary,status,description,location,start,end,htmlLink,created,updated,creator,organizer,attendees,reminders,recurrence,recurringEventId,hangoutLink,conferenceData,eventType"
 	// CalendarListFields contains fields for calendar list
 	CalendarListFields = "items(id,summary,description,primary,backgroundColor,accessRole,timeZone)"
 )
@@ -170,14 +170,16 @@ func buildConferenceData(calendarID, startTime, summary string) *calendar.Confer
 // === Handle functions - generated via WrapHandler ===
 
 var (
-	HandleCalendarListEvents     = common.WrapHandler[CalendarService](TestableCalendarListEvents)
-	HandleCalendarGetEvent       = common.WrapHandler[CalendarService](TestableCalendarGetEvent)
-	HandleCalendarCreateEvent    = common.WrapHandler[CalendarService](TestableCalendarCreateEvent)
-	HandleCalendarUpdateEvent    = common.WrapHandler[CalendarService](TestableCalendarUpdateEvent)
-	HandleCalendarDeleteEvent    = common.WrapHandler[CalendarService](TestableCalendarDeleteEvent)
-	HandleCalendarListCalendars  = common.WrapHandler[CalendarService](TestableCalendarListCalendars)
-	HandleCalendarQuickAdd       = common.WrapHandler[CalendarService](TestableCalendarQuickAdd)
-	HandleCalendarFreeBusy       = common.WrapHandler[CalendarService](TestableCalendarFreeBusy)
-	HandleCalendarListInstances  = common.WrapHandler[CalendarService](TestableCalendarListInstances)
-	HandleCalendarUpdateInstance = common.WrapHandler[CalendarService](TestableCalendarUpdateInstance)
+	HandleCalendarListEvents      = common.WrapHandler[CalendarService](TestableCalendarListEvents)
+	HandleCalendarGetEvent        = common.WrapHandler[CalendarService](TestableCalendarGetEvent)
+	HandleCalendarCreateEvent     = common.WrapHandler[CalendarService](TestableCalendarCreateEvent)
+	HandleCalendarUpdateEvent     = common.WrapHandler[CalendarService](TestableCalendarUpdateEvent)
+	HandleCalendarDeleteEvent     = common.WrapHandler[CalendarService](TestableCalendarDeleteEvent)
+	HandleCalendarListCalendars   = common.WrapHandler[CalendarService](TestableCalendarListCalendars)
+	HandleCalendarQuickAdd        = common.WrapHandler[CalendarService](TestableCalendarQuickAdd)
+	HandleCalendarFreeBusy        = common.WrapHandler[CalendarService](TestableCalendarFreeBusy)
+	HandleCalendarListInstances   = common.WrapHandler[CalendarService](TestableCalendarListInstances)
+	HandleCalendarUpdateInstance  = common.WrapHandler[CalendarService](TestableCalendarUpdateInstance)
+	HandleCalendarCreateFocusTime = common.WrapHandler[CalendarService](TestableCalendarCreateFocusTime)
+	HandleCalendarCreateOOO       = common.WrapHandler[CalendarService](TestableCalendarCreateOutOfOffice)
 )

--- a/internal/calendar/helpers.go
+++ b/internal/calendar/helpers.go
@@ -35,6 +35,14 @@ func formatEvent(event *calendar.Event) map[string]any {
 		result["location"] = event.Location
 	}
 
+	if event.EventType != "" && event.EventType != "default" {
+		result["event_type"] = event.EventType
+	}
+
+	if event.HangoutLink != "" {
+		result["hangout_link"] = event.HangoutLink
+	}
+
 	return result
 }
 
@@ -114,13 +122,32 @@ func formatEventFull(event *calendar.Event) map[string]any {
 		result["hangout_link"] = event.HangoutLink
 	}
 
-	if event.ConferenceData != nil && event.ConferenceData.EntryPoints != nil {
-		for _, ep := range event.ConferenceData.EntryPoints {
-			if ep.EntryPointType == "video" {
-				result["video_link"] = ep.Uri
-				break
-			}
+	if event.ConferenceData != nil {
+		confData := map[string]any{}
+		if event.ConferenceData.ConferenceSolution != nil {
+			confData["solution"] = event.ConferenceData.ConferenceSolution.Name
 		}
+		if event.ConferenceData.ConferenceId != "" {
+			confData["conference_id"] = event.ConferenceData.ConferenceId
+		}
+		if event.ConferenceData.EntryPoints != nil {
+			entryPoints := make([]map[string]any, 0, len(event.ConferenceData.EntryPoints))
+			for _, ep := range event.ConferenceData.EntryPoints {
+				entry := map[string]any{
+					"type": ep.EntryPointType,
+					"uri":  ep.Uri,
+				}
+				if ep.Label != "" {
+					entry["label"] = ep.Label
+				}
+				entryPoints = append(entryPoints, entry)
+				if ep.EntryPointType == "video" {
+					result["video_link"] = ep.Uri
+				}
+			}
+			confData["entry_points"] = entryPoints
+		}
+		result["conference_data"] = confData
 	}
 
 	return result

--- a/internal/calendar/register.go
+++ b/internal/calendar/register.go
@@ -20,6 +20,7 @@ func RegisterTools(s *server.MCPServer) {
 		common.WithPageToken(),
 		mcp.WithString("query", mcp.Description("Free text search query")),
 		mcp.WithBoolean("single_events", mcp.Description("Expand recurring events into instances (default: false)")),
+		mcp.WithArray("event_types", mcp.Description("Filter by event types: 'default', 'focusTime', 'outOfOffice', 'workingLocation'")),
 		common.WithAccountParam(),
 	), HandleCalendarListEvents)
 
@@ -119,4 +120,38 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
 		common.WithAccountParam(),
 	), HandleCalendarUpdateInstance)
+
+	// === Calendar Special Events (Phase 3) ===
+
+	// calendar_create_focus_time - Create Focus Time event
+	s.AddTool(mcp.NewTool("calendar_create_focus_time",
+		mcp.WithDescription("Create a Focus Time event that auto-declines conflicting meetings."),
+		mcp.WithString("start_time", mcp.Required(), mcp.Description("Start time (RFC3339, e.g., 2024-01-15T09:00:00-08:00)")),
+		mcp.WithString("end_time", mcp.Description("End time (RFC3339). Defaults to 1 hour after start.")),
+		mcp.WithString("summary", mcp.Description("Event title (default: 'Focus Time')")),
+		mcp.WithString("description", mcp.Description("Event description")),
+		mcp.WithString("timezone", mcp.Description("Timezone (e.g., America/Los_Angeles)")),
+		mcp.WithBoolean("auto_decline", mcp.Description("Auto-decline conflicting invitations (default: true)")),
+		mcp.WithString("decline_message", mcp.Description("Message sent when declining (default: 'Declined because I am in focus time.')")),
+		mcp.WithString("chat_status", mcp.Description("Chat status during focus time: 'doNotDisturb' or 'available' (default: 'doNotDisturb')")),
+		mcp.WithString("recurrence", mcp.Description("RRULE for recurring focus time (e.g., 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')")),
+		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
+		common.WithAccountParam(),
+	), HandleCalendarCreateFocusTime)
+
+	// calendar_create_out_of_office - Create Out of Office event
+	s.AddTool(mcp.NewTool("calendar_create_out_of_office",
+		mcp.WithDescription("Create an Out of Office event that auto-declines meetings."),
+		mcp.WithString("start_time", mcp.Required(), mcp.Description("Start time (RFC3339, e.g., 2024-01-15T09:00:00-08:00)")),
+		mcp.WithString("end_time", mcp.Description("End time (RFC3339). Defaults to 1 hour after start.")),
+		mcp.WithString("summary", mcp.Description("Event title (default: 'Out of office')")),
+		mcp.WithString("description", mcp.Description("Event description")),
+		mcp.WithString("timezone", mcp.Description("Timezone (e.g., America/Los_Angeles)")),
+		mcp.WithBoolean("all_day", mcp.Description("Create all-day OOO event (use YYYY-MM-DD for start/end)")),
+		mcp.WithBoolean("auto_decline", mcp.Description("Auto-decline conflicting invitations (default: true)")),
+		mcp.WithString("decline_message", mcp.Description("Message sent when declining (default: 'I am out of office and unable to attend.')")),
+		mcp.WithString("recurrence", mcp.Description("RRULE for recurring OOO (e.g., 'RRULE:FREQ=WEEKLY;BYDAY=FR')")),
+		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
+		common.WithAccountParam(),
+	), HandleCalendarCreateOOO)
 }

--- a/internal/calendar/testable_events.go
+++ b/internal/calendar/testable_events.go
@@ -51,6 +51,19 @@ func TestableCalendarListEvents(ctx context.Context, request mcp.CallToolRequest
 		opts.OrderBy = "startTime"
 	}
 
+	// Filter by event types (e.g., "focusTime", "outOfOffice")
+	if eventTypesRaw, ok := request.Params.Arguments["event_types"].([]any); ok && len(eventTypesRaw) > 0 {
+		eventTypes := make([]string, 0, len(eventTypesRaw))
+		for _, et := range eventTypesRaw {
+			if etStr, ok := et.(string); ok && etStr != "" {
+				eventTypes = append(eventTypes, etStr)
+			}
+		}
+		if len(eventTypes) > 0 {
+			opts.EventTypes = eventTypes
+		}
+	}
+
 	resp, err := srv.ListEvents(ctx, calendarID, opts)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Calendar API error: %v", err)), nil

--- a/internal/calendar/testable_special_events.go
+++ b/internal/calendar/testable_special_events.go
@@ -1,0 +1,120 @@
+package calendar
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/calendar/v3"
+)
+
+// TestableCalendarCreateFocusTime creates a Focus Time event with auto-decline.
+func TestableCalendarCreateFocusTime(ctx context.Context, request mcp.CallToolRequest, deps *CalendarHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveCalendarServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	summary := common.ParseStringArg(request.Params.Arguments, "summary", "Focus Time")
+	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+
+	event := &calendar.Event{
+		Summary:   summary,
+		EventType: "focusTime",
+	}
+
+	if desc := common.ParseStringArg(request.Params.Arguments, "description", ""); desc != "" {
+		event.Description = desc
+	}
+
+	// Set start/end times
+	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+		return errResult, nil
+	}
+
+	// Focus Time uses FocusTimeProperties for auto-decline
+	autoDecline := common.ParseBoolArg(request.Params.Arguments, "auto_decline", true)
+	declineMessage := common.ParseStringArg(request.Params.Arguments, "decline_message", "Declined because I am in focus time.")
+	chatStatus := common.ParseStringArg(request.Params.Arguments, "chat_status", "doNotDisturb")
+
+	event.FocusTimeProperties = &calendar.EventFocusTimeProperties{
+		AutoDeclineMode: boolToDeclineMode(autoDecline),
+		DeclineMessage:  declineMessage,
+		ChatStatus:      chatStatus,
+	}
+
+	// Recurrence
+	if rrule := common.ParseStringArg(request.Params.Arguments, "recurrence", ""); rrule != "" {
+		event.Recurrence = []string{rrule}
+	}
+
+	created, err := srv.CreateEvent(ctx, calendarID, event, 0)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Calendar API error: %v", err)), nil
+	}
+
+	result := formatEvent(created)
+	result["html_link"] = created.HtmlLink
+	result["event_type"] = "focusTime"
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableCalendarCreateOutOfOffice creates an Out of Office event.
+func TestableCalendarCreateOutOfOffice(ctx context.Context, request mcp.CallToolRequest, deps *CalendarHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveCalendarServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	summary := common.ParseStringArg(request.Params.Arguments, "summary", "Out of office")
+	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+
+	event := &calendar.Event{
+		Summary:   summary,
+		EventType: "outOfOffice",
+	}
+
+	if desc := common.ParseStringArg(request.Params.Arguments, "description", ""); desc != "" {
+		event.Description = desc
+	}
+
+	// Set start/end times
+	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+		return errResult, nil
+	}
+
+	// Out of Office uses OutOfOfficeProperties for auto-decline
+	autoDecline := common.ParseBoolArg(request.Params.Arguments, "auto_decline", true)
+	declineMessage := common.ParseStringArg(request.Params.Arguments, "decline_message", "I am out of office and unable to attend.")
+
+	event.OutOfOfficeProperties = &calendar.EventOutOfOfficeProperties{
+		AutoDeclineMode: boolToDeclineMode(autoDecline),
+		DeclineMessage:  declineMessage,
+	}
+
+	// Recurrence
+	if rrule := common.ParseStringArg(request.Params.Arguments, "recurrence", ""); rrule != "" {
+		event.Recurrence = []string{rrule}
+	}
+
+	created, err := srv.CreateEvent(ctx, calendarID, event, 0)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Calendar API error: %v", err)), nil
+	}
+
+	result := formatEvent(created)
+	result["html_link"] = created.HtmlLink
+	result["event_type"] = "outOfOffice"
+
+	return common.MarshalToolResult(result)
+}
+
+// boolToDeclineMode converts a boolean auto_decline flag to the Google Calendar API decline mode string.
+func boolToDeclineMode(autoDecline bool) string {
+	if autoDecline {
+		return "declineAllConflictingInvitations"
+	}
+	return "declineNone"
+}

--- a/internal/calendar/testable_special_events_test.go
+++ b/internal/calendar/testable_special_events_test.go
@@ -1,0 +1,374 @@
+package calendar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/calendar/v3"
+)
+
+// ============================================================================
+// calendar_create_focus_time tests
+// ============================================================================
+
+func TestCalendarCreateFocusTime(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		setupMock  func(*MockCalendarService)
+		wantErr    bool
+		errContain string
+		validate   func(t *testing.T, result string)
+	}{
+		{
+			name: "create focus time with defaults",
+			args: map[string]any{
+				"start_time": "2024-03-01T09:00:00-08:00",
+				"end_time":   "2024-03-01T11:00:00-08:00",
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["summary"] != "Focus Time" {
+					t.Errorf("expected default summary 'Focus Time', got %v", data["summary"])
+				}
+				if data["event_type"] != "focusTime" {
+					t.Errorf("expected event_type 'focusTime', got %v", data["event_type"])
+				}
+				if data["html_link"] == nil {
+					t.Error("expected html_link in response")
+				}
+			},
+		},
+		{
+			name: "create focus time with custom summary",
+			args: map[string]any{
+				"summary":    "Deep Work",
+				"start_time": "2024-03-01T09:00:00-08:00",
+				"end_time":   "2024-03-01T12:00:00-08:00",
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["summary"] != "Deep Work" {
+					t.Errorf("expected summary 'Deep Work', got %v", data["summary"])
+				}
+			},
+		},
+		{
+			name: "create focus time with auto_decline disabled",
+			args: map[string]any{
+				"start_time":   "2024-03-01T09:00:00-08:00",
+				"auto_decline": false,
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["event_type"] != "focusTime" {
+					t.Errorf("expected event_type 'focusTime', got %v", data["event_type"])
+				}
+			},
+		},
+		{
+			name: "create recurring focus time",
+			args: map[string]any{
+				"start_time": "2024-03-01T09:00:00-08:00",
+				"end_time":   "2024-03-01T11:00:00-08:00",
+				"recurrence": "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["event_type"] != "focusTime" {
+					t.Errorf("expected event_type 'focusTime', got %v", data["event_type"])
+				}
+			},
+		},
+		{
+			name:       "missing start_time",
+			args:       map[string]any{},
+			wantErr:    true,
+			errContain: "start_time parameter is required",
+		},
+		{
+			name: "api error",
+			args: map[string]any{
+				"start_time": "2024-03-01T09:00:00-08:00",
+			},
+			setupMock: func(m *MockCalendarService) {
+				m.Error = errors.New("API error")
+			},
+			wantErr:    true,
+			errContain: "Calendar API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtures := NewCalendarTestFixtures()
+			if tt.setupMock != nil {
+				tt.setupMock(fixtures.MockService)
+			}
+
+			request := CreateMCPRequest(tt.args)
+			result, err := TestableCalendarCreateFocusTime(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			content := getCalendarTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got success")
+				}
+				if tt.errContain != "" && !strings.Contains(content, tt.errContain) {
+					t.Errorf("expected error containing %q, got %q", tt.errContain, content)
+				}
+				return
+			}
+
+			if result.IsError {
+				t.Errorf("unexpected error: %s", content)
+				return
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, content)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// calendar_create_out_of_office tests
+// ============================================================================
+
+func TestCalendarCreateOutOfOffice(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		setupMock  func(*MockCalendarService)
+		wantErr    bool
+		errContain string
+		validate   func(t *testing.T, result string)
+	}{
+		{
+			name: "create OOO with defaults",
+			args: map[string]any{
+				"start_time": "2024-03-15T00:00:00Z",
+				"end_time":   "2024-03-16T00:00:00Z",
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["summary"] != "Out of office" {
+					t.Errorf("expected default summary 'Out of office', got %v", data["summary"])
+				}
+				if data["event_type"] != "outOfOffice" {
+					t.Errorf("expected event_type 'outOfOffice', got %v", data["event_type"])
+				}
+			},
+		},
+		{
+			name: "create OOO with custom summary and message",
+			args: map[string]any{
+				"summary":         "Vacation",
+				"start_time":      "2024-03-15T00:00:00Z",
+				"end_time":        "2024-03-22T00:00:00Z",
+				"decline_message": "On vacation, back March 22.",
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["summary"] != "Vacation" {
+					t.Errorf("expected summary 'Vacation', got %v", data["summary"])
+				}
+				if data["event_type"] != "outOfOffice" {
+					t.Errorf("expected event_type 'outOfOffice', got %v", data["event_type"])
+				}
+			},
+		},
+		{
+			name: "create all-day OOO",
+			args: map[string]any{
+				"start_time": "2024-03-15",
+				"end_time":   "2024-03-16",
+				"all_day":    true,
+			},
+			validate: func(t *testing.T, result string) {
+				var data map[string]any
+				if err := json.Unmarshal([]byte(result), &data); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if data["event_type"] != "outOfOffice" {
+					t.Errorf("expected event_type 'outOfOffice', got %v", data["event_type"])
+				}
+			},
+		},
+		{
+			name:       "missing start_time",
+			args:       map[string]any{},
+			wantErr:    true,
+			errContain: "start_time parameter is required",
+		},
+		{
+			name: "api error",
+			args: map[string]any{
+				"start_time": "2024-03-15T00:00:00Z",
+			},
+			setupMock: func(m *MockCalendarService) {
+				m.Error = errors.New("API error")
+			},
+			wantErr:    true,
+			errContain: "Calendar API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtures := NewCalendarTestFixtures()
+			if tt.setupMock != nil {
+				tt.setupMock(fixtures.MockService)
+			}
+
+			request := CreateMCPRequest(tt.args)
+			result, err := TestableCalendarCreateOutOfOffice(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			content := getCalendarTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got success")
+				}
+				if tt.errContain != "" && !strings.Contains(content, tt.errContain) {
+					t.Errorf("expected error containing %q, got %q", tt.errContain, content)
+				}
+				return
+			}
+
+			if result.IsError {
+				t.Errorf("unexpected error: %s", content)
+				return
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, content)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// boolToDeclineMode tests
+// ============================================================================
+
+func TestBoolToDeclineMode(t *testing.T) {
+	if got := boolToDeclineMode(true); got != "declineAllConflictingInvitations" {
+		t.Errorf("expected declineAllConflictingInvitations, got %s", got)
+	}
+	if got := boolToDeclineMode(false); got != "declineNone" {
+		t.Errorf("expected declineNone, got %s", got)
+	}
+}
+
+// ============================================================================
+// formatEvent with event_type tests
+// ============================================================================
+
+func TestFormatEventWithEventType(t *testing.T) {
+	t.Run("focusTime event includes event_type", func(t *testing.T) {
+		event := createTestEvent("ft1", "Focus Time", "", "2024-03-01T09:00:00-08:00", "2024-03-01T11:00:00-08:00", false)
+		event.EventType = "focusTime"
+		result := formatEvent(event)
+		if result["event_type"] != "focusTime" {
+			t.Errorf("expected event_type 'focusTime', got %v", result["event_type"])
+		}
+	})
+
+	t.Run("outOfOffice event includes event_type", func(t *testing.T) {
+		event := createTestEvent("ooo1", "Out of office", "", "2024-03-15T00:00:00Z", "2024-03-16T00:00:00Z", false)
+		event.EventType = "outOfOffice"
+		result := formatEvent(event)
+		if result["event_type"] != "outOfOffice" {
+			t.Errorf("expected event_type 'outOfOffice', got %v", result["event_type"])
+		}
+	})
+
+	t.Run("default event omits event_type", func(t *testing.T) {
+		event := createTestEvent("e1", "Meeting", "", "2024-03-01T10:00:00-08:00", "2024-03-01T11:00:00-08:00", false)
+		event.EventType = "default"
+		result := formatEvent(event)
+		if _, exists := result["event_type"]; exists {
+			t.Error("default event should not include event_type field")
+		}
+	})
+}
+
+// ============================================================================
+// formatEventFull with conference data tests
+// ============================================================================
+
+func TestFormatEventFullWithConferenceData(t *testing.T) {
+	t.Run("includes conference data entry points", func(t *testing.T) {
+		event := createTestEvent("conf1", "Meeting", "", "2024-03-01T10:00:00-08:00", "2024-03-01T11:00:00-08:00", false)
+		event.ConferenceData = &calendar.ConferenceData{
+			ConferenceId: "abc-defg-hij",
+			ConferenceSolution: &calendar.ConferenceSolution{
+				Name: "Google Meet",
+			},
+			EntryPoints: []*calendar.EntryPoint{
+				{
+					EntryPointType: "video",
+					Uri:            "https://meet.google.com/abc-defg-hij",
+					Label:          "meet.google.com/abc-defg-hij",
+				},
+				{
+					EntryPointType: "phone",
+					Uri:            "tel:+1-234-567-8901",
+				},
+			},
+		}
+
+		result := formatEventFull(event)
+
+		if result["video_link"] != "https://meet.google.com/abc-defg-hij" {
+			t.Errorf("expected video_link, got %v", result["video_link"])
+		}
+
+		confData, ok := result["conference_data"].(map[string]any)
+		if !ok {
+			t.Fatal("expected conference_data map")
+		}
+		if confData["solution"] != "Google Meet" {
+			t.Errorf("expected solution 'Google Meet', got %v", confData["solution"])
+		}
+		if confData["conference_id"] != "abc-defg-hij" {
+			t.Errorf("expected conference_id, got %v", confData["conference_id"])
+		}
+
+		entryPoints, ok := confData["entry_points"].([]map[string]any)
+		if !ok {
+			t.Fatal("expected entry_points array")
+		}
+		if len(entryPoints) != 2 {
+			t.Errorf("expected 2 entry points, got %d", len(entryPoints))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `calendar_create_focus_time` tool with auto-decline, chat status (doNotDisturb/available), custom decline messages, and recurring schedule support
- Add `calendar_create_out_of_office` tool with auto-decline, custom decline messages, all-day support, and recurring schedule support
- Add `event_types` filter to `calendar_list_events` for querying Focus Time, OOO, and working location events
- Enhance event formatting to include full conference data (entry points with URIs, solution name, conference ID) and event type in both compact and full views

## Test plan
- [x] All existing calendar tests pass (`go test ./internal/calendar/`)
- [x] New tests for `TestCalendarCreateFocusTime` (6 cases including defaults, custom summary, auto-decline disabled, recurrence, missing start_time, API error)
- [x] New tests for `TestCalendarCreateOutOfOffice` (5 cases including defaults, custom summary/message, all-day, missing start_time, API error)
- [x] New tests for `TestBoolToDeclineMode`, `TestFormatEventWithEventType`, `TestFormatEventFullWithConferenceData`
- [x] `go build ./cmd/gsuite-mcp/` succeeds
- [x] `go vet ./...` clean

Closes #67