### PR TITLE
feat(gmail): add send-as aliases and delegation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ gsuite-mcp auth personal
 
 ## Tools Overview
 
-### Gmail (36 tools)
-Full inbox management: search, read, send, reply, archive, trash, labels, filters, drafts, threads, batch operations, vacation responder.
+### Gmail (45 tools)
+Full inbox management: search, read, send, reply, archive, trash, labels, filters, drafts, threads, batch operations, vacation responder, send-as aliases, delegation.
 
 ### Calendar (12 tools)
 Complete calendar control: list events, create/update/delete, recurring events, free/busy queries, Google Meet integration.
@@ -112,6 +112,10 @@ Contact management: list, search, create, update, delete, contact groups.
 | `gmail_thread_archive` / `gmail_thread_trash` / `gmail_thread_untrash` / `gmail_modify_thread` | Thread operations |
 | `gmail_get_profile` | Account info |
 | `gmail_get_vacation` / `gmail_set_vacation` | Vacation responder |
+| `gmail_list_send_as` / `gmail_get_send_as` | List/get send-as aliases |
+| `gmail_create_send_as` / `gmail_update_send_as` / `gmail_delete_send_as` | Manage send-as aliases |
+| `gmail_verify_send_as` | Verify external send-as alias |
+| `gmail_list_delegates` / `gmail_create_delegate` / `gmail_delete_delegate` | Delegation management |
 
 #### Calendar
 | Tool | Description |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,7 +23,7 @@ This document provides AI agents with project-specific context and guidelines fo
 - Full inbox management: archive, trash, labels, batch operations
 
 ### Services Supported
-- Gmail (36 tools)
+- Gmail (45 tools)
 - Google Calendar (12 tools)
 - Google Drive (23 tools) — includes shared drive support, comments, revisions
 - Google Docs (20 tools)

--- a/internal/gmail/gmail_extended.go
+++ b/internal/gmail/gmail_extended.go
@@ -65,3 +65,20 @@ var (
 	HandleGmailSpam    = common.WrapHandler[GmailService](TestableGmailSpam)
 	HandleGmailNotSpam = common.WrapHandler[GmailService](TestableGmailNotSpam)
 )
+
+// Send-As Aliases
+var (
+	HandleGmailListSendAs   = common.WrapHandler[GmailService](TestableGmailListSendAs)
+	HandleGmailGetSendAs    = common.WrapHandler[GmailService](TestableGmailGetSendAs)
+	HandleGmailCreateSendAs = common.WrapHandler[GmailService](TestableGmailCreateSendAs)
+	HandleGmailUpdateSendAs = common.WrapHandler[GmailService](TestableGmailUpdateSendAs)
+	HandleGmailDeleteSendAs = common.WrapHandler[GmailService](TestableGmailDeleteSendAs)
+	HandleGmailVerifySendAs = common.WrapHandler[GmailService](TestableGmailVerifySendAs)
+)
+
+// Delegates
+var (
+	HandleGmailListDelegates  = common.WrapHandler[GmailService](TestableGmailListDelegates)
+	HandleGmailCreateDelegate = common.WrapHandler[GmailService](TestableGmailCreateDelegate)
+	HandleGmailDeleteDelegate = common.WrapHandler[GmailService](TestableGmailDeleteDelegate)
+)

--- a/internal/gmail/gmail_service.go
+++ b/internal/gmail/gmail_service.go
@@ -52,6 +52,19 @@ type GmailService interface {
 	GetProfile(ctx context.Context) (*gmail.Profile, error)
 	GetVacationSettings(ctx context.Context) (*gmail.VacationSettings, error)
 	UpdateVacationSettings(ctx context.Context, settings *gmail.VacationSettings) (*gmail.VacationSettings, error)
+
+	// Send-As
+	ListSendAs(ctx context.Context) ([]*gmail.SendAs, error)
+	GetSendAs(ctx context.Context, sendAsEmail string) (*gmail.SendAs, error)
+	CreateSendAs(ctx context.Context, sendAs *gmail.SendAs) (*gmail.SendAs, error)
+	UpdateSendAs(ctx context.Context, sendAsEmail string, sendAs *gmail.SendAs) (*gmail.SendAs, error)
+	DeleteSendAs(ctx context.Context, sendAsEmail string) error
+	VerifySendAs(ctx context.Context, sendAsEmail string) error
+
+	// Delegates
+	ListDelegates(ctx context.Context) ([]*gmail.Delegate, error)
+	CreateDelegate(ctx context.Context, delegate *gmail.Delegate) (*gmail.Delegate, error)
+	DeleteDelegate(ctx context.Context, delegateEmail string) error
 }
 
 // RealGmailService wraps the actual Gmail API service.
