### PR TITLE
feat(config): add configurable Drive access filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,25 @@ The default OAuth callback port is **8100**. Override it in `config.json`:
 
 Or via environment variable: `GSUITE_MCP_OAUTH_PORT=9000`
 
+### Drive Access Filtering
+
+Restrict which shared drives are accessible via MCP tools. Add `drive_access` to `config.json`:
+
+```json
+{
+  "oauth_port": 8100,
+  "drive_access": {
+    "allowed": ["Marketing", "Engineering"]
+  }
+}
+```
+
+**Modes** (choose one):
+- **Allowlist**: `"allowed": ["Drive A", "Drive B"]` — only these shared drives + My Drive
+- **Blocklist**: `"blocked": ["SENSITIVE", "HR"]` — everything except these drives
+
+My Drive is always accessible. Setting both `allowed` and `blocked` is an error. Drives can be specified by name (case-insensitive) or ID. The filter applies to Drive, Docs, and Sheets tools.
+
 ### HTTP Auth Endpoint (MCP Server Mode)
 
 When running as an MCP server, gsuite-mcp starts a persistent HTTP server on the OAuth port so agents and users can trigger re-authentication from a browser:

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 }
 
-// initializeApp sets up the auth manager and shared dependencies.
+// initializeApp sets up the auth manager, drive access filter, and shared dependencies.
 // No configuration required - uses dynamic credential discovery.
 func initializeApp() error {
 	authManager, err := auth.NewManager()
@@ -91,9 +91,30 @@ func initializeApp() error {
 		return err
 	}
 
+	// Load config for drive access filtering (optional)
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	driveFilter := common.NewDriveAccessFilter(cfg.DriveAccess)
+	if driveFilter != nil && driveFilter.IsActive() {
+		fmt.Fprintf(os.Stderr, "drive access filter active")
+		if cfg.DriveAccess != nil {
+			if len(cfg.DriveAccess.Allowed) > 0 {
+				fmt.Fprintf(os.Stderr, " (allowed: %v)", cfg.DriveAccess.Allowed)
+			}
+			if len(cfg.DriveAccess.Blocked) > 0 {
+				fmt.Fprintf(os.Stderr, " (blocked: %v)", cfg.DriveAccess.Blocked)
+			}
+		}
+		fmt.Fprintln(os.Stderr)
+	}
+
 	// Set up shared dependencies for all packages
 	common.SetDeps(&common.Deps{
-		AuthManager: authManager,
+		AuthManager:       authManager,
+		DriveAccessFilter: driveFilter,
 	})
 
 	return nil

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -59,10 +59,29 @@ gsuite-mcp/
 ```
 ~/.config/gsuite-mcp/
 ├── client_secret.json      # Google OAuth app credentials
-├── config.json             # Settings: oauth_port (optional — created by init)
+├── config.json             # Settings: oauth_port, drive_access (optional — created by init)
 └── credentials/
     └── {email}.json        # Per-account OAuth tokens
 ```
+
+### Drive Access Filtering
+
+The `drive_access` config restricts which shared drives are accessible:
+
+```json
+{
+  "drive_access": {
+    "allowed": ["Marketing"]
+  }
+}
+```
+
+- **Allowlist** (`allowed`): Only these shared drives + My Drive are accessible
+- **Blocklist** (`blocked`): Everything except these shared drives
+- Cannot set both — validation error at startup
+- Applies to Drive, Docs, and Sheets tools (all file-backed services)
+- Drive names are case-insensitive; drive IDs also accepted
+- Fails open on API errors (does not block if check cannot be performed)
 
 ## Key Rules
 

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -11,7 +11,8 @@ import (
 
 // Deps holds shared dependencies for all service handlers.
 type Deps struct {
-	AuthManager *auth.Manager
+	AuthManager       *auth.Manager
+	DriveAccessFilter *DriveAccessFilter
 }
 
 // Global instance set during initialization

--- a/internal/common/drive_access.go
+++ b/internal/common/drive_access.go
@@ -1,0 +1,235 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/aliwatters/gsuite-mcp/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+)
+
+// DriveInfo holds minimal shared drive metadata for name resolution.
+type DriveInfo struct {
+	ID   string
+	Name string
+}
+
+// DriveAccessFilter enforces allowlist/blocklist access control on shared drives.
+// It is safe for concurrent use.
+type DriveAccessFilter struct {
+	config     *config.DriveAccess
+	allowedIDs map[string]bool
+	blockedIDs map[string]bool
+	resolved   bool
+	mu         sync.RWMutex
+}
+
+// NewDriveAccessFilter creates a filter from configuration.
+// Returns nil if cfg is nil or has no restrictions.
+func NewDriveAccessFilter(cfg *config.DriveAccess) *DriveAccessFilter {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Allowed) == 0 && len(cfg.Blocked) == 0 {
+		return nil
+	}
+	return &DriveAccessFilter{config: cfg}
+}
+
+// IsActive returns true if the filter has any restrictions configured.
+func (f *DriveAccessFilter) IsActive() bool {
+	if f == nil || f.config == nil {
+		return false
+	}
+	return len(f.config.Allowed) > 0 || len(f.config.Blocked) > 0
+}
+
+// ResolveDriveNames maps configured drive names to IDs using the provided drive list.
+// Call once after listing shared drives. Safe to call multiple times (no-op after first).
+func (f *DriveAccessFilter) ResolveDriveNames(drives []DriveInfo) {
+	if f == nil {
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.resolved {
+		return
+	}
+
+	nameToID := make(map[string]string)
+	idSet := make(map[string]bool)
+	for _, d := range drives {
+		nameToID[strings.ToLower(d.Name)] = d.ID
+		idSet[d.ID] = true
+	}
+
+	resolve := func(names []string) map[string]bool {
+		ids := make(map[string]bool)
+		for _, name := range names {
+			lower := strings.ToLower(name)
+			if id, ok := nameToID[lower]; ok {
+				ids[id] = true
+			} else if idSet[name] {
+				// Config value is already an ID
+				ids[name] = true
+			}
+			// Unresolved names are silently ignored — may be drives
+			// the user doesn't have access to with this account.
+		}
+		return ids
+	}
+
+	if len(f.config.Allowed) > 0 {
+		f.allowedIDs = resolve(f.config.Allowed)
+	}
+	if len(f.config.Blocked) > 0 {
+		f.blockedIDs = resolve(f.config.Blocked)
+	}
+
+	f.resolved = true
+}
+
+// IsResolved returns true if drive names have been resolved to IDs.
+func (f *DriveAccessFilter) IsResolved() bool {
+	if f == nil {
+		return false
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.resolved
+}
+
+// Check returns an error if the given driveID is not permitted.
+// Empty driveID (My Drive) is always allowed.
+func (f *DriveAccessFilter) Check(driveID string) error {
+	if f == nil || !f.IsActive() {
+		return nil
+	}
+
+	// My Drive is always allowed
+	if driveID == "" {
+		return nil
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if !f.resolved {
+		// Names not yet resolved — fail open to avoid blocking
+		return nil
+	}
+
+	if f.allowedIDs != nil {
+		if !f.allowedIDs[driveID] {
+			return fmt.Errorf("access denied: file is in a shared drive not in the allowed list; check drive_access.allowed in config.json")
+		}
+		return nil
+	}
+
+	if f.blockedIDs != nil {
+		if f.blockedIDs[driveID] {
+			return fmt.Errorf("access denied: file is in a blocked shared drive; check drive_access.blocked in config.json")
+		}
+	}
+
+	return nil
+}
+
+// ensureResolved resolves drive names to IDs if not already done.
+func (f *DriveAccessFilter) ensureResolved(ctx context.Context, driveSrv *drive.Service) {
+	f.mu.RLock()
+	if f.resolved {
+		f.mu.RUnlock()
+		return
+	}
+	f.mu.RUnlock()
+
+	var allDrives []DriveInfo
+	pageToken := ""
+	for {
+		call := driveSrv.Drives.List().PageSize(100).Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		result, err := call.Do()
+		if err != nil {
+			return // fail open
+		}
+		for _, d := range result.Drives {
+			allDrives = append(allDrives, DriveInfo{ID: d.Id, Name: d.Name})
+		}
+		if result.NextPageToken == "" {
+			break
+		}
+		pageToken = result.NextPageToken
+	}
+
+	f.ResolveDriveNames(allDrives)
+}
+
+// CheckFileAccess checks whether a file is in an allowed drive using the Drive API.
+// Fails open on API errors (does not block if check cannot be performed).
+func (f *DriveAccessFilter) CheckFileAccess(ctx context.Context, client *http.Client, fileID string) error {
+	if f == nil || !f.IsActive() {
+		return nil
+	}
+
+	driveSrv, err := drive.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil // fail open
+	}
+
+	f.ensureResolved(ctx, driveSrv)
+
+	file, err := driveSrv.Files.Get(fileID).
+		Fields("driveId").
+		SupportsAllDrives(true).
+		Context(ctx).Do()
+	if err != nil {
+		return nil // fail open
+	}
+
+	return f.Check(file.DriveId)
+}
+
+// WithDriveAccessCheck wraps an MCP handler to check drive access before execution.
+// paramName is the request parameter containing the file/document/spreadsheet ID.
+// Use this to protect Docs, Sheets, and other services that access Drive files.
+func WithDriveAccessCheck(handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error), paramName string) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		d := GetDeps()
+		if d == nil || d.DriveAccessFilter == nil || !d.DriveAccessFilter.IsActive() {
+			return handler(ctx, request)
+		}
+
+		fileID := ParseStringArg(request.Params.Arguments, paramName, "")
+		if fileID == "" {
+			return handler(ctx, request)
+		}
+		fileID = ExtractGoogleResourceID(fileID)
+
+		email, err := ResolveAccountFromRequest(request)
+		if err != nil {
+			// Let the handler deal with auth errors
+			return handler(ctx, request)
+		}
+
+		client, err := d.AuthManager.GetClientOrAuthenticate(ctx, email, false)
+		if err != nil {
+			return handler(ctx, request)
+		}
+
+		if err := d.DriveAccessFilter.CheckFileAccess(ctx, client, fileID); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return handler(ctx, request)
+	}
+}

