### PR TITLE
feat(forms): add Google Forms API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Complete Google Workspace MCP server — Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, and Contacts. Single Go binary with true multi-account support.
+Complete Google Workspace MCP server — Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, and Contacts. Single Go binary with true multi-account support.
 
 ## Quick Start
 
@@ -23,7 +23,7 @@ gsuite-mcp auth personal
 ## Why gsuite-mcp?
 
 - **Multi-account**: Switch accounts per-operation with `"account": "work"`
-- **Complete coverage**: Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Contacts
+- **Complete coverage**: Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, Contacts
 - **Single binary**: No Python, no Node, no runtime dependencies
 - **MCP native**: JSON Schema 2020-12, proper tool descriptions
 
@@ -62,6 +62,9 @@ Spreadsheet operations: read, write, append, batch operations, create, cell form
 
 ### Slides (5 tools)
 Presentation operations: get presentation metadata and structure, get individual slide details, slide thumbnails, create presentations, batch update (add/modify/delete slides, text, shapes, images).
+
+### Forms (5 tools)
+Form management: get form structure and questions, create forms, batch update (add/update/delete questions, settings), list responses, get individual responses.
 
 ### Contacts (12 tools)
 Contact management: list, search, create, update, delete, contact groups.
@@ -234,6 +237,15 @@ Contact management: list, search, create, update, delete, contact groups.
 | `slides_get_thumbnail` | Get slide thumbnail image URL |
 | `slides_create` | Create new presentation |
 | `slides_batch_update` | Batch update (add/modify/delete slides, text, shapes, images) |
+
+#### Forms
+| Tool | Description |
+|------|-------------|
+| `forms_get` | Get form metadata, questions, and structure |
+| `forms_create` | Create new form |
+| `forms_batch_update` | Batch update (add/update/delete questions, settings) |
+| `forms_list_responses` | List all form responses |
+| `forms_get_response` | Get a single form response |
 
 </details>
 

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aliwatters/gsuite-mcp/internal/contacts"
 	"github.com/aliwatters/gsuite-mcp/internal/docs"
 	"github.com/aliwatters/gsuite-mcp/internal/drive"
+	"github.com/aliwatters/gsuite-mcp/internal/forms"
 	"github.com/aliwatters/gsuite-mcp/internal/gmail"
 	"github.com/aliwatters/gsuite-mcp/internal/sheets"
 	"github.com/aliwatters/gsuite-mcp/internal/slides"