@@ -200,4 +213,52 @@ func (s *RealGmailService) GetVacationSettings(ctx context.Context) (*gmail.Vaca
 
 func (s *RealGmailService) UpdateVacationSettings(ctx context.Context, settings *gmail.VacationSettings) (*gmail.VacationSettings, error) {
 	return s.service.Users.Settings.UpdateVacation(common.GmailUserMe, settings).Context(ctx).Do()
+}
+
+// === Send-As ===
+
+func (s *RealGmailService) ListSendAs(ctx context.Context) ([]*gmail.SendAs, error) {
+	resp, err := s.service.Users.Settings.SendAs.List(common.GmailUserMe).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return resp.SendAs, nil
+}
+
+func (s *RealGmailService) GetSendAs(ctx context.Context, sendAsEmail string) (*gmail.SendAs, error) {
+	return s.service.Users.Settings.SendAs.Get(common.GmailUserMe, sendAsEmail).Context(ctx).Do()
+}
+
+func (s *RealGmailService) CreateSendAs(ctx context.Context, sendAs *gmail.SendAs) (*gmail.SendAs, error) {
+	return s.service.Users.Settings.SendAs.Create(common.GmailUserMe, sendAs).Context(ctx).Do()
+}
+
+func (s *RealGmailService) UpdateSendAs(ctx context.Context, sendAsEmail string, sendAs *gmail.SendAs) (*gmail.SendAs, error) {
+	return s.service.Users.Settings.SendAs.Patch(common.GmailUserMe, sendAsEmail, sendAs).Context(ctx).Do()
+}
+
+func (s *RealGmailService) DeleteSendAs(ctx context.Context, sendAsEmail string) error {
+	return s.service.Users.Settings.SendAs.Delete(common.GmailUserMe, sendAsEmail).Context(ctx).Do()
+}
+
+func (s *RealGmailService) VerifySendAs(ctx context.Context, sendAsEmail string) error {
+	return s.service.Users.Settings.SendAs.Verify(common.GmailUserMe, sendAsEmail).Context(ctx).Do()
+}
+
+// === Delegates ===
+
+func (s *RealGmailService) ListDelegates(ctx context.Context) ([]*gmail.Delegate, error) {
+	resp, err := s.service.Users.Settings.Delegates.List(common.GmailUserMe).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Delegates, nil
+}
+
+func (s *RealGmailService) CreateDelegate(ctx context.Context, delegate *gmail.Delegate) (*gmail.Delegate, error) {
+	return s.service.Users.Settings.Delegates.Create(common.GmailUserMe, delegate).Context(ctx).Do()
+}
+
+func (s *RealGmailService) DeleteDelegate(ctx context.Context, delegateEmail string) error {
+	return s.service.Users.Settings.Delegates.Delete(common.GmailUserMe, delegateEmail).Context(ctx).Do()
 }

--- a/internal/gmail/gmail_service_mock.go
+++ b/internal/gmail/gmail_service_mock.go
@@ -17,13 +17,15 @@ type MethodCall struct {
 // MockGmailService is a mock implementation of GmailService for testing.
 type MockGmailService struct {
 	// Data stores
-	Messages map[string]*gmail.Message
-	Threads  map[string]*gmail.Thread
-	Labels   map[string]*gmail.Label
-	Drafts   map[string]*gmail.Draft
-	Filters  map[string]*gmail.Filter
-	Profile  *gmail.Profile
-	Vacation *gmail.VacationSettings
+	Messages  map[string]*gmail.Message
+	Threads   map[string]*gmail.Thread
+	Labels    map[string]*gmail.Label
+	Drafts    map[string]*gmail.Draft
+	Filters   map[string]*gmail.Filter
+	Profile   *gmail.Profile
+	Vacation  *gmail.VacationSettings
+	SendAs    map[string]*gmail.SendAs
+	Delegates map[string]*gmail.Delegate
 
 	// Error to return (if set, operations return this error)
 	Error error
@@ -41,11 +43,13 @@ type MockGmailService struct {
 // NewMockGmailService creates a new MockGmailService with initialized maps.
 func NewMockGmailService() *MockGmailService {
 	return &MockGmailService{
-		Messages: make(map[string]*gmail.Message),
-		Threads:  make(map[string]*gmail.Thread),
-		Labels:   make(map[string]*gmail.Label),
-		Drafts:   make(map[string]*gmail.Draft),
-		Filters:  make(map[string]*gmail.Filter),
+		Messages:  make(map[string]*gmail.Message),
+		Threads:   make(map[string]*gmail.Thread),
+		Labels:    make(map[string]*gmail.Label),
+		Drafts:    make(map[string]*gmail.Draft),
+		Filters:   make(map[string]*gmail.Filter),
+		SendAs:    make(map[string]*gmail.SendAs),
+		Delegates: make(map[string]*gmail.Delegate),
 		Profile: &gmail.Profile{
 			EmailAddress:  common.TestEmail,
 			MessagesTotal: 100,
@@ -69,6 +73,8 @@ func (m *MockGmailService) Reset() {
 	m.Labels = make(map[string]*gmail.Label)
 	m.Drafts = make(map[string]*gmail.Draft)
 	m.Filters = make(map[string]*gmail.Filter)
+	m.SendAs = make(map[string]*gmail.SendAs)
+	m.Delegates = make(map[string]*gmail.Delegate)
 	m.MethodCalls = nil
 	m.Error = nil
 }
@@ -630,4 +636,134 @@ func (m *MockGmailService) SetError(errMsg string) {
 // VacationSettings is an alias for Vacation field for convenience in tests.
 func (m *MockGmailService) SetVacationSettings(settings *gmail.VacationSettings) {
 	m.Vacation = settings
+}
+
+// === Send-As ===
+
+func (m *MockGmailService) ListSendAs(ctx context.Context) ([]*gmail.SendAs, error) {
+	m.recordCall("ListSendAs")
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	var sendAs []*gmail.SendAs
+	for _, sa := range m.SendAs {
+		sendAs = append(sendAs, sa)
+	}
+	return sendAs, nil
+}
+
+func (m *MockGmailService) GetSendAs(ctx context.Context, sendAsEmail string) (*gmail.SendAs, error) {
+	m.recordCall("GetSendAs", sendAsEmail)
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	sa, ok := m.SendAs[sendAsEmail]
+	if !ok {
+		return nil, fmt.Errorf("send-as not found: %s", sendAsEmail)
+	}
+	return sa, nil
+}
+
+func (m *MockGmailService) CreateSendAs(ctx context.Context, sendAs *gmail.SendAs) (*gmail.SendAs, error) {
+	m.recordCall("CreateSendAs", sendAs)
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	m.SendAs[sendAs.SendAsEmail] = sendAs
+	return sendAs, nil
+}
+
+func (m *MockGmailService) UpdateSendAs(ctx context.Context, sendAsEmail string, sendAs *gmail.SendAs) (*gmail.SendAs, error) {
+	m.recordCall("UpdateSendAs", sendAsEmail, sendAs)
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	if _, ok := m.SendAs[sendAsEmail]; !ok {
+		return nil, fmt.Errorf("send-as not found: %s", sendAsEmail)
+	}
+
+	sendAs.SendAsEmail = sendAsEmail
+	m.SendAs[sendAsEmail] = sendAs
+	return sendAs, nil
+}
+
+func (m *MockGmailService) DeleteSendAs(ctx context.Context, sendAsEmail string) error {
+	m.recordCall("DeleteSendAs", sendAsEmail)
+	if m.Error != nil {
+		return m.Error
+	}
+
+	if _, ok := m.SendAs[sendAsEmail]; !ok {
+		return fmt.Errorf("send-as not found: %s", sendAsEmail)
+	}
+
+	delete(m.SendAs, sendAsEmail)
+	return nil
+}
+
+func (m *MockGmailService) VerifySendAs(ctx context.Context, sendAsEmail string) error {
+	m.recordCall("VerifySendAs", sendAsEmail)
+	if m.Error != nil {
+		return m.Error
+	}
+
+	if _, ok := m.SendAs[sendAsEmail]; !ok {
+		return fmt.Errorf("send-as not found: %s", sendAsEmail)
+	}
+
+	return nil
+}
+
+// === Delegates ===
+
+func (m *MockGmailService) ListDelegates(ctx context.Context) ([]*gmail.Delegate, error) {
+	m.recordCall("ListDelegates")
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	var delegates []*gmail.Delegate
+	for _, d := range m.Delegates {
+		delegates = append(delegates, d)
+	}
+	return delegates, nil
+}
+
+func (m *MockGmailService) CreateDelegate(ctx context.Context, delegate *gmail.Delegate) (*gmail.Delegate, error) {
+	m.recordCall("CreateDelegate", delegate)
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	delegate.VerificationStatus = "accepted"
+	m.Delegates[delegate.DelegateEmail] = delegate
+	return delegate, nil
+}
+
+func (m *MockGmailService) DeleteDelegate(ctx context.Context, delegateEmail string) error {
+	m.recordCall("DeleteDelegate", delegateEmail)
+	if m.Error != nil {
+		return m.Error
+	}
+
+	if _, ok := m.Delegates[delegateEmail]; !ok {
+		return fmt.Errorf("delegate not found: %s", delegateEmail)
+	}
+
+	delete(m.Delegates, delegateEmail)
+	return nil
+}
+
+// AddSendAs adds a send-as alias to the mock store.
+func (m *MockGmailService) AddSendAs(sendAs *gmail.SendAs) {
+	m.SendAs[sendAs.SendAsEmail] = sendAs
+}
+
+// AddDelegate adds a delegate to the mock store.
+func (m *MockGmailService) AddDelegate(delegate *gmail.Delegate) {
+	m.Delegates[delegate.DelegateEmail] = delegate
 }

--- a/internal/gmail/register.go
+++ b/internal/gmail/register.go
@@ -306,6 +306,84 @@ func registerExtendedTools(s *server.MCPServer) {
 		common.WithAccountParam(),
 	), HandleGmailModifyThread)
 
+	// === Send-As Aliases ===
+
+	// gmail_list_send_as - List send-as aliases
+	s.AddTool(mcp.NewTool("gmail_list_send_as",
+		mcp.WithDescription("List all send-as aliases (alternate from addresses) for the account"),
+		common.WithAccountParam(),
+	), HandleGmailListSendAs)
+
+	// gmail_get_send_as - Get send-as alias
+	s.AddTool(mcp.NewTool("gmail_get_send_as",
+		mcp.WithDescription("Get details of a specific send-as alias"),
+		mcp.WithString("send_as_email", mcp.Required(), mcp.Description("The send-as email address")),
+		common.WithAccountParam(),
+	), HandleGmailGetSendAs)
+
+	// gmail_create_send_as - Create send-as alias
+	s.AddTool(mcp.NewTool("gmail_create_send_as",
+		mcp.WithDescription("Create a new send-as alias. For external addresses, SMTP configuration is required."),
+		mcp.WithString("send_as_email", mcp.Required(), mcp.Description("The email address to send as")),
+		mcp.WithString("display_name", mcp.Description("Display name for the alias")),
+		mcp.WithString("reply_to_address", mcp.Description("Reply-to address (defaults to send-as address)")),
+		mcp.WithString("signature", mcp.Description("HTML signature for this alias")),
+		mcp.WithBoolean("is_default", mcp.Description("Set as default send-as alias")),
+		mcp.WithString("smtp_host", mcp.Description("SMTP server hostname (for external addresses)")),
+		mcp.WithNumber("smtp_port", mcp.Description("SMTP server port (for external addresses)")),
+		mcp.WithString("smtp_username", mcp.Description("SMTP username (for external addresses)")),
+		mcp.WithString("smtp_password", mcp.Description("SMTP password (for external addresses)")),
+		mcp.WithString("smtp_security_mode", mcp.Description("SMTP security: none, ssl, starttls")),
+		common.WithAccountParam(),
+	), HandleGmailCreateSendAs)
+
+	// gmail_update_send_as - Update send-as alias
+	s.AddTool(mcp.NewTool("gmail_update_send_as",
+		mcp.WithDescription("Update an existing send-as alias (display name, signature, reply-to)"),
+		mcp.WithString("send_as_email", mcp.Required(), mcp.Description("The send-as email address to update")),
+		mcp.WithString("display_name", mcp.Description("New display name")),
+		mcp.WithString("reply_to_address", mcp.Description("New reply-to address")),
+		mcp.WithString("signature", mcp.Description("New HTML signature")),
+		mcp.WithBoolean("is_default", mcp.Description("Set as default send-as alias")),
+		common.WithAccountParam(),
+	), HandleGmailUpdateSendAs)
+
+	// gmail_delete_send_as - Delete send-as alias
+	s.AddTool(mcp.NewTool("gmail_delete_send_as",
+		mcp.WithDescription("Delete a send-as alias. Cannot delete the primary address."),
+		mcp.WithString("send_as_email", mcp.Required(), mcp.Description("The send-as email address to delete")),
+		common.WithAccountParam(),
+	), HandleGmailDeleteSendAs)
+
+	// gmail_verify_send_as - Verify send-as alias
+	s.AddTool(mcp.NewTool("gmail_verify_send_as",
+		mcp.WithDescription("Send verification email for a send-as alias. Required for external addresses."),
+		mcp.WithString("send_as_email", mcp.Required(), mcp.Description("The send-as email address to verify")),
+		common.WithAccountParam(),
+	), HandleGmailVerifySendAs)
+
+	// === Delegates ===
+
+	// gmail_list_delegates - List delegates
+	s.AddTool(mcp.NewTool("gmail_list_delegates",
+		mcp.WithDescription("List all delegates who have access to this account"),
+		common.WithAccountParam(),
+	), HandleGmailListDelegates)
+
+	// gmail_create_delegate - Add delegate
+	s.AddTool(mcp.NewTool("gmail_create_delegate",
+		mcp.WithDescription("Add a delegate who can read, send, and delete messages on your behalf. Requires domain-wide delegation or same-domain accounts."),
+		mcp.WithString("delegate_email", mcp.Required(), mcp.Description("Email address of the delegate to add")),
+		common.WithAccountParam(),
+	), HandleGmailCreateDelegate)
+
+	// gmail_delete_delegate - Remove delegate
+	s.AddTool(mcp.NewTool("gmail_delete_delegate",
+		mcp.WithDescription("Remove a delegate's access to this account"),
+		mcp.WithString("delegate_email", mcp.Required(), mcp.Description("Email address of the delegate to remove")),
+		common.WithAccountParam(),
+	), HandleGmailDeleteDelegate)
+
 	// gmail_get_profile - Get account profile
 	s.AddTool(mcp.NewTool("gmail_get_profile",
 		mcp.WithDescription("Get email address, message count, and thread count for account"),

--- a/internal/gmail/testable_sendas_delegates.go
+++ b/internal/gmail/testable_sendas_delegates.go
@@ -1,0 +1,316 @@
+package gmail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/gmail/v1"
+)
+
+// === Send-As Testable Functions ===
+
+// TestableGmailListSendAs lists all send-as aliases for the account.
+func TestableGmailListSendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	aliases, err := svc.ListSendAs(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	results := make([]map[string]any, 0, len(aliases))
+	for _, sa := range aliases {
+		results = append(results, formatSendAs(sa))
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"send_as_count": len(aliases),
+		"send_as":       results,
+	})
+}
+
+// TestableGmailGetSendAs gets a specific send-as alias.
+func TestableGmailGetSendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	sa, err := svc.GetSendAs(ctx, email)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(formatSendAs(sa))
+}
+
+// TestableGmailCreateSendAs creates a new send-as alias.
+func TestableGmailCreateSendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	sendAs := &gmail.SendAs{
+		SendAsEmail: email,
+	}
+
+	if val := common.ParseStringArg(request.Params.Arguments, "display_name", ""); val != "" {
+		sendAs.DisplayName = val
+	}
+	if val := common.ParseStringArg(request.Params.Arguments, "reply_to_address", ""); val != "" {
+		sendAs.ReplyToAddress = val
+	}
+	if val := common.ParseStringArg(request.Params.Arguments, "signature", ""); val != "" {
+		sendAs.Signature = val
+	}
+	if val, ok := request.Params.Arguments["is_default"].(bool); ok && val {
+		sendAs.IsDefault = val
+	}
+
+	// SMTP configuration for external send-as
+	smtpHost := common.ParseStringArg(request.Params.Arguments, "smtp_host", "")
+	if smtpHost != "" {
+		sendAs.SmtpMsa = &gmail.SmtpMsa{
+			Host: smtpHost,
+		}
+		if port, ok := request.Params.Arguments["smtp_port"].(float64); ok {
+			sendAs.SmtpMsa.Port = int64(port)
+		}
+		if val := common.ParseStringArg(request.Params.Arguments, "smtp_username", ""); val != "" {
+			sendAs.SmtpMsa.Username = val
+		}
+		if val := common.ParseStringArg(request.Params.Arguments, "smtp_password", ""); val != "" {
+			sendAs.SmtpMsa.Password = val
+		}
+		if val := common.ParseStringArg(request.Params.Arguments, "smtp_security_mode", ""); val != "" {
+			sendAs.SmtpMsa.SecurityMode = val
+		}
+	}
+
+	created, err := svc.CreateSendAs(ctx, sendAs)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	result := formatSendAs(created)
+	result["success"] = true
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableGmailUpdateSendAs updates an existing send-as alias.
+func TestableGmailUpdateSendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	sendAs := &gmail.SendAs{}
+
+	if val := common.ParseStringArg(request.Params.Arguments, "display_name", ""); val != "" {
+		sendAs.DisplayName = val
+	}
+	if val := common.ParseStringArg(request.Params.Arguments, "reply_to_address", ""); val != "" {
+		sendAs.ReplyToAddress = val
+	}
+	if val := common.ParseStringArg(request.Params.Arguments, "signature", ""); val != "" {
+		sendAs.Signature = val
+	}
+	if val, ok := request.Params.Arguments["is_default"].(bool); ok {
+		sendAs.IsDefault = val
+	}
+
+	updated, err := svc.UpdateSendAs(ctx, email, sendAs)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	result := formatSendAs(updated)
+	result["success"] = true
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableGmailDeleteSendAs deletes a send-as alias.
+func TestableGmailDeleteSendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	err := svc.DeleteSendAs(ctx, email)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"success":       true,
+		"send_as_email": email,
+		"action":        "deleted",
+	})
+}
+
+// TestableGmailVerifySendAs initiates verification for a send-as alias.
+func TestableGmailVerifySendAs(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	err := svc.VerifySendAs(ctx, email)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"success":       true,
+		"send_as_email": email,
+		"action":        "verification_sent",
+	})
+}
+
+// === Delegate Testable Functions ===
+
+// TestableGmailListDelegates lists all delegates for the account.
+func TestableGmailListDelegates(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	delegates, err := svc.ListDelegates(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	results := make([]map[string]any, 0, len(delegates))
+	for _, d := range delegates {
+		results = append(results, formatDelegate(d))
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"delegate_count": len(delegates),
+		"delegates":      results,
+	})
+}
+
+// TestableGmailCreateDelegate adds a new delegate to the account.
+func TestableGmailCreateDelegate(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "delegate_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	delegate := &gmail.Delegate{
+		DelegateEmail: email,
+	}
+
+	created, err := svc.CreateDelegate(ctx, delegate)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	result := formatDelegate(created)
+	result["success"] = true
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableGmailDeleteDelegate removes a delegate from the account.
+func TestableGmailDeleteDelegate(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	email, errResult := common.RequireStringArg(request.Params.Arguments, "delegate_email")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	err := svc.DeleteDelegate(ctx, email)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"success":        true,
+		"delegate_email": email,
+		"action":         "deleted",
+	})
+}
+
+// === Format Helpers ===
+
+// formatSendAs formats a SendAs alias for MCP output.
+func formatSendAs(sa *gmail.SendAs) map[string]any {
+	result := map[string]any{
+		"send_as_email": sa.SendAsEmail,
+		"display_name":  sa.DisplayName,
+		"is_default":    sa.IsDefault,
+		"is_primary":    sa.IsPrimary,
+	}
+
+	if sa.ReplyToAddress != "" {
+		result["reply_to_address"] = sa.ReplyToAddress
+	}
+	if sa.Signature != "" {
+		result["signature"] = sa.Signature
+	}
+	if sa.VerificationStatus != "" {
+		result["verification_status"] = sa.VerificationStatus
+	}
+	if sa.SmtpMsa != nil {
+		result["smtp_msa"] = map[string]any{
+			"host":          sa.SmtpMsa.Host,
+			"port":          sa.SmtpMsa.Port,
+			"security_mode": sa.SmtpMsa.SecurityMode,
+		}
+	}
+
+	return result
+}
+
+// formatDelegate formats a Delegate for MCP output.
+func formatDelegate(d *gmail.Delegate) map[string]any {
+	return map[string]any{
+		"delegate_email":      d.DelegateEmail,
+		"verification_status": d.VerificationStatus,
+	}
+}