--- a/internal/common/drive_access_test.go
+++ b/internal/common/drive_access_test.go
@@ -1,0 +1,138 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/config"
+)
+
+func TestNewDriveAccessFilter_NilConfig(t *testing.T) {
+	f := NewDriveAccessFilter(nil)
+	if f != nil {
+		t.Fatal("expected nil filter for nil config")
+	}
+}
+
+func TestNewDriveAccessFilter_EmptyConfig(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{})
+	if f != nil {
+		t.Fatal("expected nil filter for empty config")
+	}
+}
+
+func TestDriveAccessFilter_IsActive(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *DriveAccessFilter
+		want   bool
+	}{
+		{"nil filter", nil, false},
+		{"allowed set", NewDriveAccessFilter(&config.DriveAccess{Allowed: []string{"Marketing"}}), true},
+		{"blocked set", NewDriveAccessFilter(&config.DriveAccess{Blocked: []string{"SENSITIVE"}}), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.filter.IsActive(); got != tt.want {
+				t.Errorf("IsActive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDriveAccessFilter_Check_Allowlist(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{Allowed: []string{"Marketing"}})
+	f.ResolveDriveNames([]DriveInfo{
+		{ID: "drive-marketing", Name: "Marketing"},
+		{ID: "drive-sensitive", Name: "SENSITIVE"},
+	})
+
+	tests := []struct {
+		name    string
+		driveID string
+		wantErr bool
+	}{
+		{"my drive always allowed", "", false},
+		{"allowed drive", "drive-marketing", false},
+		{"blocked drive", "drive-sensitive", true},
+		{"unknown drive", "drive-unknown", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.Check(tt.driveID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Check(%q) error = %v, wantErr %v", tt.driveID, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDriveAccessFilter_Check_Blocklist(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{Blocked: []string{"SENSITIVE", "HR"}})
+	f.ResolveDriveNames([]DriveInfo{
+		{ID: "drive-marketing", Name: "Marketing"},
+		{ID: "drive-sensitive", Name: "SENSITIVE"},
+		{ID: "drive-hr", Name: "HR"},
+	})
+
+	tests := []struct {
+		name    string
+		driveID string
+		wantErr bool
+	}{
+		{"my drive always allowed", "", false},
+		{"unblocked drive", "drive-marketing", false},
+		{"blocked drive sensitive", "drive-sensitive", true},
+		{"blocked drive hr", "drive-hr", true},
+		{"unknown drive allowed", "drive-unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := f.Check(tt.driveID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Check(%q) error = %v, wantErr %v", tt.driveID, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDriveAccessFilter_Check_CaseInsensitive(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{Allowed: []string{"marketing"}})
+	f.ResolveDriveNames([]DriveInfo{
+		{ID: "drive-marketing", Name: "Marketing"},
+	})
+
+	if err := f.Check("drive-marketing"); err != nil {
+		t.Errorf("lowercase config should match titlecase drive name: %v", err)
+	}
+}
+
+func TestDriveAccessFilter_Check_DirectID(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{Allowed: []string{"drive-direct-id"}})
+	f.ResolveDriveNames([]DriveInfo{
+		{ID: "drive-direct-id", Name: "Some Drive"},
+	})
+
+	if err := f.Check("drive-direct-id"); err != nil {
+		t.Errorf("direct ID in config should work: %v", err)
+	}
+}
+
+func TestDriveAccessFilter_Check_UnresolvedFailsOpen(t *testing.T) {
+	f := NewDriveAccessFilter(&config.DriveAccess{Blocked: []string{"SENSITIVE"}})
+	// Don't call ResolveDriveNames — should fail open
+
+	if err := f.Check("any-drive"); err != nil {
+		t.Errorf("unresolved filter should fail open: %v", err)
+	}
+}
+
+func TestDriveAccessFilter_NilSafe(t *testing.T) {
+	var f *DriveAccessFilter
+	f.ResolveDriveNames(nil)
+	if err := f.Check("any"); err != nil {
+		t.Errorf("nil filter should always allow: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,9 +13,26 @@ import (
 // DefaultOAuthPort is the default port used for the OAuth callback server.
 const DefaultOAuthPort = 8100
 
+// DriveAccess configures which shared drives are accessible via MCP tools.
+// Set either Allowed (allowlist) or Blocked (blocklist), not both.
+// My Drive is always accessible. If neither is set, all drives are accessible.
+type DriveAccess struct {
+	Allowed []string `json:"allowed,omitempty"` // Only these shared drives + My Drive
+	Blocked []string `json:"blocked,omitempty"` // Everything except these shared drives
+}
+
 // Config holds the application configuration loaded from config.json.
 type Config struct {
-	OAuthPort int `json:"oauth_port"`
+	OAuthPort   int          `json:"oauth_port"`
+	DriveAccess *DriveAccess `json:"drive_access,omitempty"`
+}
+
+// Validate checks the configuration for errors.
+func (c Config) Validate() error {
+	if c.DriveAccess != nil && len(c.DriveAccess.Allowed) > 0 && len(c.DriveAccess.Blocked) > 0 {
+		return fmt.Errorf("drive_access: cannot set both 'allowed' and 'blocked' — choose one mode")
+	}
+	return nil
 }
 
 // ConfigPath returns the path to config.json.
@@ -48,6 +65,10 @@ func loadConfigFromPath(path string) (Config, error) {
 
 	if fileCfg.OAuthPort == 0 {
 		fileCfg.OAuthPort = DefaultOAuthPort
+	}
+
+	if err := fileCfg.Validate(); err != nil {
+		return cfg, fmt.Errorf("invalid config: %w", err)
 	}
 
 	return fileCfg, nil

--- a/internal/config/config_validation_test.go
+++ b/internal/config/config_validation_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestConfig_Validate_BothAllowedAndBlocked(t *testing.T) {
+	cfg := Config{
+		DriveAccess: &DriveAccess{
+			Allowed: []string{"A"},
+			Blocked: []string{"B"},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when both allowed and blocked are set")
+	}
+}
+
+func TestConfig_Validate_AllowedOnly(t *testing.T) {
+	cfg := Config{
+		DriveAccess: &DriveAccess{
+			Allowed: []string{"Marketing"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_BlockedOnly(t *testing.T) {
+	cfg := Config{
+		DriveAccess: &DriveAccess{
+			Blocked: []string{"SENSITIVE"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_NoDriveAccess(t *testing.T) {
+	cfg := Config{}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfig_Validate_EmptyDriveAccess(t *testing.T) {
+	cfg := Config{DriveAccess: &DriveAccess{}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/docs/register.go
+++ b/internal/docs/register.go
@@ -22,14 +22,14 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithDescription("Get the full content of a Google Doc as plain text."),
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		common.WithAccountParam(),
-	), HandleDocsGet)
+	), common.WithDriveAccessCheck(HandleDocsGet, "document_id"))
 
 	// docs_get_metadata - Get document metadata
 	s.AddTool(mcp.NewTool("docs_get_metadata",
 		mcp.WithDescription("Get document metadata (title, revision, word count) without full content."),
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		common.WithAccountParam(),
-	), HandleDocsGetMetadata)
+	), common.WithDriveAccessCheck(HandleDocsGetMetadata, "document_id"))
 
 	// docs_append_text - Append text to document
 	s.AddTool(mcp.NewTool("docs_append_text",
@@ -37,7 +37,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		mcp.WithString("text", mcp.Required(), mcp.Description("Text to append to the document")),
 		common.WithAccountParam(),
-	), HandleDocsAppendText)
+	), common.WithDriveAccessCheck(HandleDocsAppendText, "document_id"))
 
 	// docs_insert_text - Insert text at specific location
 	s.AddTool(mcp.NewTool("docs_insert_text",
@@ -46,7 +46,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("text", mcp.Required(), mcp.Description("Text to insert")),
 		mcp.WithNumber("index", mcp.Required(), mcp.Description("1-based position in document where text will be inserted")),
 		common.WithAccountParam(),
-	), HandleDocsInsertText)
+	), common.WithDriveAccessCheck(HandleDocsInsertText, "document_id"))
 
 	// === Docs Extended (Phase 2) ===
 
@@ -58,7 +58,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("replace_text", mcp.Description("Text to replace with (empty to delete matches)")),
 		mcp.WithBoolean("match_case", mcp.Description("Case-sensitive matching (default: false)")),
 		common.WithAccountParam(),
-	), HandleDocsReplaceText)
+	), common.WithDriveAccessCheck(HandleDocsReplaceText, "document_id"))
 
 	// docs_delete_text - Delete text at specified range
 	s.AddTool(mcp.NewTool("docs_delete_text",
@@ -67,7 +67,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("start_index", mcp.Required(), mcp.Description("1-based start position (inclusive)")),
 		mcp.WithNumber("end_index", mcp.Required(), mcp.Description("1-based end position (exclusive)")),
 		common.WithAccountParam(),
-	), HandleDocsDeleteText)
+	), common.WithDriveAccessCheck(HandleDocsDeleteText, "document_id"))
 
 	// docs_insert_table - Insert a table at specified location
 	s.AddTool(mcp.NewTool("docs_insert_table",
@@ -77,7 +77,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("columns", mcp.Required(), mcp.Description("Number of columns")),
 		mcp.WithNumber("index", mcp.Description("1-based position for table insertion (default: 1, beginning of document)")),
 		common.WithAccountParam(),
-	), HandleDocsInsertTable)
+	), common.WithDriveAccessCheck(HandleDocsInsertTable, "document_id"))
 
 	// docs_insert_link - Insert a hyperlink
 	s.AddTool(mcp.NewTool("docs_insert_link",
@@ -87,7 +87,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("url", mcp.Required(), mcp.Description("URL to link to")),
 		mcp.WithNumber("index", mcp.Required(), mcp.Description("1-based position where link will be inserted")),
 		common.WithAccountParam(),
-	), HandleDocsInsertLink)
+	), common.WithDriveAccessCheck(HandleDocsInsertLink, "document_id"))
 
 	// docs_batch_update - Raw batchUpdate for power users
 	s.AddTool(mcp.NewTool("docs_batch_update",
@@ -95,7 +95,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		mcp.WithString("requests", mcp.Required(), mcp.Description("JSON array of batch update requests (see Google Docs API docs)")),
 		common.WithAccountParam(),
-	), HandleDocsBatchUpdate)
+	), common.WithDriveAccessCheck(HandleDocsBatchUpdate, "document_id"))
 
 	// === Docs Extended (Phase 3) - Advanced Formatting ===
 
@@ -117,7 +117,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("background_color", mcp.Description("Background/highlight color as hex")),
 		mcp.WithString("baseline_offset", mcp.Description("Vertical offset: NONE, SUPERSCRIPT, or SUBSCRIPT")),
 		common.WithAccountParam(),
-	), HandleDocsFormatText)
+	), common.WithDriveAccessCheck(HandleDocsFormatText, "document_id"))
 
 	// docs_clear_formatting - Remove text formatting
 	s.AddTool(mcp.NewTool("docs_clear_formatting",
@@ -126,7 +126,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("start_index", mcp.Required(), mcp.Description("1-based start position (inclusive)")),
 		mcp.WithNumber("end_index", mcp.Required(), mcp.Description("1-based end position (exclusive)")),
 		common.WithAccountParam(),
-	), HandleDocsClearFormatting)
+	), common.WithDriveAccessCheck(HandleDocsClearFormatting, "document_id"))
 
 	// docs_set_paragraph_style - Set paragraph formatting
 	s.AddTool(mcp.NewTool("docs_set_paragraph_style",
@@ -143,7 +143,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("space_above", mcp.Description("Space above paragraph in points")),
 		mcp.WithNumber("space_below", mcp.Description("Space below paragraph in points")),
 		common.WithAccountParam(),
-	), HandleDocsSetParagraphStyle)
+	), common.WithDriveAccessCheck(HandleDocsSetParagraphStyle, "document_id"))
 
 	// docs_create_list - Create bulleted or numbered list
 	s.AddTool(mcp.NewTool("docs_create_list",
@@ -153,7 +153,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("end_index", mcp.Required(), mcp.Description("1-based end position (exclusive)")),
 		mcp.WithString("bullet_preset", mcp.Description("Bullet preset (default: BULLET_DISC_CIRCLE_SQUARE). Use NUMBERED_DECIMAL_ALPHA_ROMAN for numbered lists.")),
 		common.WithAccountParam(),
-	), HandleDocsCreateList)
+	), common.WithDriveAccessCheck(HandleDocsCreateList, "document_id"))
 
 	// docs_remove_list - Remove list formatting
 	s.AddTool(mcp.NewTool("docs_remove_list",
@@ -162,7 +162,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("start_index", mcp.Required(), mcp.Description("1-based start position (inclusive)")),
 		mcp.WithNumber("end_index", mcp.Required(), mcp.Description("1-based end position (exclusive)")),
 		common.WithAccountParam(),
-	), HandleDocsRemoveList)
+	), common.WithDriveAccessCheck(HandleDocsRemoveList, "document_id"))
 
 	// docs_insert_page_break - Insert page break
 	s.AddTool(mcp.NewTool("docs_insert_page_break",
@@ -170,7 +170,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		mcp.WithNumber("index", mcp.Required(), mcp.Description("1-based position in document")),
 		common.WithAccountParam(),
-	), HandleDocsInsertPageBreak)
+	), common.WithDriveAccessCheck(HandleDocsInsertPageBreak, "document_id"))
 
 	// docs_insert_image - Insert inline image from URL
 	s.AddTool(mcp.NewTool("docs_insert_image",
@@ -181,7 +181,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("width", mcp.Description("Image width in points (aspect ratio preserved if only one dimension set)")),
 		mcp.WithNumber("height", mcp.Description("Image height in points")),
 		common.WithAccountParam(),
-	), HandleDocsInsertImage)
+	), common.WithDriveAccessCheck(HandleDocsInsertImage, "document_id"))
 
 	// docs_create_header - Create document header
 	s.AddTool(mcp.NewTool("docs_create_header",
@@ -189,7 +189,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		mcp.WithString("content", mcp.Description("Optional text content for the header")),
 		common.WithAccountParam(),
-	), HandleDocsCreateHeader)
+	), common.WithDriveAccessCheck(HandleDocsCreateHeader, "document_id"))
 
 	// docs_create_footer - Create document footer
 	s.AddTool(mcp.NewTool("docs_create_footer",
@@ -197,7 +197,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		mcp.WithString("content", mcp.Description("Optional text content for the footer")),
 		common.WithAccountParam(),
-	), HandleDocsCreateFooter)
+	), common.WithDriveAccessCheck(HandleDocsCreateFooter, "document_id"))
 
 	// === Docs Enhanced (Phase 4) ===
 