@@ -76,6 +77,7 @@ func main() {
 	drive.RegisterTools(s)
 	sheets.RegisterTools(s)
 	slides.RegisterTools(s)
+	forms.RegisterTools(s)
 	contacts.RegisterTools(s)
 
 	// Start server

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -30,6 +30,7 @@ This document provides AI agents with project-specific context and guidelines fo
 - Google Tasks (10 tools)
 - Google Sheets (16 tools)
 - Google Slides (5 tools) — read presentations, get slides, thumbnails, create, batch update
+- Google Forms (5 tools) — get form structure, create forms, batch update, list/get responses
 - Google Contacts (12 tools)
 
 ## Architecture
@@ -50,6 +51,7 @@ gsuite-mcp/
 │   ├── gmail/              # Gmail tools
 │   ├── sheets/             # Google Sheets tools
 │   ├── slides/             # Google Slides tools
+│   ├── forms/              # Google Forms tools
 │   └── tasks/              # Google Tasks tools
 ├── docs/
 │   ├── AGENTS.md           # This file

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -79,7 +79,7 @@ type successPageData struct {
 	OtherAccounts []string
 }
 
-// DefaultScopes are the OAuth scopes required for Gmail, Calendar, Docs, Tasks, Drive, Sheets, Slides, and Contacts operations.
+// DefaultScopes are the OAuth scopes required for Gmail, Calendar, Docs, Tasks, Drive, Sheets, Slides, Forms, and Contacts operations.
 var DefaultScopes = []string{
 	// OpenID Connect scopes (required for getting authenticated user email)
 	"openid",
@@ -102,6 +102,9 @@ var DefaultScopes = []string{
 	"https://www.googleapis.com/auth/spreadsheets",
 	// Slides scopes
 	"https://www.googleapis.com/auth/presentations",
+	// Forms scopes
+	"https://www.googleapis.com/auth/forms.body",
+	"https://www.googleapis.com/auth/forms.responses.readonly",
 	// Contacts scopes (People API)
 	"https://www.googleapis.com/auth/contacts",
 }

--- a/internal/forms/forms_handlers.go
+++ b/internal/forms/forms_handlers.go
@@ -1,0 +1,31 @@
+package forms
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/forms/v1"
+	"google.golang.org/api/option"
+)
+
+// Type alias using generic types from common package.
+type FormsHandlerDeps = common.HandlerDeps[FormsService]
+
+// NewFormsService creates a FormsService from an authenticated HTTP client.
+func NewFormsService(ctx context.Context, client *http.Client) (FormsService, error) {
+	srv, err := forms.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	return NewRealFormsService(srv), nil
+}
+
+// DefaultFormsHandlerDeps holds the default dependencies for production use.
+var DefaultFormsHandlerDeps = common.NewDefaultHandlerDeps(NewFormsService)
+
+// ResolveFormsServiceOrError resolves a Forms service, returning an MCP error result on failure.
+func ResolveFormsServiceOrError(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (FormsService, *mcp.CallToolResult, bool) {
+	return common.ResolveServiceOrError(ctx, request, deps, DefaultFormsHandlerDeps)
+}

--- a/internal/forms/forms_service.go
+++ b/internal/forms/forms_service.go
@@ -1,0 +1,205 @@
+package forms
+
+import (
+	"context"
+	"encoding/json"
+
+	"google.golang.org/api/forms/v1"
+)
+
+// FormsService defines the interface for Google Forms API operations.
+// This interface enables dependency injection and testing with mocks.
+type FormsService interface {
+	// GetForm retrieves a form by ID.
+	GetForm(ctx context.Context, formID string) (*forms.Form, error)
+
+	// CreateForm creates a new form with the given title.
+	CreateForm(ctx context.Context, title string) (*forms.Form, error)
+
+	// BatchUpdate performs a batch update on a form.
+	BatchUpdate(ctx context.Context, formID string, requests []*forms.Request) (*forms.BatchUpdateFormResponse, error)
+
+	// ListResponses lists responses for a form.
+	ListResponses(ctx context.Context, formID string) ([]*forms.FormResponse, error)
+
+	// GetResponse retrieves a single form response by ID.
+	GetResponse(ctx context.Context, formID string, responseID string) (*forms.FormResponse, error)
+}
+
+// RealFormsService wraps the Forms API client and implements FormsService.
+type RealFormsService struct {
+	service *forms.Service
+}
+
+// NewRealFormsService creates a new RealFormsService wrapping the given API service.
+func NewRealFormsService(service *forms.Service) *RealFormsService {
+	return &RealFormsService{service: service}
+}
+
+// GetForm retrieves a form by ID.
+func (s *RealFormsService) GetForm(ctx context.Context, formID string) (*forms.Form, error) {
+	return s.service.Forms.Get(formID).Context(ctx).Do()
+}
+
+// CreateForm creates a new form with the given title.
+func (s *RealFormsService) CreateForm(ctx context.Context, title string) (*forms.Form, error) {
+	form := &forms.Form{
+		Info: &forms.Info{
+			Title: title,
+		},
+	}
+	return s.service.Forms.Create(form).Context(ctx).Do()
+}
+
+// BatchUpdate performs a batch update on a form.
+func (s *RealFormsService) BatchUpdate(ctx context.Context, formID string, requests []*forms.Request) (*forms.BatchUpdateFormResponse, error) {
+	req := &forms.BatchUpdateFormRequest{
+		Requests:              requests,
+		IncludeFormInResponse: true,
+	}
+	return s.service.Forms.BatchUpdate(formID, req).Context(ctx).Do()
+}
+
+// maxResponsePages limits pagination to prevent unbounded memory growth.
+const maxResponsePages = 10
+
+// ListResponses lists responses for a form (up to maxResponsePages pages).
+func (s *RealFormsService) ListResponses(ctx context.Context, formID string) ([]*forms.FormResponse, error) {
+	var allResponses []*forms.FormResponse
+	pageToken := ""
+	for page := 0; page < maxResponsePages; page++ {
+		call := s.service.Forms.Responses.List(formID).Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			return nil, err
+		}
+		allResponses = append(allResponses, resp.Responses...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return allResponses, nil
+}
+
+// GetResponse retrieves a single form response by ID.
+func (s *RealFormsService) GetResponse(ctx context.Context, formID string, responseID string) (*forms.FormResponse, error) {
+	return s.service.Forms.Responses.Get(formID, responseID).Context(ctx).Do()
+}
+
+// formatItem formats a form item for output.
+func formatItem(item *forms.Item) map[string]any {
+	result := map[string]any{
+		"item_id": item.ItemId,
+		"title":   item.Title,
+	}
+
+	if item.Description != "" {
+		result["description"] = item.Description
+	}
+
+	if item.QuestionItem != nil {
+		result["type"] = "question"
+		q := item.QuestionItem.Question
+		if q != nil {
+			result["question_id"] = q.QuestionId
+			result["required"] = q.Required
+			if q.ChoiceQuestion != nil {
+				result["question_type"] = "choice"
+				result["choice_type"] = q.ChoiceQuestion.Type
+				options := make([]string, 0, len(q.ChoiceQuestion.Options))
+				for _, opt := range q.ChoiceQuestion.Options {
+					options = append(options, opt.Value)
+				}
+				result["options"] = options
+			} else if q.TextQuestion != nil {
+				result["question_type"] = "text"
+				result["paragraph"] = q.TextQuestion.Paragraph
+			} else if q.ScaleQuestion != nil {
+				result["question_type"] = "scale"
+				result["low"] = q.ScaleQuestion.Low
+				result["high"] = q.ScaleQuestion.High
+			} else if q.DateQuestion != nil {
+				result["question_type"] = "date"
+			} else if q.TimeQuestion != nil {
+				result["question_type"] = "time"
+			} else if q.FileUploadQuestion != nil {
+				result["question_type"] = "file_upload"
+			} else if q.RatingQuestion != nil {
+				result["question_type"] = "rating"
+			}
+		}
+	} else if item.QuestionGroupItem != nil {
+		result["type"] = "question_group"
+		questions := make([]map[string]any, 0, len(item.QuestionGroupItem.Questions))
+		for _, q := range item.QuestionGroupItem.Questions {
+			qMap := map[string]any{
+				"question_id": q.QuestionId,
+				"required":    q.Required,
+			}
+			questions = append(questions, qMap)
+		}
+		result["questions"] = questions
+	} else if item.PageBreakItem != nil {
+		result["type"] = "page_break"
+	} else if item.TextItem != nil {
+		result["type"] = "text"
+	} else if item.ImageItem != nil {
+		result["type"] = "image"
+	} else if item.VideoItem != nil {
+		result["type"] = "video"
+	}
+
+	return result
+}
+
+// formatResponse formats a form response for output.
+func formatResponse(resp *forms.FormResponse) map[string]any {
+	result := map[string]any{
+		"response_id":         resp.ResponseId,
+		"create_time":         resp.CreateTime,
+		"last_submitted_time": resp.LastSubmittedTime,
+	}
+
+	if resp.RespondentEmail != "" {
+		result["respondent_email"] = resp.RespondentEmail
+	}
+
+	if resp.TotalScore > 0 {
+		result["total_score"] = resp.TotalScore
+	}
+
+	answers := make(map[string]any, len(resp.Answers))
+	for qID, answer := range resp.Answers {
+		a := map[string]any{
+			"question_id": answer.QuestionId,
+		}
+		if answer.TextAnswers != nil {
+			texts := make([]string, 0, len(answer.TextAnswers.Answers))
+			for _, ta := range answer.TextAnswers.Answers {
+				texts = append(texts, ta.Value)
+			}
+			a["text_answers"] = texts
+		}
+		if answer.Grade != nil {
+			a["score"] = answer.Grade.Score
+			a["correct"] = answer.Grade.Correct
+		}
+		answers[qID] = a
+	}
+	result["answers"] = answers
+
+	return result
+}
+
+// parseBatchUpdateRequests parses a JSON string into Forms batch update requests.
+func parseBatchUpdateRequests(requestsJSON string) ([]*forms.Request, error) {
+	var requests []*forms.Request
+	if err := json.Unmarshal([]byte(requestsJSON), &requests); err != nil {
+		return nil, err
+	}
+	return requests, nil
+}

--- a/internal/forms/forms_service_mock.go
+++ b/internal/forms/forms_service_mock.go
@@ -1,0 +1,221 @@
+package forms
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/forms/v1"
+)
+
+// MockFormsService implements FormsService for testing.
+type MockFormsService struct {
+	// Forms stores mock form data keyed by ID.
+	Forms map[string]*forms.Form
+
+	// Responses stores mock response data keyed by form ID.
+	Responses map[string][]*forms.FormResponse
+
+	// Errors allows tests to configure specific errors for methods.
+	Errors struct {
+		GetForm       error
+		Create        error
+		BatchUpdate   error
+		ListResponses error
+		GetResponse   error
+	}
+
+	// Calls tracks method invocations for verification.
+	Calls struct {
+		GetForm     []string
+		Create      []string
+		BatchUpdate []struct {
+			FormID   string
+			Requests []*forms.Request
+		}
+		ListResponses []string
+		GetResponse   []struct{ FormID, ResponseID string }
+	}
+}
+
+// NewMockFormsService creates a new mock Forms service with default test data.
+func NewMockFormsService() *MockFormsService {
+	m := &MockFormsService{
+		Forms:     make(map[string]*forms.Form),
+		Responses: make(map[string][]*forms.FormResponse),
+	}
+
+	// Add a default test form
+	m.Forms["test-form-1"] = &forms.Form{
+		FormId: "test-form-1",
+		Info: &forms.Info{
+			Title:         "Test Form",
+			Description:   "A test form",
+			DocumentTitle: "Test Form Doc",
+		},
+		ResponderUri: "https://docs.google.com/forms/d/test-form-1/viewform",
+		Items: []*forms.Item{
+			{
+				ItemId: "item-1",
+				Title:  "What is your name?",
+				QuestionItem: &forms.QuestionItem{
+					Question: &forms.Question{
+						QuestionId: "q-1",
+						Required:   true,
+						TextQuestion: &forms.TextQuestion{
+							Paragraph: false,
+						},
+					},
+				},
+			},
+			{
+				ItemId: "item-2",
+				Title:  "Favorite color?",
+				QuestionItem: &forms.QuestionItem{
+					Question: &forms.Question{
+						QuestionId: "q-2",
+						ChoiceQuestion: &forms.ChoiceQuestion{
+							Type: "RADIO",
+							Options: []*forms.Option{
+								{Value: "Red"},
+								{Value: "Blue"},
+								{Value: "Green"},
+							},
+						},
+					},
+				},
+			},
+			{
+				ItemId:        "item-3",
+				Title:         "Section 2",
+				PageBreakItem: &forms.PageBreakItem{},
+			},
+		},
+	}
+
+	// Add test responses
+	m.Responses["test-form-1"] = []*forms.FormResponse{
+		{
+			ResponseId:        "resp-1",
+			FormId:            "test-form-1",
+			CreateTime:        "2024-01-15T10:00:00Z",
+			LastSubmittedTime: "2024-01-15T10:00:00Z",
+			RespondentEmail:   "user@example.com",
+			Answers: map[string]forms.Answer{
+				"q-1": {
+					QuestionId: "q-1",
+					TextAnswers: &forms.TextAnswers{
+						Answers: []*forms.TextAnswer{
+							{Value: "Alice"},
+						},
+					},
+				},
+				"q-2": {
+					QuestionId: "q-2",
+					TextAnswers: &forms.TextAnswers{
+						Answers: []*forms.TextAnswer{
+							{Value: "Blue"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return m
+}
+
+// GetForm retrieves a mock form by ID.
+func (m *MockFormsService) GetForm(ctx context.Context, formID string) (*forms.Form, error) {
+	m.Calls.GetForm = append(m.Calls.GetForm, formID)
+
+	if m.Errors.GetForm != nil {
+		return nil, m.Errors.GetForm
+	}
+
+	form, ok := m.Forms[formID]
+	if !ok {
+		return nil, fmt.Errorf("form not found: %s", formID)
+	}
+
+	return form, nil
+}
+
+// CreateForm creates a mock form.
+func (m *MockFormsService) CreateForm(ctx context.Context, title string) (*forms.Form, error) {
+	m.Calls.Create = append(m.Calls.Create, title)
+
+	if m.Errors.Create != nil {
+		return nil, m.Errors.Create
+	}
+
+	formID := fmt.Sprintf("new-form-%d", len(m.Forms)+1)
+	form := &forms.Form{
+		FormId: formID,
+		Info: &forms.Info{
+			Title: title,
+		},
+		ResponderUri: fmt.Sprintf("https://docs.google.com/forms/d/%s/viewform", formID),
+	}
+
+	m.Forms[formID] = form
+	return form, nil
+}
+
+// BatchUpdate performs a mock batch update.
+func (m *MockFormsService) BatchUpdate(ctx context.Context, formID string, requests []*forms.Request) (*forms.BatchUpdateFormResponse, error) {
+	m.Calls.BatchUpdate = append(m.Calls.BatchUpdate, struct {
+		FormID   string
+		Requests []*forms.Request
+	}{formID, requests})
+
+	if m.Errors.BatchUpdate != nil {
+		return nil, m.Errors.BatchUpdate
+	}
+
+	_, ok := m.Forms[formID]
+	if !ok {
+		return nil, fmt.Errorf("form not found: %s", formID)
+	}
+
+	return &forms.BatchUpdateFormResponse{
+		Replies: make([]*forms.Response, len(requests)),
+	}, nil
+}
+
+// ListResponses lists mock responses for a form.
+func (m *MockFormsService) ListResponses(ctx context.Context, formID string) ([]*forms.FormResponse, error) {
+	m.Calls.ListResponses = append(m.Calls.ListResponses, formID)
+
+	if m.Errors.ListResponses != nil {
+		return nil, m.Errors.ListResponses
+	}
+
+	_, ok := m.Forms[formID]
+	if !ok {
+		return nil, fmt.Errorf("form not found: %s", formID)
+	}
+
+	responses := m.Responses[formID]
+	if responses == nil {
+		responses = []*forms.FormResponse{}
+	}
+	return responses, nil
+}
+
+// GetResponse retrieves a mock form response by ID.
+func (m *MockFormsService) GetResponse(ctx context.Context, formID string, responseID string) (*forms.FormResponse, error) {
+	m.Calls.GetResponse = append(m.Calls.GetResponse, struct{ FormID, ResponseID string }{formID, responseID})
+
+	if m.Errors.GetResponse != nil {
+		return nil, m.Errors.GetResponse
+	}
+
+	responses := m.Responses[formID]
+	for _, resp := range responses {
+		if resp.ResponseId == responseID {
+			return resp, nil
+		}
+	}
+
+	return nil, fmt.Errorf("response not found: %s", responseID)
+}

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -1,0 +1,477 @@
+package forms
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+)
+
+func TestHandleFormsGet(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "get form successfully",
+			args: map[string]any{
+				"form_id": "test-form-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["title"] != "Test Form" {
+					t.Errorf("expected title 'Test Form', got %v", result["title"])
+				}
+				if result["form_id"] != "test-form-1" {
+					t.Errorf("expected form_id 'test-form-1', got %v", result["form_id"])
+				}
+				if result["description"] != "A test form" {
+					t.Errorf("expected description 'A test form', got %v", result["description"])
+				}
+				itemCount, ok := result["item_count"].(float64)
+				if !ok || itemCount != 3 {
+					t.Errorf("expected item_count 3, got %v", result["item_count"])
+				}
+				url, ok := result["edit_url"].(string)
+				if !ok || !strings.Contains(url, "docs.google.com/forms/d/") {
+					t.Errorf("expected valid forms URL, got %v", result["edit_url"])
+				}
+				items, ok := result["items"].([]any)
+				if !ok || len(items) != 3 {
+					t.Errorf("expected 3 items, got %v", result["items"])
+				}
+			},
+		},
+		{
+			name: "get form with URL",
+			args: map[string]any{
+				"form_id": "https://docs.google.com/forms/d/test-form-1/edit",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["form_id"] != "test-form-1" {
+					t.Errorf("expected ID extraction from URL, got %v", result["form_id"])
+				}
+			},
+		},
+		{
+			name:        "missing form_id",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "form_id parameter is required",
+		},
+		{
+			name: "form not found",
+			args: map[string]any{
+				"form_id": "nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Forms API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableFormsGet(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleFormsCreate(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "create form successfully",
+			args: map[string]any{
+				"title": "My New Form",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["title"] != "My New Form" {
+					t.Errorf("expected title 'My New Form', got %v", result["title"])
+				}
+				if result["form_id"] == nil || result["form_id"] == "" {
+					t.Error("expected form_id to be set")
+				}
+				url, ok := result["edit_url"].(string)
+				if !ok || !strings.Contains(url, "docs.google.com/forms/d/") {
+					t.Errorf("expected valid forms URL, got %v", result["edit_url"])
+				}
+			},
+		},
+		{
+			name:        "missing title parameter",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "title parameter is required",
+		},
+		{
+			name: "empty title parameter",
+			args: map[string]any{
+				"title": "",
+			},
+			wantErr:     true,
+			errContains: "title parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableFormsCreate(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleFormsBatchUpdate(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "batch update successfully",
+			args: map[string]any{
+				"form_id":  "test-form-1",
+				"requests": `[{"createItem": {"item": {"title": "New Question", "questionItem": {"question": {"textQuestion": {}}}}, "location": {"index": 0}}}]`,
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["form_id"] != "test-form-1" {
+					t.Errorf("expected form_id 'test-form-1', got %v", result["form_id"])
+				}
+			},
+		},
+		{
+			name: "invalid JSON requests",
+			args: map[string]any{
+				"form_id":  "test-form-1",
+				"requests": "not valid json",
+			},
+			wantErr:     true,
+			errContains: "Invalid requests JSON",
+		},
+		{
+			name: "missing requests parameter",
+			args: map[string]any{
+				"form_id": "test-form-1",
+			},
+			wantErr:     true,
+			errContains: "requests parameter is required",
+		},
+		{
+			name: "form not found",
+			args: map[string]any{
+				"form_id":  "nonexistent",
+				"requests": `[{"createItem": {"item": {"title": "Q"}, "location": {"index": 0}}}]`,
+			},
+			wantErr:     true,
+			errContains: "Forms API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableFormsBatchUpdate(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleFormsListResponses(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "list responses successfully",
+			args: map[string]any{
+				"form_id": "test-form-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["form_id"] != "test-form-1" {
+					t.Errorf("expected form_id 'test-form-1', got %v", result["form_id"])
+				}
+				count, ok := result["response_count"].(float64)
+				if !ok || count != 1 {
+					t.Errorf("expected response_count 1, got %v", result["response_count"])
+				}
+				responses, ok := result["responses"].([]any)
+				if !ok || len(responses) != 1 {
+					t.Errorf("expected 1 response, got %v", result["responses"])
+				}
+			},
+		},
+		{
+			name:        "missing form_id",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "form_id parameter is required",
+		},
+		{
+			name: "form not found",
+			args: map[string]any{
+				"form_id": "nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Forms API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableFormsListResponses(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleFormsGetResponse(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "get response successfully",
+			args: map[string]any{
+				"form_id":     "test-form-1",
+				"response_id": "resp-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["response_id"] != "resp-1" {
+					t.Errorf("expected response_id 'resp-1', got %v", result["response_id"])
+				}
+				if result["respondent_email"] != "user@example.com" {
+					t.Errorf("expected respondent_email 'user@example.com', got %v", result["respondent_email"])
+				}
+				if result["form_id"] != "test-form-1" {
+					t.Errorf("expected form_id 'test-form-1', got %v", result["form_id"])
+				}
+			},
+		},
+		{
+			name: "missing response_id",
+			args: map[string]any{
+				"form_id": "test-form-1",
+			},
+			wantErr:     true,
+			errContains: "response_id parameter is required",
+		},
+		{
+			name: "response not found",
+			args: map[string]any{
+				"form_id":     "test-form-1",
+				"response_id": "nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Forms API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableFormsGetResponse(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestFormsServiceErrors(t *testing.T) {
+	fixtures := NewFormsTestFixtures()
+
+	t.Run("API error on get form", func(t *testing.T) {
+		fixtures.MockService.Errors.GetForm = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.GetForm = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{"form_id": "test-form-1"})
+		result, err := testableFormsGet(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "Forms API error") {
+			t.Errorf("expected Forms API error, got: %s", text)
+		}
+	})
+
+	t.Run("API error on create", func(t *testing.T) {
+		fixtures.MockService.Errors.Create = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.Create = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{"title": "Test"})
+		result, err := testableFormsCreate(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+	})
+
+	t.Run("API error on list responses", func(t *testing.T) {
+		fixtures.MockService.Errors.ListResponses = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.ListResponses = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{"form_id": "test-form-1"})
+		result, err := testableFormsListResponses(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+	})
+}

--- a/internal/forms/forms_test_helpers.go
+++ b/internal/forms/forms_test_helpers.go
@@ -1,0 +1,45 @@
+package forms
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Aliases for testable functions used by test files.
+var (
+	testableFormsGet           = TestableFormsGet
+	testableFormsCreate        = TestableFormsCreate
+	testableFormsBatchUpdate   = TestableFormsBatchUpdate
+	testableFormsListResponses = TestableFormsListResponses
+	testableFormsGetResponse   = TestableFormsGetResponse
+)
+
+// getTextContent extracts text content from an MCP CallToolResult.
+func getTextContent(result *mcp.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+		return textContent.Text
+	}
+	return ""
+}
+
+// FormsTestFixtures contains test fixtures for Forms tool testing.
+type FormsTestFixtures struct {
+	DefaultEmail string
+	MockService  *MockFormsService
+	Deps         *FormsHandlerDeps
+}
+
+// NewFormsTestFixtures creates a new set of test fixtures.
+func NewFormsTestFixtures() *FormsTestFixtures {
+	mockService := NewMockFormsService()
+	f := common.NewTestFixtures[FormsService](mockService)
+
+	return &FormsTestFixtures{
+		DefaultEmail: f.DefaultEmail,
+		MockService:  mockService,
+		Deps:         f.Deps,
+	}
+}

--- a/internal/forms/forms_testable.go
+++ b/internal/forms/forms_testable.go
@@ -1,0 +1,192 @@
+package forms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// formsEditURLFormat is the URL template for Google Forms edit links.
+const formsEditURLFormat = "https://docs.google.com/forms/d/%s/edit"
+
+// extractRequiredFormID extracts, validates, and normalizes the form_id parameter.
+func extractRequiredFormID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
+	formID := common.ParseStringArg(request.Params.Arguments, "form_id", "")
+	if formID == "" {
+		return "", mcp.NewToolResultError("form_id parameter is required")
+	}
+	return common.ExtractGoogleResourceID(formID), nil
+}
+
+// TestableFormsGet retrieves a form's metadata, items, and structure.
+func TestableFormsGet(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveFormsServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	formID, errResult := extractRequiredFormID(request)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	form, err := srv.GetForm(ctx, formID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Forms API error: %v", err)), nil
+	}
+
+	// Format items summary
+	items := make([]map[string]any, 0, len(form.Items))
+	for _, item := range form.Items {
+		items = append(items, formatItem(item))
+	}
+
+	result := map[string]any{
+		"form_id":    form.FormId,
+		"title":      form.Info.Title,
+		"edit_url":   fmt.Sprintf(formsEditURLFormat, form.FormId),
+		"item_count": len(form.Items),
+		"items":      items,
+	}
+
+	if form.Info.Description != "" {
+		result["description"] = form.Info.Description
+	}
+	if form.Info.DocumentTitle != "" {
+		result["document_title"] = form.Info.DocumentTitle
+	}
+	if form.ResponderUri != "" {
+		result["responder_url"] = form.ResponderUri
+	}
+	if form.LinkedSheetId != "" {
+		result["linked_sheet_id"] = form.LinkedSheetId
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableFormsCreate creates a new form.
+func TestableFormsCreate(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveFormsServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	form, err := srv.CreateForm(ctx, title)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Forms API error: %v", err)), nil
+	}
+
+	result := map[string]any{
+		"form_id":  form.FormId,
+		"title":    form.Info.Title,
+		"edit_url": fmt.Sprintf(formsEditURLFormat, form.FormId),
+	}
+
+	if form.ResponderUri != "" {
+		result["responder_url"] = form.ResponderUri
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableFormsBatchUpdate performs a batch update on a form.
+func TestableFormsBatchUpdate(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveFormsServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	formID, errResult := extractRequiredFormID(request)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	requestsJSON, errResult := common.RequireStringArg(request.Params.Arguments, "requests")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	requests, err := parseBatchUpdateRequests(requestsJSON)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Invalid requests JSON: %v", err)), nil
+	}
+
+	resp, err := srv.BatchUpdate(ctx, formID, requests)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Forms API error: %v", err)), nil
+	}
+
+	result := map[string]any{
+		"form_id":       formID,
+		"replies_count": len(resp.Replies),
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableFormsListResponses lists all responses for a form.
+func TestableFormsListResponses(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveFormsServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	formID, errResult := extractRequiredFormID(request)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	responses, err := srv.ListResponses(ctx, formID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Forms API error: %v", err)), nil
+	}
+
+	formattedResponses := make([]map[string]any, 0, len(responses))
+	for _, resp := range responses {
+		formattedResponses = append(formattedResponses, formatResponse(resp))
+	}
+
+	result := map[string]any{
+		"form_id":        formID,
+		"response_count": len(responses),
+		"responses":      formattedResponses,
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableFormsGetResponse retrieves a single form response by ID.
+func TestableFormsGetResponse(ctx context.Context, request mcp.CallToolRequest, deps *FormsHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveFormsServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	formID, errResult := extractRequiredFormID(request)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	responseID, errResult := common.RequireStringArg(request.Params.Arguments, "response_id")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	resp, err := srv.GetResponse(ctx, formID, responseID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Forms API error: %v", err)), nil
+	}
+
+	result := formatResponse(resp)
+	result["form_id"] = formID
+
+	return common.MarshalToolResult(result)
+}

--- a/internal/forms/forms_tools.go
+++ b/internal/forms/forms_tools.go
@@ -1,0 +1,15 @@
+package forms
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+)
+
+// === Handle functions - generated via WrapHandler ===
+
+var (
+	HandleFormsGet           = common.WrapHandler[FormsService](TestableFormsGet)
+	HandleFormsCreate        = common.WrapHandler[FormsService](TestableFormsCreate)
+	HandleFormsBatchUpdate   = common.WrapHandler[FormsService](TestableFormsBatchUpdate)
+	HandleFormsListResponses = common.WrapHandler[FormsService](TestableFormsListResponses)
+	HandleFormsGetResponse   = common.WrapHandler[FormsService](TestableFormsGetResponse)
+)

--- a/internal/forms/register.go
+++ b/internal/forms/register.go
@@ -1,0 +1,51 @@
+package forms
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterTools registers all Forms tools with the MCP server.
+func RegisterTools(s *server.MCPServer) {
+	// === Forms Read ===
+
+	// forms_get - Get form metadata and structure
+	s.AddTool(mcp.NewTool("forms_get",
+		mcp.WithDescription("Get a Google Form's metadata, questions, and structure including item types and options."),
+		mcp.WithString("form_id", mcp.Required(), mcp.Description("Form ID or full Google Forms URL")),
+		common.WithAccountParam(),
+	), HandleFormsGet)
+
+	// forms_list_responses - List form responses
+	s.AddTool(mcp.NewTool("forms_list_responses",
+		mcp.WithDescription("List all responses submitted to a Google Form."),
+		mcp.WithString("form_id", mcp.Required(), mcp.Description("Form ID or full Google Forms URL")),
+		common.WithAccountParam(),
+	), HandleFormsListResponses)
+
+	// forms_get_response - Get a single form response
+	s.AddTool(mcp.NewTool("forms_get_response",
+		mcp.WithDescription("Get a single response submitted to a Google Form by response ID."),
+		mcp.WithString("form_id", mcp.Required(), mcp.Description("Form ID or full Google Forms URL")),
+		mcp.WithString("response_id", mcp.Required(), mcp.Description("Response ID (from forms_list_responses)")),
+		common.WithAccountParam(),
+	), HandleFormsGetResponse)
+
+	// === Forms Write ===
+
+	// forms_create - Create a new form
+	s.AddTool(mcp.NewTool("forms_create",
+		mcp.WithDescription("Create a new Google Form with the given title."),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Form title")),
+		common.WithAccountParam(),
+	), HandleFormsCreate)
+
+	// forms_batch_update - Batch update form
+	s.AddTool(mcp.NewTool("forms_batch_update",
+		mcp.WithDescription("Execute batch update requests on a Google Form. Use to add/update/delete questions, update form info, and modify settings. See Google Forms API batchUpdate documentation for request format."),
+		mcp.WithString("form_id", mcp.Required(), mcp.Description("Form ID or full Google Forms URL")),
+		mcp.WithString("requests", mcp.Required(), mcp.Description("JSON array of batch update requests (see Google Forms API docs)")),
+		common.WithAccountParam(),
+	), HandleFormsBatchUpdate)
+}


### PR DESCRIPTION
## Summary

- Adds complete Google Forms API integration with 5 MCP tools: `forms_get`, `forms_create`, `forms_batch_update`, `forms_list_responses`, `forms_get_response`
- Follows established service interface pattern (FormsService interface, RealFormsService, MockFormsService)
- 18 unit tests covering all tools: success cases, missing params, not found, API errors
- OAuth scopes: `forms.body` (read/write form structure), `forms.responses.readonly` (read responses)
- Pagination in ListResponses bounded to 10 pages to prevent unbounded memory growth

Closes #60

## Test plan

- [x] `go build ./cmd/gsuite-mcp/` — builds clean
- [x] `go test ./internal/forms/ -v` — 18/18 tests pass
- [x] `go test ./...` — all existing tests still pass
- [x] `gofmt -l ./internal/forms/` — no formatting issues
- [x] `go vet ./...` — no issues