--- a/internal/gmail/testable_sendas_delegates_test.go
+++ b/internal/gmail/testable_sendas_delegates_test.go
@@ -1,0 +1,297 @@
+package gmail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/gmail/v1"
+)
+
+// getTextResult extracts the text from a tool result for error messages.
+func getTextResult(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}
+
+func TestTestableGmailSendAs(t *testing.T) {
+	fix := NewGmailTestFixtures()
+	ctx := context.Background()
+
+	// Seed send-as aliases
+	fix.MockService.AddSendAs(&gmail.SendAs{
+		SendAsEmail:        "primary@example.com",
+		DisplayName:        "Primary User",
+		IsPrimary:          true,
+		IsDefault:          true,
+		VerificationStatus: "accepted",
+	})
+	fix.MockService.AddSendAs(&gmail.SendAs{
+		SendAsEmail:        "alias@example.com",
+		DisplayName:        "Alias User",
+		ReplyToAddress:     "reply@example.com",
+		Signature:          "<b>My Signature</b>",
+		VerificationStatus: "accepted",
+	})
+
+	t.Run("ListSendAs", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailListSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %s", getTextResult(result))
+		}
+
+		resp := extractResponse(t, result)
+		if resp["send_as_count"] == nil {
+			t.Error("expected send_as_count in response")
+		}
+		if !fix.MockService.WasMethodCalled("ListSendAs") {
+			t.Error("expected ListSendAs to be called")
+		}
+	})
+
+	t.Run("GetSendAs", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email": "alias@example.com",
+		})
+		result, err := TestableGmailGetSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %s", getTextResult(result))
+		}
+
+		resp := extractResponse(t, result)
+		if resp["send_as_email"] != "alias@example.com" {
+			t.Errorf("expected alias@example.com, got %v", resp["send_as_email"])
+		}
+	})
+
+	t.Run("GetSendAs_missing_email", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailGetSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error for missing send_as_email")
+		}
+	})
+
+	t.Run("GetSendAs_not_found", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email": "notfound@example.com",
+		})
+		result, err := TestableGmailGetSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error for non-existent send-as")
+		}
+	})
+
+	t.Run("CreateSendAs", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email":    "new@example.com",
+			"display_name":     "New Alias",
+			"reply_to_address": "reply-new@example.com",
+		})
+		result, err := TestableGmailCreateSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+		if !fix.MockService.WasMethodCalled("CreateSendAs") {
+			t.Error("expected CreateSendAs to be called")
+		}
+		if _, ok := fix.MockService.SendAs["new@example.com"]; !ok {
+			t.Error("expected send-as to be added to mock store")
+		}
+	})
+
+	t.Run("UpdateSendAs", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email": "alias@example.com",
+			"display_name":  "Updated Alias",
+		})
+		result, err := TestableGmailUpdateSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+	})
+
+	t.Run("DeleteSendAs", func(t *testing.T) {
+		fix.MockService.AddSendAs(&gmail.SendAs{
+			SendAsEmail: "todelete@example.com",
+			DisplayName: "To Delete",
+		})
+
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email": "todelete@example.com",
+		})
+		result, err := TestableGmailDeleteSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+		if _, ok := fix.MockService.SendAs["todelete@example.com"]; ok {
+			t.Error("expected send-as to be removed from mock store")
+		}
+	})
+
+	t.Run("VerifySendAs", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"send_as_email": "alias@example.com",
+		})
+		result, err := TestableGmailVerifySendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+		if !fix.MockService.WasMethodCalled("VerifySendAs") {
+			t.Error("expected VerifySendAs to be called")
+		}
+	})
+
+	t.Run("API_error", func(t *testing.T) {
+		fix.MockService.SetError("send-as API failure")
+		defer func() { fix.MockService.Error = nil }()
+
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailListSendAs(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for API failure")
+		}
+	})
+}
+
+func TestTestableGmailDelegates(t *testing.T) {
+	fix := NewGmailTestFixtures()
+	ctx := context.Background()
+
+	// Seed delegates
+	fix.MockService.AddDelegate(&gmail.Delegate{
+		DelegateEmail:      "delegate1@example.com",
+		VerificationStatus: "accepted",
+	})
+	fix.MockService.AddDelegate(&gmail.Delegate{
+		DelegateEmail:      "delegate2@example.com",
+		VerificationStatus: "pending",
+	})
+
+	t.Run("ListDelegates", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailListDelegates(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %s", getTextResult(result))
+		}
+
+		resp := extractResponse(t, result)
+		if resp["delegate_count"] == nil {
+			t.Error("expected delegate_count in response")
+		}
+		if !fix.MockService.WasMethodCalled("ListDelegates") {
+			t.Error("expected ListDelegates to be called")
+		}
+	})
+
+	t.Run("CreateDelegate", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"delegate_email": "newdelegate@example.com",
+		})
+		result, err := TestableGmailCreateDelegate(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+		if !fix.MockService.WasMethodCalled("CreateDelegate") {
+			t.Error("expected CreateDelegate to be called")
+		}
+		if _, ok := fix.MockService.Delegates["newdelegate@example.com"]; !ok {
+			t.Error("expected delegate to be added to mock store")
+		}
+	})
+
+	t.Run("CreateDelegate_missing_email", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailCreateDelegate(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error for missing delegate_email")
+		}
+	})
+
+	t.Run("DeleteDelegate", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"delegate_email": "delegate1@example.com",
+		})
+		result, err := TestableGmailDeleteDelegate(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Errorf("unexpected error: %s", getTextResult(result))
+		}
+		if _, ok := fix.MockService.Delegates["delegate1@example.com"]; ok {
+			t.Error("expected delegate to be removed from mock store")
+		}
+	})
+
+	t.Run("DeleteDelegate_not_found", func(t *testing.T) {
+		req := common.CreateMCPRequest(map[string]any{
+			"delegate_email": "notfound@example.com",
+		})
+		result, err := TestableGmailDeleteDelegate(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error for non-existent delegate")
+		}
+	})
+
+	t.Run("API_error", func(t *testing.T) {
+		fix.MockService.SetError("delegate API failure")
+		defer func() { fix.MockService.Error = nil }()
+
+		req := common.CreateMCPRequest(map[string]any{})
+		result, err := TestableGmailListDelegates(ctx, req, fix.Deps)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for API failure")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add 9 new Gmail tools for managing send-as aliases and mail delegation
- Send-as: list, get, create (with SMTP config for external addresses), update, delete, verify
- Delegates: list, create, delete
- Gmail tool count: 36 → 45
- 15 new tests covering happy paths, error cases, and missing params

Closes #68

## Test plan

```bash
go build ./cmd/gsuite-mcp/
go test ./internal/gmail/ -run "TestTestableGmail(SendAs|Delegates)" -v
go test ./...
go vet ./...
```