@@ -206,7 +206,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithDescription("Get document content as clean markdown. Converts headings, bold, italic, links, lists, and tables to markdown format. Ideal for AI consumption."),
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs URL")),
 		common.WithAccountParam(),
-	), HandleDocsGetAsMarkdown)
+	), common.WithDriveAccessCheck(HandleDocsGetAsMarkdown, "document_id"))
 
 	// docs_find_and_replace - Find and replace with case sensitivity control
 	s.AddTool(mcp.NewTool("docs_find_and_replace",
@@ -216,14 +216,14 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("replace_text", mcp.Description("Text to replace with (empty to delete matches)")),
 		mcp.WithBoolean("match_case", mcp.Description("Case-sensitive matching (default: true)")),
 		common.WithAccountParam(),
-	), HandleDocsFindAndReplace)
+	), common.WithDriveAccessCheck(HandleDocsFindAndReplace, "document_id"))
 
 	// docs_export_to_pdf - Export document to PDF
 	s.AddTool(mcp.NewTool("docs_export_to_pdf",
 		mcp.WithDescription("Export a Google Doc, Sheet, or Slides presentation to PDF. Returns base64-encoded PDF content."),
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("Document ID or full Google Docs/Sheets/Slides URL")),
 		common.WithAccountParam(),
-	), HandleDocsExportToPDF)
+	), common.WithDriveAccessCheck(HandleDocsExportToPDF, "document_id"))
 
 	// docs_import_to_google_doc - Import file as Google Doc
 	s.AddTool(mcp.NewTool("docs_import_to_google_doc",

--- a/internal/drive/drive_handlers.go
+++ b/internal/drive/drive_handlers.go
@@ -14,12 +14,20 @@ import (
 type DriveHandlerDeps = common.HandlerDeps[DriveService]
 
 // NewDriveService creates a DriveService from an authenticated HTTP client.
+// If a DriveAccessFilter is configured, the service is wrapped with access control.
 func NewDriveService(ctx context.Context, client *http.Client) (DriveService, error) {
 	srv, err := drive.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
-	return NewRealDriveService(srv), nil
+	real := NewRealDriveService(srv)
+
+	d := common.GetDeps()
+	if d != nil && d.DriveAccessFilter != nil && d.DriveAccessFilter.IsActive() {
+		return NewFilteredDriveService(real, d.DriveAccessFilter), nil
+	}
+
+	return real, nil
 }
 
 // DefaultDriveHandlerDeps holds the default dependencies for production use.

--- a/internal/drive/drive_service.go
+++ b/internal/drive/drive_service.go
@@ -24,6 +24,7 @@ type DriveService interface {
 
 	// Drives
 	GetDrive(ctx context.Context, driveID string) (*drive.Drive, error)
+	ListDrives(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error)
 
 	// Permissions
 	ListPermissions(ctx context.Context, fileID string) (*drive.PermissionList, error)
@@ -168,6 +169,15 @@ func (s *RealDriveService) ExportFile(ctx context.Context, fileID string, mimeTy
 // GetDrive gets a shared drive by ID.
 func (s *RealDriveService) GetDrive(ctx context.Context, driveID string) (*drive.Drive, error) {
 	return s.service.Drives.Get(driveID).Context(ctx).Fields("id,name").Do()
+}
+
+// ListDrives lists shared drives accessible to the user.
+func (s *RealDriveService) ListDrives(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+	call := s.service.Drives.List().Context(ctx).PageSize(pageSize)
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	return call.Do()
 }
 
 // ListPermissions lists a file's permissions.

--- a/internal/drive/drive_service_mock.go
+++ b/internal/drive/drive_service_mock.go
@@ -21,7 +21,8 @@ type MockDriveService struct {
 	ExportFileFunc   func(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error)
 
 	// Drives
-	GetDriveFunc func(ctx context.Context, driveID string) (*drive.Drive, error)
+	GetDriveFunc   func(ctx context.Context, driveID string) (*drive.Drive, error)
+	ListDrivesFunc func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error)
 
 	// Permissions
 	ListPermissionsFunc  func(ctx context.Context, fileID string) (*drive.PermissionList, error)
@@ -117,6 +118,13 @@ func (m *MockDriveService) GetDrive(ctx context.Context, driveID string) (*drive
 		return m.GetDriveFunc(ctx, driveID)
 	}
 	return &drive.Drive{}, nil
+}
+
+func (m *MockDriveService) ListDrives(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+	if m.ListDrivesFunc != nil {
+		return m.ListDrivesFunc(ctx, pageSize, pageToken)
+	}
+	return &drive.DriveList{}, nil
 }
 
 // Permission methods

--- a/internal/drive/filtered_service.go
+++ b/internal/drive/filtered_service.go
@@ -1,0 +1,292 @@
+package drive
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"google.golang.org/api/drive/v3"
+)
+
+// FilteredDriveService wraps a DriveService and enforces drive access restrictions.
+// Files in restricted drives are filtered from list results and blocked from direct access.
+type FilteredDriveService struct {
+	inner  DriveService
+	filter *common.DriveAccessFilter
+}
+
+// NewFilteredDriveService creates a filtered service wrapping the given inner service.
+func NewFilteredDriveService(inner DriveService, filter *common.DriveAccessFilter) *FilteredDriveService {
+	return &FilteredDriveService{inner: inner, filter: filter}
+}
+
+// ensureResolved resolves drive names to IDs using the inner service's ListDrives.
+func (f *FilteredDriveService) ensureResolved(ctx context.Context) {
+	if f.filter.IsResolved() {
+		return
+	}
+
+	var allDrives []common.DriveInfo
+	pageToken := ""
+	for {
+		result, err := f.inner.ListDrives(ctx, 100, pageToken)
+		if err != nil {
+			return // fail open
+		}
+		for _, d := range result.Drives {
+			allDrives = append(allDrives, common.DriveInfo{ID: d.Id, Name: d.Name})
+		}
+		if result.NextPageToken == "" {
+			break
+		}
+		pageToken = result.NextPageToken
+	}
+	f.filter.ResolveDriveNames(allDrives)
+}
+
+// checkFileAccess verifies that the file is in an allowed drive.
+func (f *FilteredDriveService) checkFileAccess(ctx context.Context, fileID string) error {
+	f.ensureResolved(ctx)
+	file, err := f.inner.GetFile(ctx, fileID, "driveId")
+	if err != nil {
+		return nil // fail open
+	}
+	return f.filter.Check(file.DriveId)
+}
+
+// ensureDriveIDField ensures driveId is included in the requested fields.
+func ensureDriveIDField(fields string) string {
+	if fields == "" {
+		return "driveId"
+	}
+	if strings.Contains(fields, "driveId") {
+		return fields
+	}
+	return fields + ",driveId"
+}
+
+// === File Operations ===
+
+// ListFiles returns results filtered to only include files from allowed drives.
+func (f *FilteredDriveService) ListFiles(ctx context.Context, opts *ListFilesOptions) (*drive.FileList, error) {
+	f.ensureResolved(ctx)
+
+	// Copy opts to avoid mutating the caller's struct when injecting driveId field
+	innerOpts := opts
+	if opts != nil && opts.Fields != "" {
+		cp := *opts
+		cp.Fields = ensureDriveIDField(opts.Fields)
+		innerOpts = &cp
+	}
+
+	result, err := f.inner.ListFiles(ctx, innerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter files by drive access
+	filtered := make([]*drive.File, 0, len(result.Files))
+	for _, file := range result.Files {
+		if f.filter.Check(file.DriveId) == nil {
+			filtered = append(filtered, file)
+		}
+	}
+	result.Files = filtered
+
+	return result, nil
+}
+
+// GetFile checks drive access after retrieving file metadata.
+func (f *FilteredDriveService) GetFile(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+	f.ensureResolved(ctx)
+	file, err := f.inner.GetFile(ctx, fileID, ensureDriveIDField(fields))
+	if err != nil {
+		return nil, err
+	}
+	if err := f.filter.Check(file.DriveId); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+// CreateFile checks the destination parent's drive before creating.
+func (f *FilteredDriveService) CreateFile(ctx context.Context, file *drive.File, content io.Reader) (*drive.File, error) {
+	if len(file.Parents) > 0 {
+		if err := f.checkFileAccess(ctx, file.Parents[0]); err != nil {
+			return nil, err
+		}
+	}
+	return f.inner.CreateFile(ctx, file, content)
+}
+
+// UpdateFile checks drive access before updating.
+func (f *FilteredDriveService) UpdateFile(ctx context.Context, fileID string, file *drive.File) (*drive.File, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.UpdateFile(ctx, fileID, file)
+}
+
+// MoveFile checks both source file and destination drive.
+func (f *FilteredDriveService) MoveFile(ctx context.Context, fileID string, newParentID string, previousParents string) (*drive.File, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	if err := f.checkFileAccess(ctx, newParentID); err != nil {
+		return nil, err
+	}
+	return f.inner.MoveFile(ctx, fileID, newParentID, previousParents)
+}
+
+// CopyFile checks the source file's drive before copying.
+func (f *FilteredDriveService) CopyFile(ctx context.Context, fileID string, file *drive.File) (*drive.File, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	if len(file.Parents) > 0 {
+		if err := f.checkFileAccess(ctx, file.Parents[0]); err != nil {
+			return nil, err
+		}
+	}
+	return f.inner.CopyFile(ctx, fileID, file)
+}
+
+// DeleteFile checks drive access before deleting.
+func (f *FilteredDriveService) DeleteFile(ctx context.Context, fileID string) error {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return err
+	}
+	return f.inner.DeleteFile(ctx, fileID)
+}
+
+// DownloadFile checks drive access before downloading.
+func (f *FilteredDriveService) DownloadFile(ctx context.Context, fileID string) (io.ReadCloser, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.DownloadFile(ctx, fileID)
+}
+
+// ExportFile checks drive access before exporting.
+func (f *FilteredDriveService) ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.ExportFile(ctx, fileID, mimeType)
+}
+
+// === Drives ===
+
+// GetDrive checks if the requested drive is accessible.
+func (f *FilteredDriveService) GetDrive(ctx context.Context, driveID string) (*drive.Drive, error) {
+	f.ensureResolved(ctx)
+	if err := f.filter.Check(driveID); err != nil {
+		return nil, err
+	}
+	return f.inner.GetDrive(ctx, driveID)
+}
+
+// ListDrives passes through to inner service (needed for name resolution).
+func (f *FilteredDriveService) ListDrives(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+	return f.inner.ListDrives(ctx, pageSize, pageToken)
+}
+
+// === Permissions ===
+
+func (f *FilteredDriveService) ListPermissions(ctx context.Context, fileID string) (*drive.PermissionList, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.ListPermissions(ctx, fileID)
+}
+
+func (f *FilteredDriveService) CreatePermission(ctx context.Context, fileID string, permission *drive.Permission, sendNotification bool) (*drive.Permission, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.CreatePermission(ctx, fileID, permission, sendNotification)
+}
+
+func (f *FilteredDriveService) DeletePermission(ctx context.Context, fileID string, permissionID string) error {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return err
+	}
+	return f.inner.DeletePermission(ctx, fileID, permissionID)
+}
+
+// === Comments ===
+
+func (f *FilteredDriveService) ListComments(ctx context.Context, fileID string, fields string, pageSize int64, pageToken string, includeDeleted bool) (*drive.CommentList, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.ListComments(ctx, fileID, fields, pageSize, pageToken, includeDeleted)
+}
+
+func (f *FilteredDriveService) GetComment(ctx context.Context, fileID string, commentID string, fields string, includeDeleted bool) (*drive.Comment, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.GetComment(ctx, fileID, commentID, fields, includeDeleted)
+}
+
+func (f *FilteredDriveService) CreateComment(ctx context.Context, fileID string, comment *drive.Comment, fields string) (*drive.Comment, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.CreateComment(ctx, fileID, comment, fields)
+}
+
+func (f *FilteredDriveService) UpdateComment(ctx context.Context, fileID string, commentID string, comment *drive.Comment, fields string) (*drive.Comment, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.UpdateComment(ctx, fileID, commentID, comment, fields)
+}
+
+func (f *FilteredDriveService) DeleteComment(ctx context.Context, fileID string, commentID string) error {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return err
+	}
+	return f.inner.DeleteComment(ctx, fileID, commentID)
+}
+
+// === Replies ===
+
+func (f *FilteredDriveService) ListReplies(ctx context.Context, fileID string, commentID string, fields string, pageSize int64, pageToken string, includeDeleted bool) (*drive.ReplyList, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.ListReplies(ctx, fileID, commentID, fields, pageSize, pageToken, includeDeleted)
+}
+
+func (f *FilteredDriveService) CreateReply(ctx context.Context, fileID string, commentID string, reply *drive.Reply, fields string) (*drive.Reply, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.CreateReply(ctx, fileID, commentID, reply, fields)
+}
+
+// === Revisions ===
+
+func (f *FilteredDriveService) ListRevisions(ctx context.Context, fileID string, fields string, pageSize int64, pageToken string) (*drive.RevisionList, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.ListRevisions(ctx, fileID, fields, pageSize, pageToken)
+}
+
+func (f *FilteredDriveService) GetRevision(ctx context.Context, fileID string, revisionID string, fields string) (*drive.Revision, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.GetRevision(ctx, fileID, revisionID, fields)
+}
+
+func (f *FilteredDriveService) DownloadRevision(ctx context.Context, fileID string, revisionID string) (io.ReadCloser, error) {
+	if err := f.checkFileAccess(ctx, fileID); err != nil {
+		return nil, err
+	}
+	return f.inner.DownloadRevision(ctx, fileID, revisionID)
+}

--- a/internal/drive/filtered_service_test.go
+++ b/internal/drive/filtered_service_test.go
@@ -1,0 +1,178 @@
+package drive
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/aliwatters/gsuite-mcp/internal/config"
+	"google.golang.org/api/drive/v3"
+)
+
+func newTestFilter(allowed, blocked []string) *common.DriveAccessFilter {
+	f := common.NewDriveAccessFilter(&config.DriveAccess{
+		Allowed: allowed,
+		Blocked: blocked,
+	})
+	f.ResolveDriveNames([]common.DriveInfo{
+		{ID: "drive-marketing", Name: "Marketing"},
+		{ID: "drive-sensitive", Name: "SENSITIVE"},
+		{ID: "drive-hr", Name: "HR"},
+	})
+	return f
+}
+
+func TestFilteredDriveService_ListFiles_Allowlist(t *testing.T) {
+	filter := newTestFilter([]string{"Marketing"}, nil)
+	mock := &MockDriveService{
+		ListFilesFunc: func(ctx context.Context, opts *ListFilesOptions) (*drive.FileList, error) {
+			return &drive.FileList{
+				Files: []*drive.File{
+					{Id: "1", Name: "allowed.doc", DriveId: "drive-marketing"},
+					{Id: "2", Name: "blocked.doc", DriveId: "drive-sensitive"},
+					{Id: "3", Name: "mydrive.doc", DriveId: ""},
+				},
+			}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	result, err := srv.ListFiles(context.Background(), &ListFilesOptions{Fields: "files(id,name)"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(result.Files))
+	}
+	if result.Files[0].Id != "1" {
+		t.Errorf("expected first file id=1, got %s", result.Files[0].Id)
+	}
+	if result.Files[1].Id != "3" {
+		t.Errorf("expected second file id=3, got %s", result.Files[1].Id)
+	}
+}
+
+func TestFilteredDriveService_GetFile_Blocked(t *testing.T) {
+	filter := newTestFilter([]string{"Marketing"}, nil)
+	mock := &MockDriveService{
+		GetFileFunc: func(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+			return &drive.File{Id: fileID, DriveId: "drive-sensitive"}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	_, err := srv.GetFile(context.Background(), "file1", "id,name")
+	if err == nil {
+		t.Fatal("expected error for file in blocked drive")
+	}
+}
+
+func TestFilteredDriveService_GetFile_Allowed(t *testing.T) {
+	filter := newTestFilter([]string{"Marketing"}, nil)
+	mock := &MockDriveService{
+		GetFileFunc: func(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+			return &drive.File{Id: fileID, DriveId: "drive-marketing"}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	file, err := srv.GetFile(context.Background(), "file1", "id,name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if file.Id != "file1" {
+		t.Errorf("expected file1, got %s", file.Id)
+	}
+}
+
+func TestFilteredDriveService_DeleteFile_Blocked(t *testing.T) {
+	filter := newTestFilter(nil, []string{"SENSITIVE"})
+	mock := &MockDriveService{
+		GetFileFunc: func(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+			return &drive.File{Id: fileID, DriveId: "drive-sensitive"}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+		DeleteFileFunc: func(ctx context.Context, fileID string) error {
+			t.Fatal("DeleteFile should not be called for blocked file")
+			return nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	err := srv.DeleteFile(context.Background(), "file-in-sensitive")
+	if err == nil {
+		t.Fatal("expected error for file in blocked drive")
+	}
+}
+
+func TestFilteredDriveService_DownloadFile_MyDrive(t *testing.T) {
+	filter := newTestFilter([]string{"Marketing"}, nil)
+	mock := &MockDriveService{
+		GetFileFunc: func(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+			return &drive.File{Id: fileID, DriveId: ""}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+		DownloadFileFunc: func(ctx context.Context, fileID string) (io.ReadCloser, error) {
+			return nil, io.ErrUnexpectedEOF
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	// My Drive files should pass the access check
+	_, err := srv.DownloadFile(context.Background(), "my-file")
+	// The error should come from the download (not access denied)
+	if err == nil || err != io.ErrUnexpectedEOF {
+		t.Fatalf("expected download to proceed for My Drive file, got: %v", err)
+	}
+}
+
+func TestFilteredDriveService_GetDrive_Blocked(t *testing.T) {
+	filter := newTestFilter(nil, []string{"SENSITIVE"})
+	mock := &MockDriveService{
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	_, err := srv.GetDrive(context.Background(), "drive-sensitive")
+	if err == nil {
+		t.Fatal("expected error for blocked drive")
+	}
+}
+
+func TestFilteredDriveService_MoveFile_BlockedDestination(t *testing.T) {
+	filter := newTestFilter(nil, []string{"SENSITIVE"})
+	mock := &MockDriveService{
+		GetFileFunc: func(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+			if fileID == "src-file" {
+				return &drive.File{Id: fileID, DriveId: ""}, nil
+			}
+			return &drive.File{Id: fileID, DriveId: "drive-sensitive"}, nil
+		},
+		ListDrivesFunc: func(ctx context.Context, pageSize int64, pageToken string) (*drive.DriveList, error) {
+			return &drive.DriveList{}, nil
+		},
+	}
+
+	srv := NewFilteredDriveService(mock, filter)
+	_, err := srv.MoveFile(context.Background(), "src-file", "dest-in-sensitive", "old-parent")
+	if err == nil {
+		t.Fatal("expected error when moving to blocked drive")
+	}
+}

--- a/internal/sheets/register.go
+++ b/internal/sheets/register.go
@@ -15,7 +15,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithDescription("Get spreadsheet metadata including title, sheets list, and properties."),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		common.WithAccountParam(),
-	), HandleSheetsGet)
+	), common.WithDriveAccessCheck(HandleSheetsGet, "spreadsheet_id"))
 
 	// sheets_read - Read cell values from range
 	s.AddTool(mcp.NewTool("sheets_read",
@@ -23,7 +23,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range (e.g., 'Sheet1!A1:C10', 'A1:B5')")),
 		common.WithAccountParam(),
-	), HandleSheetsRead)
+	), common.WithDriveAccessCheck(HandleSheetsRead, "spreadsheet_id"))
 
 	// sheets_write - Write values to cell range
 	s.AddTool(mcp.NewTool("sheets_write",
@@ -33,7 +33,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithArray("values", mcp.Required(), mcp.Description("2D array of values (rows of cells)")),
 		mcp.WithString("value_input_option", mcp.Description("How to interpret input: RAW (as-is) or USER_ENTERED (parse formulas, default)")),
 		common.WithAccountParam(),
-	), HandleSheetsWrite)
+	), common.WithDriveAccessCheck(HandleSheetsWrite, "spreadsheet_id"))
 
 	// sheets_append - Append rows to sheet
 	s.AddTool(mcp.NewTool("sheets_append",
@@ -43,7 +43,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithArray("values", mcp.Required(), mcp.Description("2D array of values (rows to append)")),
 		mcp.WithString("value_input_option", mcp.Description("How to interpret input: RAW or USER_ENTERED (default)")),
 		common.WithAccountParam(),
-	), HandleSheetsAppend)
+	), common.WithDriveAccessCheck(HandleSheetsAppend, "spreadsheet_id"))
 
 	// === Sheets Extended (Phase 2) ===
 
@@ -60,7 +60,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		mcp.WithArray("ranges", mcp.Required(), mcp.Description("Array of A1 notation ranges to read")),
 		common.WithAccountParam(),
-	), HandleSheetsBatchRead)
+	), common.WithDriveAccessCheck(HandleSheetsBatchRead, "spreadsheet_id"))
 
 	// sheets_batch_write - Write to multiple ranges at once
 	s.AddTool(mcp.NewTool("sheets_batch_write",
@@ -69,7 +69,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithArray("data", mcp.Required(), mcp.Description("Array of {range, values} objects")),
 		mcp.WithString("value_input_option", mcp.Description("How to interpret input: RAW or USER_ENTERED (default)")),
 		common.WithAccountParam(),
-	), HandleSheetsBatchWrite)
+	), common.WithDriveAccessCheck(HandleSheetsBatchWrite, "spreadsheet_id"))
 
 	// sheets_clear - Clear cell range
 	s.AddTool(mcp.NewTool("sheets_clear",
@@ -77,7 +77,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range to clear (e.g., 'Sheet1!A1:C10')")),
 		common.WithAccountParam(),
-	), HandleSheetsClear)
+	), common.WithDriveAccessCheck(HandleSheetsClear, "spreadsheet_id"))
 
 	// === Sheets Formatting (Phase 3) ===
 
@@ -104,7 +104,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("vertical_alignment", mcp.Description("Vertical alignment: TOP, MIDDLE, BOTTOM")),
 		mcp.WithString("wrap_strategy", mcp.Description("Text wrap: OVERFLOW_CELL, LEGACY_WRAP, CLIP, WRAP")),
 		common.WithAccountParam(),
-	), HandleSheetsFormatCells)
+	), common.WithDriveAccessCheck(HandleSheetsFormatCells, "spreadsheet_id"))
 
 	// sheets_add_conditional_format - Add conditional formatting rule
 	s.AddTool(mcp.NewTool("sheets_add_conditional_format",
@@ -134,7 +134,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("max_type", mcp.Description("Gradient max type: MAX, NUMBER, PERCENT, PERCENTILE")),
 		mcp.WithString("max_value", mcp.Description("Gradient max value")),
 		common.WithAccountParam(),
-	), HandleSheetsAddConditionalFormat)
+	), common.WithDriveAccessCheck(HandleSheetsAddConditionalFormat, "spreadsheet_id"))
 
 	// sheets_add_data_validation - Add data validation rules
 	s.AddTool(mcp.NewTool("sheets_add_data_validation",
@@ -151,7 +151,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithBoolean("show_dropdown", mcp.Description("Show dropdown UI for list validations (default: true)")),
 		mcp.WithString("input_message", mcp.Description("Help text shown when cell is selected")),
 		common.WithAccountParam(),
-	), HandleSheetsAddDataValidation)
+	), common.WithDriveAccessCheck(HandleSheetsAddDataValidation, "spreadsheet_id"))
 
 	// === Sheets Charts & Pivot Tables (Phase 3) ===
 
@@ -170,7 +170,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithNumber("anchor_row", mcp.Description("Row index for chart placement (default: 0)")),
 		mcp.WithNumber("anchor_col", mcp.Description("Column index for chart placement (default: 0)")),
 		common.WithAccountParam(),
-	), HandleSheetsCreateChart)
+	), common.WithDriveAccessCheck(HandleSheetsCreateChart, "spreadsheet_id"))
 
 	// sheets_update_chart - Update existing chart
 	s.AddTool(mcp.NewTool("sheets_update_chart",
@@ -180,7 +180,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("title", mcp.Description("New chart title")),
 		mcp.WithString("chart_type", mcp.Description("New chart type: BAR, LINE, AREA, COLUMN, SCATTER, COMBO, STEPPED_AREA, PIE")),
 		common.WithAccountParam(),
-	), HandleSheetsUpdateChart)
+	), common.WithDriveAccessCheck(HandleSheetsUpdateChart, "spreadsheet_id"))
 
 	// sheets_delete_chart - Delete embedded chart
 	s.AddTool(mcp.NewTool("sheets_delete_chart",
@@ -188,7 +188,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		mcp.WithNumber("chart_id", mcp.Required(), mcp.Description("Chart ID to delete")),
 		common.WithAccountParam(),
-	), HandleSheetsDeleteChart)
+	), common.WithDriveAccessCheck(HandleSheetsDeleteChart, "spreadsheet_id"))
 
 	// sheets_create_pivot_table - Create pivot table
 	s.AddTool(mcp.NewTool("sheets_create_pivot_table",
@@ -206,7 +206,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithArray("col_source_columns", mcp.Description("Array of column offsets (0-based) for column grouping")),
 		mcp.WithArray("value_columns", mcp.Description("Array of {column, summarize_function} objects. summarize_function: SUM, COUNTA, COUNT, AVERAGE, MAX, MIN, CUSTOM")),
 		common.WithAccountParam(),
-	), HandleSheetsCreatePivotTable)
+	), common.WithDriveAccessCheck(HandleSheetsCreatePivotTable, "spreadsheet_id"))
 
 	// sheets_batch_update - Raw batchUpdate for power users
 	s.AddTool(mcp.NewTool("sheets_batch_update",
@@ -214,5 +214,5 @@ func RegisterTools(s *server.MCPServer) {
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("Spreadsheet ID or full Google Sheets URL")),
 		mcp.WithString("requests", mcp.Required(), mcp.Description("JSON array of batch update requests (see Google Sheets API docs)")),
 		common.WithAccountParam(),
-	), HandleSheetsBatchUpdateSpreadsheet)
+	), common.WithDriveAccessCheck(HandleSheetsBatchUpdateSpreadsheet, "spreadsheet_id"))
 }


### PR DESCRIPTION
## Summary

- Add `drive_access` config to restrict which shared drives are accessible via MCP tools (allowlist or blocklist mode)
- `FilteredDriveService` wraps all 24 `DriveService` methods with access checks at the Drive layer
- `WithDriveAccessCheck` middleware protects Docs (21 tools) and Sheets (15 tools) without modifying their service interfaces
- Lazy drive name resolution (names → IDs on first use), case-insensitive matching, My Drive always allowed, fail-open on API errors

## Config example

```json
{
  "drive_access": {
    "allowed": ["Marketing", "Engineering"]
  }
}
```

## Test plan

- [x] `go build ./cmd/gsuite-mcp/` — builds clean
- [x] `go test ./...` — all tests pass (new tests for filter logic, config validation, filtered service)
- [x] `go vet ./...` — clean
- [ ] Manual: configure `drive_access.allowed` in config.json, verify blocked drive files are rejected
- [ ] Manual: verify Docs/Sheets tools reject files in blocked drives

Closes #75