### PR TITLE
feat: add Drive Activity and Google Chat API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Complete Google Workspace MCP server — Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, and Contacts. Single Go binary with true multi-account support.
+Complete Google Workspace MCP server — Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, Contacts, Drive Activity, and Chat. Single Go binary with true multi-account support.
 
 ## Quick Start
 
@@ -23,7 +23,7 @@ gsuite-mcp auth personal
 ## Why gsuite-mcp?
 
 - **Multi-account**: Switch accounts per-operation with `"account": "work"`
-- **Complete coverage**: Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, Contacts
+- **Complete coverage**: Gmail, Calendar, Drive, Docs, Tasks, Sheets, Slides, Forms, Contacts, Drive Activity, Chat
 - **Single binary**: No Python, no Node, no runtime dependencies
 - **MCP native**: JSON Schema 2020-12, proper tool descriptions
 
@@ -68,6 +68,12 @@ Form management: get form structure and questions, create forms, batch update (a
 
 ### Contacts (12 tools)
 Contact management: list, search, create, update, delete, contact groups.
+
+### Drive Activity (1 tool)
+Audit trail queries: query activity history for Drive files and folders (who edited, created, moved, shared, with time range and action type filters).
+
+### Chat (9 tools)
+Google Chat management: list/get/create spaces, list/get/send messages, thread replies, add/remove reactions, list space members.
 
 <details>
 <summary>Full tool reference</summary>
@@ -252,6 +258,24 @@ Contact management: list, search, create, update, delete, contact groups.
 | `forms_batch_update` | Batch update (add/update/delete questions, settings) |
 | `forms_list_responses` | List all form responses |
 | `forms_get_response` | Get a single form response |
+
+#### Drive Activity
+| Tool | Description |
+|------|-------------|
+| `driveactivity_query` | Query activity history for a Drive file or folder |
+
+#### Chat
+| Tool | Description |
+|------|-------------|
+| `chat_list_spaces` | List Chat spaces |
+| `chat_get_space` | Get space details |
+| `chat_create_space` | Create a new space |
+| `chat_list_messages` | List messages in a space |
+| `chat_get_message` | Get a specific message |
+| `chat_send_message` | Send a message to a space |
+| `chat_create_reaction` | Add a reaction to a message |
+| `chat_delete_reaction` | Remove a reaction |
+| `chat_list_members` | List members of a space |
 
 </details>
 

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/aliwatters/gsuite-mcp/internal/auth"
 	"github.com/aliwatters/gsuite-mcp/internal/calendar"
+	"github.com/aliwatters/gsuite-mcp/internal/chat"
 	"github.com/aliwatters/gsuite-mcp/internal/citation"
 	"github.com/aliwatters/gsuite-mcp/internal/common"
 	"github.com/aliwatters/gsuite-mcp/internal/config"
 	"github.com/aliwatters/gsuite-mcp/internal/contacts"
 	"github.com/aliwatters/gsuite-mcp/internal/docs"
 	"github.com/aliwatters/gsuite-mcp/internal/drive"
+	"github.com/aliwatters/gsuite-mcp/internal/driveactivity"
 	"github.com/aliwatters/gsuite-mcp/internal/forms"
 	"github.com/aliwatters/gsuite-mcp/internal/gmail"
 	"github.com/aliwatters/gsuite-mcp/internal/sheets"
@@ -85,6 +87,8 @@ func main() {
 	slides.RegisterTools(s)
 	forms.RegisterTools(s)
 	contacts.RegisterTools(s)
+	driveactivity.RegisterTools(s)
+	chat.RegisterTools(s)
 
 	// Conditionally register citation tools (feature-flagged)
 	registerCitationIfEnabled(s)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -32,6 +32,8 @@ This document provides AI agents with project-specific context and guidelines fo
 - Google Slides (5 tools) — read presentations, get slides, thumbnails, create, batch update
 - Google Forms (5 tools) — get form structure, create forms, batch update, list/get responses
 - Google Contacts (12 tools)
+- Google Drive Activity (1 tool) — audit trail queries for Drive files/folders
+- Google Chat (9 tools) — spaces, messages, reactions, members
 
 ## Architecture
 
@@ -52,6 +54,8 @@ gsuite-mcp/
 │   ├── sheets/             # Google Sheets tools
 │   ├── slides/             # Google Slides tools
 │   ├── forms/              # Google Forms tools
+│   ├── driveactivity/      # Google Drive Activity tools
+│   ├── chat/               # Google Chat tools
 │   └── tasks/              # Google Tasks tools
 ├── docs/
 │   ├── AGENTS.md           # This file

--- a/internal/chat/chat_handlers.go
+++ b/internal/chat/chat_handlers.go
@@ -1,0 +1,31 @@
+package chat
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	chatapi "google.golang.org/api/chat/v1"
+	"google.golang.org/api/option"
+)
+
+// Type alias using generic types from common package.
+type ChatHandlerDeps = common.HandlerDeps[ChatService]
+
+// NewChatService creates a ChatService from an authenticated HTTP client.
+func NewChatService(ctx context.Context, client *http.Client) (ChatService, error) {
+	srv, err := chatapi.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	return NewRealChatService(srv), nil
+}
+
+// DefaultChatHandlerDeps holds the default dependencies for production use.
+var DefaultChatHandlerDeps = common.NewDefaultHandlerDeps(NewChatService)
+
+// ResolveChatServiceOrError resolves a Chat service, returning an MCP error result on failure.
+func ResolveChatServiceOrError(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (ChatService, *mcp.CallToolResult, bool) {
+	return common.ResolveServiceOrError(ctx, request, deps, DefaultChatHandlerDeps)
+}

--- a/internal/chat/chat_service.go
+++ b/internal/chat/chat_service.go
@@ -1,0 +1,150 @@
+package chat
+
+import (
+	"context"
+
+	chatapi "google.golang.org/api/chat/v1"
+)
+
+// ChatService defines the interface for Google Chat API operations.
+// This interface enables dependency injection and testing with mocks.
+type ChatService interface {
+	// ListSpaces lists Chat spaces the user is a member of.
+	ListSpaces(ctx context.Context, pageSize int64, pageToken string) ([]*chatapi.Space, string, error)
+
+	// GetSpace gets details about a Chat space.
+	GetSpace(ctx context.Context, spaceName string) (*chatapi.Space, error)
+
+	// CreateSpace creates a new Chat space.
+	CreateSpace(ctx context.Context, displayName string, spaceType string) (*chatapi.Space, error)
+
+	// ListMessages lists messages in a Chat space.
+	ListMessages(ctx context.Context, spaceName string, pageSize int64, pageToken string, filter string) ([]*chatapi.Message, string, error)
+
+	// GetMessage gets a specific message.
+	GetMessage(ctx context.Context, messageName string) (*chatapi.Message, error)
+
+	// SendMessage sends a message to a Chat space.
+	SendMessage(ctx context.Context, spaceName string, text string, threadName string) (*chatapi.Message, error)
+
+	// CreateReaction adds a reaction to a message.
+	CreateReaction(ctx context.Context, messageName string, emoji string) (*chatapi.Reaction, error)
+
+	// DeleteReaction removes a reaction from a message.
+	DeleteReaction(ctx context.Context, reactionName string) error
+
+	// ListMembers lists members of a Chat space.
+	ListMembers(ctx context.Context, spaceName string, pageSize int64, pageToken string) ([]*chatapi.Membership, string, error)
+}
+
+// maxPages limits pagination to prevent unbounded memory growth.
+const maxPages = 10
+
+// RealChatService wraps the Chat API client and implements ChatService.
+type RealChatService struct {
+	service *chatapi.Service
+}
+
+// NewRealChatService creates a new RealChatService wrapping the given API service.
+func NewRealChatService(service *chatapi.Service) *RealChatService {
+	return &RealChatService{service: service}
+}
+
+// ListSpaces lists Chat spaces the user is a member of.
+func (s *RealChatService) ListSpaces(ctx context.Context, pageSize int64, pageToken string) ([]*chatapi.Space, string, error) {
+	call := s.service.Spaces.List().Context(ctx)
+	if pageSize > 0 {
+		call = call.PageSize(pageSize)
+	}
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Spaces, resp.NextPageToken, nil
+}
+
+// GetSpace gets details about a Chat space.
+func (s *RealChatService) GetSpace(ctx context.Context, spaceName string) (*chatapi.Space, error) {
+	return s.service.Spaces.Get(spaceName).Context(ctx).Do()
+}
+
+// CreateSpace creates a new Chat space.
+func (s *RealChatService) CreateSpace(ctx context.Context, displayName string, spaceType string) (*chatapi.Space, error) {
+	space := &chatapi.Space{
+		DisplayName: displayName,
+		SpaceType:   spaceType,
+	}
+	return s.service.Spaces.Create(space).Context(ctx).Do()
+}
+
+// ListMessages lists messages in a Chat space.
+func (s *RealChatService) ListMessages(ctx context.Context, spaceName string, pageSize int64, pageToken string, filter string) ([]*chatapi.Message, string, error) {
+	call := s.service.Spaces.Messages.List(spaceName).Context(ctx)
+	if pageSize > 0 {
+		call = call.PageSize(pageSize)
+	}
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	if filter != "" {
+		call = call.Filter(filter)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Messages, resp.NextPageToken, nil
+}
+
+// GetMessage gets a specific message.
+func (s *RealChatService) GetMessage(ctx context.Context, messageName string) (*chatapi.Message, error) {
+	return s.service.Spaces.Messages.Get(messageName).Context(ctx).Do()
+}
+
+// SendMessage sends a message to a Chat space.
+func (s *RealChatService) SendMessage(ctx context.Context, spaceName string, text string, threadName string) (*chatapi.Message, error) {
+	msg := &chatapi.Message{
+		Text: text,
+	}
+	if threadName != "" {
+		msg.Thread = &chatapi.Thread{
+			Name: threadName,
+		}
+	}
+	return s.service.Spaces.Messages.Create(spaceName, msg).Context(ctx).Do()
+}
+
+// CreateReaction adds a reaction to a message.
+func (s *RealChatService) CreateReaction(ctx context.Context, messageName string, emoji string) (*chatapi.Reaction, error) {
+	reaction := &chatapi.Reaction{
+		Emoji: &chatapi.Emoji{
+			Unicode: emoji,
+		},
+	}
+	return s.service.Spaces.Messages.Reactions.Create(messageName, reaction).Context(ctx).Do()
+}
+
+// DeleteReaction removes a reaction from a message.
+func (s *RealChatService) DeleteReaction(ctx context.Context, reactionName string) error {
+	_, err := s.service.Spaces.Messages.Reactions.Delete(reactionName).Context(ctx).Do()
+	return err
+}
+
+// ListMembers lists members of a Chat space.
+func (s *RealChatService) ListMembers(ctx context.Context, spaceName string, pageSize int64, pageToken string) ([]*chatapi.Membership, string, error) {
+	call := s.service.Spaces.Members.List(spaceName).Context(ctx)
+	if pageSize > 0 {
+		call = call.PageSize(pageSize)
+	}
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Memberships, resp.NextPageToken, nil
+}

--- a/internal/chat/chat_service_mock.go
+++ b/internal/chat/chat_service_mock.go
@@ -1,0 +1,286 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+
+	chatapi "google.golang.org/api/chat/v1"
+)
+
+// MockChatService implements ChatService for testing.
+type MockChatService struct {
+	// Spaces stores mock space data keyed by name.
+	Spaces map[string]*chatapi.Space
+
+	// Messages stores mock messages keyed by space name.
+	Messages map[string][]*chatapi.Message
+
+	// Members stores mock members keyed by space name.
+	Members map[string][]*chatapi.Membership
+
+	// Reactions stores mock reactions keyed by message name.
+	Reactions map[string][]*chatapi.Reaction
+
+	// Errors allows tests to configure specific errors for methods.
+	Errors struct {
+		ListSpaces     error
+		GetSpace       error
+		CreateSpace    error
+		ListMessages   error
+		GetMessage     error
+		SendMessage    error
+		CreateReaction error
+		DeleteReaction error
+		ListMembers    error
+	}
+
+	// Calls tracks method invocations for verification.
+	Calls struct {
+		ListSpaces     int
+		GetSpace       []string
+		CreateSpace    []struct{ DisplayName, SpaceType string }
+		ListMessages   []string
+		GetMessage     []string
+		SendMessage    []struct{ SpaceName, Text, ThreadName string }
+		CreateReaction []struct{ MessageName, Emoji string }
+		DeleteReaction []string
+		ListMembers    []string
+	}
+}
+
+// NewMockChatService creates a new mock Chat service with default test data.
+func NewMockChatService() *MockChatService {
+	m := &MockChatService{
+		Spaces:    make(map[string]*chatapi.Space),
+		Messages:  make(map[string][]*chatapi.Message),
+		Members:   make(map[string][]*chatapi.Membership),
+		Reactions: make(map[string][]*chatapi.Reaction),
+	}
+
+	// Add default test spaces
+	m.Spaces["spaces/test-space-1"] = &chatapi.Space{
+		Name:                "spaces/test-space-1",
+		DisplayName:         "Test Space",
+		SpaceType:           "SPACE",
+		SpaceThreadingState: "THREADED_MESSAGES",
+	}
+	m.Spaces["spaces/test-space-2"] = &chatapi.Space{
+		Name:        "spaces/test-space-2",
+		DisplayName: "Another Space",
+		SpaceType:   "SPACE",
+	}
+
+	// Add default test messages
+	m.Messages["spaces/test-space-1"] = []*chatapi.Message{
+		{
+			Name:       "spaces/test-space-1/messages/msg-1",
+			Text:       "Hello, world!",
+			CreateTime: "2024-01-15T10:00:00.000Z",
+			Sender: &chatapi.User{
+				Name:        "users/12345",
+				DisplayName: "Alice",
+			},
+			Thread: &chatapi.Thread{
+				Name: "spaces/test-space-1/threads/thread-1",
+			},
+		},
+		{
+			Name:       "spaces/test-space-1/messages/msg-2",
+			Text:       "How are you?",
+			CreateTime: "2024-01-15T10:05:00.000Z",
+			Sender: &chatapi.User{
+				Name:        "users/67890",
+				DisplayName: "Bob",
+			},
+		},
+	}
+
+	// Add default test members
+	m.Members["spaces/test-space-1"] = []*chatapi.Membership{
+		{
+			Name: "spaces/test-space-1/members/12345",
+			Member: &chatapi.User{
+				Name:        "users/12345",
+				DisplayName: "Alice",
+			},
+			Role: "ROLE_MANAGER",
+		},
+		{
+			Name: "spaces/test-space-1/members/67890",
+			Member: &chatapi.User{
+				Name:        "users/67890",
+				DisplayName: "Bob",
+			},
+			Role: "ROLE_MEMBER",
+		},
+	}
+
+	return m
+}
+
+// ListSpaces lists mock Chat spaces.
+func (m *MockChatService) ListSpaces(ctx context.Context, pageSize int64, pageToken string) ([]*chatapi.Space, string, error) {
+	m.Calls.ListSpaces++
+
+	if m.Errors.ListSpaces != nil {
+		return nil, "", m.Errors.ListSpaces
+	}
+
+	spaces := make([]*chatapi.Space, 0, len(m.Spaces))
+	for _, s := range m.Spaces {
+		spaces = append(spaces, s)
+	}
+	return spaces, "", nil
+}
+
+// GetSpace gets a mock Chat space.
+func (m *MockChatService) GetSpace(ctx context.Context, spaceName string) (*chatapi.Space, error) {
+	m.Calls.GetSpace = append(m.Calls.GetSpace, spaceName)
+
+	if m.Errors.GetSpace != nil {
+		return nil, m.Errors.GetSpace
+	}
+
+	space, ok := m.Spaces[spaceName]
+	if !ok {
+		return nil, fmt.Errorf("space not found: %s", spaceName)
+	}
+	return space, nil
+}
+
+// CreateSpace creates a mock Chat space.
+func (m *MockChatService) CreateSpace(ctx context.Context, displayName string, spaceType string) (*chatapi.Space, error) {
+	m.Calls.CreateSpace = append(m.Calls.CreateSpace, struct{ DisplayName, SpaceType string }{displayName, spaceType})
+
+	if m.Errors.CreateSpace != nil {
+		return nil, m.Errors.CreateSpace
+	}
+
+	spaceName := fmt.Sprintf("spaces/new-space-%d", len(m.Spaces)+1)
+	space := &chatapi.Space{
+		Name:        spaceName,
+		DisplayName: displayName,
+		SpaceType:   spaceType,
+	}
+	m.Spaces[spaceName] = space
+	return space, nil
+}
+
+// ListMessages lists mock messages in a space.
+func (m *MockChatService) ListMessages(ctx context.Context, spaceName string, pageSize int64, pageToken string, filter string) ([]*chatapi.Message, string, error) {
+	m.Calls.ListMessages = append(m.Calls.ListMessages, spaceName)
+
+	if m.Errors.ListMessages != nil {
+		return nil, "", m.Errors.ListMessages
+	}
+
+	if _, ok := m.Spaces[spaceName]; !ok {
+		return nil, "", fmt.Errorf("space not found: %s", spaceName)
+	}
+
+	messages := m.Messages[spaceName]
+	if messages == nil {
+		messages = []*chatapi.Message{}
+	}
+	return messages, "", nil
+}
+
+// GetMessage gets a mock message.
+func (m *MockChatService) GetMessage(ctx context.Context, messageName string) (*chatapi.Message, error) {
+	m.Calls.GetMessage = append(m.Calls.GetMessage, messageName)
+
+	if m.Errors.GetMessage != nil {
+		return nil, m.Errors.GetMessage
+	}
+
+	for _, messages := range m.Messages {
+		for _, msg := range messages {
+			if msg.Name == messageName {
+				return msg, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("message not found: %s", messageName)
+}
+
+// SendMessage sends a mock message to a space.
+func (m *MockChatService) SendMessage(ctx context.Context, spaceName string, text string, threadName string) (*chatapi.Message, error) {
+	m.Calls.SendMessage = append(m.Calls.SendMessage, struct{ SpaceName, Text, ThreadName string }{spaceName, text, threadName})
+
+	if m.Errors.SendMessage != nil {
+		return nil, m.Errors.SendMessage
+	}
+
+	if _, ok := m.Spaces[spaceName]; !ok {
+		return nil, fmt.Errorf("space not found: %s", spaceName)
+	}
+
+	msgName := fmt.Sprintf("%s/messages/new-msg-%d", spaceName, len(m.Messages[spaceName])+1)
+	msg := &chatapi.Message{
+		Name:       msgName,
+		Text:       text,
+		CreateTime: "2024-01-15T12:00:00.000Z",
+		Sender: &chatapi.User{
+			Name:        "users/me",
+			DisplayName: "Me",
+		},
+	}
+	if threadName != "" {
+		msg.Thread = &chatapi.Thread{Name: threadName}
+	}
+	m.Messages[spaceName] = append(m.Messages[spaceName], msg)
+	return msg, nil
+}
+
+// CreateReaction adds a mock reaction to a message.
+func (m *MockChatService) CreateReaction(ctx context.Context, messageName string, emoji string) (*chatapi.Reaction, error) {
+	m.Calls.CreateReaction = append(m.Calls.CreateReaction, struct{ MessageName, Emoji string }{messageName, emoji})
+
+	if m.Errors.CreateReaction != nil {
+		return nil, m.Errors.CreateReaction
+	}
+
+	reactionName := fmt.Sprintf("%s/reactions/new-reaction-%d", messageName, len(m.Reactions[messageName])+1)
+	reaction := &chatapi.Reaction{
+		Name: reactionName,
+		Emoji: &chatapi.Emoji{
+			Unicode: emoji,
+		},
+		User: &chatapi.User{
+			Name:        "users/me",
+			DisplayName: "Me",
+		},
+	}
+	m.Reactions[messageName] = append(m.Reactions[messageName], reaction)
+	return reaction, nil
+}
+
+// DeleteReaction removes a mock reaction.
+func (m *MockChatService) DeleteReaction(ctx context.Context, reactionName string) error {
+	m.Calls.DeleteReaction = append(m.Calls.DeleteReaction, reactionName)
+
+	if m.Errors.DeleteReaction != nil {
+		return m.Errors.DeleteReaction
+	}
+
+	return nil
+}
+
+// ListMembers lists mock members of a space.
+func (m *MockChatService) ListMembers(ctx context.Context, spaceName string, pageSize int64, pageToken string) ([]*chatapi.Membership, string, error) {
+	m.Calls.ListMembers = append(m.Calls.ListMembers, spaceName)
+
+	if m.Errors.ListMembers != nil {
+		return nil, "", m.Errors.ListMembers
+	}
+
+	if _, ok := m.Spaces[spaceName]; !ok {
+		return nil, "", fmt.Errorf("space not found: %s", spaceName)
+	}
+
+	members := m.Members[spaceName]
+	if members == nil {
+		members = []*chatapi.Membership{}
+	}
+	return members, "", nil
+}

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -1,0 +1,710 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+)
+
+func TestHandleChatListSpaces(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "list spaces successfully",
+			args: map[string]any{},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["space_count"].(float64)
+				if !ok || count != 2 {
+					t.Errorf("expected space_count 2, got %v", result["space_count"])
+				}
+				spaces, ok := result["spaces"].([]any)
+				if !ok || len(spaces) != 2 {
+					t.Errorf("expected 2 spaces, got %v", result["spaces"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatListSpaces(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatGetSpace(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "get space successfully",
+			args: map[string]any{
+				"space_name": "spaces/test-space-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["name"] != "spaces/test-space-1" {
+					t.Errorf("expected name 'spaces/test-space-1', got %v", result["name"])
+				}
+				if result["display_name"] != "Test Space" {
+					t.Errorf("expected display_name 'Test Space', got %v", result["display_name"])
+				}
+			},
+		},
+		{
+			name:        "missing space_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "space_name parameter is required",
+		},
+		{
+			name: "space not found",
+			args: map[string]any{
+				"space_name": "spaces/nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Chat API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatGetSpace(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatCreateSpace(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "create space successfully",
+			args: map[string]any{
+				"display_name": "New Space",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["display_name"] != "New Space" {
+					t.Errorf("expected display_name 'New Space', got %v", result["display_name"])
+				}
+				if result["name"] == nil || result["name"] == "" {
+					t.Error("expected name to be set")
+				}
+			},
+		},
+		{
+			name: "create space with type",
+			args: map[string]any{
+				"display_name": "Group Chat",
+				"space_type":   "GROUP_CHAT",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["space_type"] != "GROUP_CHAT" {
+					t.Errorf("expected space_type 'GROUP_CHAT', got %v", result["space_type"])
+				}
+			},
+		},
+		{
+			name:        "missing display_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "display_name parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatCreateSpace(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatListMessages(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "list messages successfully",
+			args: map[string]any{
+				"space_name": "spaces/test-space-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["message_count"].(float64)
+				if !ok || count != 2 {
+					t.Errorf("expected message_count 2, got %v", result["message_count"])
+				}
+			},
+		},
+		{
+			name:        "missing space_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "space_name parameter is required",
+		},
+		{
+			name: "space not found",
+			args: map[string]any{
+				"space_name": "spaces/nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Chat API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatListMessages(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatGetMessage(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "get message successfully",
+			args: map[string]any{
+				"message_name": "spaces/test-space-1/messages/msg-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["text"] != "Hello, world!" {
+					t.Errorf("expected text 'Hello, world!', got %v", result["text"])
+				}
+				sender, ok := result["sender"].(map[string]any)
+				if !ok || sender["display_name"] != "Alice" {
+					t.Errorf("expected sender 'Alice', got %v", result["sender"])
+				}
+			},
+		},
+		{
+			name:        "missing message_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "message_name parameter is required",
+		},
+		{
+			name: "message not found",
+			args: map[string]any{
+				"message_name": "spaces/test-space-1/messages/nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Chat API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatGetMessage(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatSendMessage(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "send message successfully",
+			args: map[string]any{
+				"space_name": "spaces/test-space-1",
+				"text":       "Hello from test!",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["text"] != "Hello from test!" {
+					t.Errorf("expected text 'Hello from test!', got %v", result["text"])
+				}
+				if result["name"] == nil || result["name"] == "" {
+					t.Error("expected name to be set")
+				}
+			},
+		},
+		{
+			name: "send threaded message",
+			args: map[string]any{
+				"space_name":  "spaces/test-space-1",
+				"text":        "Reply in thread",
+				"thread_name": "spaces/test-space-1/threads/thread-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["thread_name"] != "spaces/test-space-1/threads/thread-1" {
+					t.Errorf("expected thread_name, got %v", result["thread_name"])
+				}
+			},
+		},
+		{
+			name: "missing space_name",
+			args: map[string]any{
+				"text": "Hello",
+			},
+			wantErr:     true,
+			errContains: "space_name parameter is required",
+		},
+		{
+			name: "missing text",
+			args: map[string]any{
+				"space_name": "spaces/test-space-1",
+			},
+			wantErr:     true,
+			errContains: "text parameter is required",
+		},
+		{
+			name: "space not found",
+			args: map[string]any{
+				"space_name": "spaces/nonexistent",
+				"text":       "Hello",
+			},
+			wantErr:     true,
+			errContains: "Chat API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatSendMessage(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatCreateReaction(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "create reaction successfully",
+			args: map[string]any{
+				"message_name": "spaces/test-space-1/messages/msg-1",
+				"emoji":        "\U0001F44D",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["reaction_name"] == nil || result["reaction_name"] == "" {
+					t.Error("expected reaction_name to be set")
+				}
+				if result["emoji"] != "\U0001F44D" {
+					t.Errorf("expected emoji thumbs up, got %v", result["emoji"])
+				}
+			},
+		},
+		{
+			name: "missing message_name",
+			args: map[string]any{
+				"emoji": "\U0001F44D",
+			},
+			wantErr:     true,
+			errContains: "message_name parameter is required",
+		},
+		{
+			name: "missing emoji",
+			args: map[string]any{
+				"message_name": "spaces/test-space-1/messages/msg-1",
+			},
+			wantErr:     true,
+			errContains: "emoji parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatCreateReaction(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatDeleteReaction(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "delete reaction successfully",
+			args: map[string]any{
+				"reaction_name": "spaces/test-space-1/messages/msg-1/reactions/react-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				if result["deleted"] != true {
+					t.Errorf("expected deleted true, got %v", result["deleted"])
+				}
+			},
+		},
+		{
+			name:        "missing reaction_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "reaction_name parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatDeleteReaction(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleChatListMembers(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "list members successfully",
+			args: map[string]any{
+				"space_name": "spaces/test-space-1",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["member_count"].(float64)
+				if !ok || count != 2 {
+					t.Errorf("expected member_count 2, got %v", result["member_count"])
+				}
+				members, ok := result["members"].([]any)
+				if !ok || len(members) != 2 {
+					t.Errorf("expected 2 members, got %v", result["members"])
+				}
+			},
+		},
+		{
+			name:        "missing space_name",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "space_name parameter is required",
+		},
+		{
+			name: "space not found",
+			args: map[string]any{
+				"space_name": "spaces/nonexistent",
+			},
+			wantErr:     true,
+			errContains: "Chat API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableChatListMembers(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			text := getTextContent(result)
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestChatServiceErrors(t *testing.T) {
+	fixtures := NewChatTestFixtures()
+
+	t.Run("API error on list spaces", func(t *testing.T) {
+		fixtures.MockService.Errors.ListSpaces = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.ListSpaces = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{})
+		result, err := testableChatListSpaces(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "Chat API error") {
+			t.Errorf("expected Chat API error, got: %s", text)
+		}
+	})
+
+	t.Run("API error on send message", func(t *testing.T) {
+		fixtures.MockService.Errors.SendMessage = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.SendMessage = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{"space_name": "spaces/test-space-1", "text": "Hello"})
+		result, err := testableChatSendMessage(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+	})
+
+	t.Run("API error on create reaction", func(t *testing.T) {
+		fixtures.MockService.Errors.CreateReaction = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.CreateReaction = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{
+			"message_name": "spaces/test-space-1/messages/msg-1",
+			"emoji":        "\U0001F44D",
+		})
+		result, err := testableChatCreateReaction(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+	})
+}

--- a/internal/chat/chat_test_helpers.go
+++ b/internal/chat/chat_test_helpers.go
@@ -1,0 +1,49 @@
+package chat
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Aliases for testable functions used by test files.
+var (
+	testableChatListSpaces     = TestableChatListSpaces
+	testableChatGetSpace       = TestableChatGetSpace
+	testableChatCreateSpace    = TestableChatCreateSpace
+	testableChatListMessages   = TestableChatListMessages
+	testableChatGetMessage     = TestableChatGetMessage
+	testableChatSendMessage    = TestableChatSendMessage
+	testableChatCreateReaction = TestableChatCreateReaction
+	testableChatDeleteReaction = TestableChatDeleteReaction
+	testableChatListMembers    = TestableChatListMembers
+)
+
+// getTextContent extracts text content from an MCP CallToolResult.
+func getTextContent(result *mcp.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+		return textContent.Text
+	}
+	return ""
+}
+
+// ChatTestFixtures contains test fixtures for Chat tool testing.
+type ChatTestFixtures struct {
+	DefaultEmail string
+	MockService  *MockChatService
+	Deps         *ChatHandlerDeps
+}
+
+// NewChatTestFixtures creates a new set of test fixtures.
+func NewChatTestFixtures() *ChatTestFixtures {
+	mockService := NewMockChatService()
+	f := common.NewTestFixtures[ChatService](mockService)
+
+	return &ChatTestFixtures{
+		DefaultEmail: f.DefaultEmail,
+		MockService:  mockService,
+		Deps:         f.Deps,
+	}
+}

--- a/internal/chat/chat_testable.go
+++ b/internal/chat/chat_testable.go
@@ -1,0 +1,346 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	chatapi "google.golang.org/api/chat/v1"
+)
+
+// TestableChatListSpaces lists Chat spaces the user is a member of.
+func TestableChatListSpaces(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	pageSize := common.ParseMaxResults(request.Params.Arguments, 20, 100)
+	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+
+	spaces, nextPageToken, err := srv.ListSpaces(ctx, pageSize, pageToken)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	formattedSpaces := make([]map[string]any, 0, len(spaces))
+	for _, s := range spaces {
+		formattedSpaces = append(formattedSpaces, formatSpace(s))
+	}
+
+	result := map[string]any{
+		"space_count": len(formattedSpaces),
+		"spaces":      formattedSpaces,
+	}
+	if nextPageToken != "" {
+		result["next_page_token"] = nextPageToken
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableChatGetSpace gets details about a Chat space.
+func TestableChatGetSpace(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	spaceName = normalizeSpaceName(spaceName)
+
+	space, err := srv.GetSpace(ctx, spaceName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(formatSpace(space))
+}
+
+// TestableChatCreateSpace creates a new Chat space.
+func TestableChatCreateSpace(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	displayName, errResult := common.RequireStringArg(request.Params.Arguments, "display_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	spaceType := common.ParseStringArg(request.Params.Arguments, "space_type", "SPACE")
+
+	space, err := srv.CreateSpace(ctx, displayName, spaceType)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(formatSpace(space))
+}
+
+// TestableChatListMessages lists messages in a Chat space.
+func TestableChatListMessages(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	spaceName = normalizeSpaceName(spaceName)
+	pageSize := common.ParseMaxResults(request.Params.Arguments, 25, 100)
+	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	filter := common.ParseStringArg(request.Params.Arguments, "filter", "")
+
+	messages, nextPageToken, err := srv.ListMessages(ctx, spaceName, pageSize, pageToken, filter)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	formattedMessages := make([]map[string]any, 0, len(messages))
+	for _, msg := range messages {
+		formattedMessages = append(formattedMessages, formatMessage(msg))
+	}
+
+	result := map[string]any{
+		"message_count": len(formattedMessages),
+		"messages":      formattedMessages,
+	}
+	if nextPageToken != "" {
+		result["next_page_token"] = nextPageToken
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableChatGetMessage gets a specific message.
+func TestableChatGetMessage(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	messageName, errResult := common.RequireStringArg(request.Params.Arguments, "message_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	msg, err := srv.GetMessage(ctx, messageName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(formatMessage(msg))
+}
+
+// TestableChatSendMessage sends a message to a Chat space.
+func TestableChatSendMessage(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	spaceName = normalizeSpaceName(spaceName)
+	threadName := common.ParseStringArg(request.Params.Arguments, "thread_name", "")
+
+	msg, err := srv.SendMessage(ctx, spaceName, text, threadName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(formatMessage(msg))
+}
+
+// TestableChatCreateReaction adds a reaction to a message.
+func TestableChatCreateReaction(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	messageName, errResult := common.RequireStringArg(request.Params.Arguments, "message_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	emoji, errResult := common.RequireStringArg(request.Params.Arguments, "emoji")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	reaction, err := srv.CreateReaction(ctx, messageName, emoji)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	result := map[string]any{
+		"reaction_name": reaction.Name,
+	}
+	if reaction.Emoji != nil {
+		result["emoji"] = reaction.Emoji.Unicode
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableChatDeleteReaction removes a reaction from a message.
+func TestableChatDeleteReaction(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	reactionName, errResult := common.RequireStringArg(request.Params.Arguments, "reaction_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	err := srv.DeleteReaction(ctx, reactionName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	return common.MarshalToolResult(map[string]any{
+		"deleted": true,
+	})
+}
+
+// TestableChatListMembers lists members of a Chat space.
+func TestableChatListMembers(ctx context.Context, request mcp.CallToolRequest, deps *ChatHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveChatServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	spaceName = normalizeSpaceName(spaceName)
+	pageSize := common.ParseMaxResults(request.Params.Arguments, 100, 1000)
+	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+
+	members, nextPageToken, err := srv.ListMembers(ctx, spaceName, pageSize, pageToken)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Chat API error: %v", err)), nil
+	}
+
+	formattedMembers := make([]map[string]any, 0, len(members))
+	for _, member := range members {
+		formattedMembers = append(formattedMembers, formatMembership(member))
+	}
+
+	result := map[string]any{
+		"member_count": len(formattedMembers),
+		"members":      formattedMembers,
+	}
+	if nextPageToken != "" {
+		result["next_page_token"] = nextPageToken
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// normalizeSpaceName ensures a space name has the "spaces/" prefix.
+func normalizeSpaceName(name string) string {
+	if len(name) > 0 && name[0] != 's' {
+		// If just an ID was provided, add the prefix
+		return "spaces/" + name
+	}
+	return name
+}
+
+// formatSpace formats a Chat space for output.
+func formatSpace(space *chatapi.Space) map[string]any {
+	result := map[string]any{
+		"name": space.Name,
+	}
+
+	if space.DisplayName != "" {
+		result["display_name"] = space.DisplayName
+	}
+	if space.SpaceType != "" {
+		result["space_type"] = space.SpaceType
+	}
+	if space.SpaceThreadingState != "" {
+		result["threading_state"] = space.SpaceThreadingState
+	}
+	if space.CreateTime != "" {
+		result["create_time"] = space.CreateTime
+	}
+
+	return result
+}
+
+// formatMessage formats a Chat message for output.
+func formatMessage(msg *chatapi.Message) map[string]any {
+	result := map[string]any{
+		"name": msg.Name,
+	}
+
+	if msg.Text != "" {
+		result["text"] = msg.Text
+	}
+	if msg.CreateTime != "" {
+		result["create_time"] = msg.CreateTime
+	}
+	if msg.Sender != nil {
+		sender := map[string]any{
+			"name": msg.Sender.Name,
+		}
+		if msg.Sender.DisplayName != "" {
+			sender["display_name"] = msg.Sender.DisplayName
+		}
+		result["sender"] = sender
+	}
+	if msg.Thread != nil && msg.Thread.Name != "" {
+		result["thread_name"] = msg.Thread.Name
+	}
+
+	return result
+}
+
+// formatMembership formats a Chat membership for output.
+func formatMembership(m *chatapi.Membership) map[string]any {
+	result := map[string]any{
+		"name": m.Name,
+	}
+
+	if m.Member != nil {
+		member := map[string]any{
+			"name": m.Member.Name,
+		}
+		if m.Member.DisplayName != "" {
+			member["display_name"] = m.Member.DisplayName
+		}
+		result["member"] = member
+	}
+	if m.Role != "" {
+		result["role"] = m.Role
+	}
+	if m.CreateTime != "" {
+		result["create_time"] = m.CreateTime
+	}
+
+	return result
+}

--- a/internal/chat/chat_tools.go
+++ b/internal/chat/chat_tools.go
@@ -1,0 +1,19 @@
+package chat
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+)
+
+// === Handle functions - generated via WrapHandler ===
+
+var (
+	HandleChatListSpaces     = common.WrapHandler[ChatService](TestableChatListSpaces)
+	HandleChatGetSpace       = common.WrapHandler[ChatService](TestableChatGetSpace)
+	HandleChatCreateSpace    = common.WrapHandler[ChatService](TestableChatCreateSpace)
+	HandleChatListMessages   = common.WrapHandler[ChatService](TestableChatListMessages)
+	HandleChatGetMessage     = common.WrapHandler[ChatService](TestableChatGetMessage)
+	HandleChatSendMessage    = common.WrapHandler[ChatService](TestableChatSendMessage)
+	HandleChatCreateReaction = common.WrapHandler[ChatService](TestableChatCreateReaction)
+	HandleChatDeleteReaction = common.WrapHandler[ChatService](TestableChatDeleteReaction)
+	HandleChatListMembers    = common.WrapHandler[ChatService](TestableChatListMembers)
+)

--- a/internal/chat/register.go
+++ b/internal/chat/register.go
@@ -1,0 +1,88 @@
+package chat
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterTools registers all Chat tools with the MCP server.
+func RegisterTools(s *server.MCPServer) {
+	// === Spaces ===
+
+	// chat_list_spaces - List Chat spaces
+	s.AddTool(mcp.NewTool("chat_list_spaces",
+		mcp.WithDescription("List Google Chat spaces the authenticated user is a member of."),
+		common.WithPageToken(),
+		common.WithAccountParam(),
+	), HandleChatListSpaces)
+
+	// chat_get_space - Get space details
+	s.AddTool(mcp.NewTool("chat_get_space",
+		mcp.WithDescription("Get details about a Google Chat space including display name, type, and threading state."),
+		mcp.WithString("space_name", mcp.Required(), mcp.Description("Space resource name (e.g., 'spaces/AAAA1234')")),
+		common.WithAccountParam(),
+	), HandleChatGetSpace)
+
+	// chat_create_space - Create a new space
+	s.AddTool(mcp.NewTool("chat_create_space",
+		mcp.WithDescription("Create a new Google Chat space."),
+		mcp.WithString("display_name", mcp.Required(), mcp.Description("Display name for the space")),
+		mcp.WithString("space_type", mcp.Description("Space type: SPACE (default) or GROUP_CHAT")),
+		common.WithAccountParam(),
+	), HandleChatCreateSpace)
+
+	// === Messages ===
+
+	// chat_list_messages - List messages in a space
+	s.AddTool(mcp.NewTool("chat_list_messages",
+		mcp.WithDescription("List messages in a Google Chat space. Returns messages in reverse chronological order."),
+		mcp.WithString("space_name", mcp.Required(), mcp.Description("Space resource name (e.g., 'spaces/AAAA1234')")),
+		mcp.WithString("filter", mcp.Description("Filter messages (e.g., 'createTime > \"2024-01-01T00:00:00Z\"')")),
+		common.WithPageToken(),
+		common.WithAccountParam(),
+	), HandleChatListMessages)
+
+	// chat_get_message - Get a specific message
+	s.AddTool(mcp.NewTool("chat_get_message",
+		mcp.WithDescription("Get a specific Google Chat message by its resource name."),
+		mcp.WithString("message_name", mcp.Required(), mcp.Description("Message resource name (e.g., 'spaces/AAAA1234/messages/msg123')")),
+		common.WithAccountParam(),
+	), HandleChatGetMessage)
+
+	// chat_send_message - Send a message to a space
+	s.AddTool(mcp.NewTool("chat_send_message",
+		mcp.WithDescription("Send a text message to a Google Chat space. Optionally reply in a thread."),
+		mcp.WithString("space_name", mcp.Required(), mcp.Description("Space resource name (e.g., 'spaces/AAAA1234')")),
+		mcp.WithString("text", mcp.Required(), mcp.Description("Message text content")),
+		mcp.WithString("thread_name", mcp.Description("Thread resource name to reply in (e.g., 'spaces/AAAA1234/threads/thread123')")),
+		common.WithAccountParam(),
+	), HandleChatSendMessage)
+
+	// === Reactions ===
+
+	// chat_create_reaction - Add a reaction to a message
+	s.AddTool(mcp.NewTool("chat_create_reaction",
+		mcp.WithDescription("Add a Unicode emoji reaction to a Google Chat message."),
+		mcp.WithString("message_name", mcp.Required(), mcp.Description("Message resource name (e.g., 'spaces/AAAA1234/messages/msg123')")),
+		mcp.WithString("emoji", mcp.Required(), mcp.Description("Unicode emoji (e.g., '\U0001F44D', '\u2764\uFE0F')")),
+		common.WithAccountParam(),
+	), HandleChatCreateReaction)
+
+	// chat_delete_reaction - Remove a reaction
+	s.AddTool(mcp.NewTool("chat_delete_reaction",
+		mcp.WithDescription("Remove a reaction from a Google Chat message."),
+		mcp.WithString("reaction_name", mcp.Required(), mcp.Description("Reaction resource name (e.g., 'spaces/AAAA1234/messages/msg123/reactions/react456')")),
+		common.WithAccountParam(),
+	), HandleChatDeleteReaction)
+
+	// === Members ===
+
+	// chat_list_members - List members of a space
+	s.AddTool(mcp.NewTool("chat_list_members",
+		mcp.WithDescription("List members of a Google Chat space including their roles."),
+		mcp.WithString("space_name", mcp.Required(), mcp.Description("Space resource name (e.g., 'spaces/AAAA1234')")),
+		common.WithPageToken(),
+		common.WithAccountParam(),
+	), HandleChatListMembers)
+}

--- a/internal/driveactivity/driveactivity_handlers.go
+++ b/internal/driveactivity/driveactivity_handlers.go
@@ -1,0 +1,31 @@
+package driveactivity
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/driveactivity/v2"
+	"google.golang.org/api/option"
+)
+
+// Type alias using generic types from common package.
+type DriveActivityHandlerDeps = common.HandlerDeps[DriveActivityService]
+
+// NewDriveActivityService creates a DriveActivityService from an authenticated HTTP client.
+func NewDriveActivityService(ctx context.Context, client *http.Client) (DriveActivityService, error) {
+	srv, err := driveactivity.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	return NewRealDriveActivityService(srv), nil
+}
+
+// DefaultDriveActivityHandlerDeps holds the default dependencies for production use.
+var DefaultDriveActivityHandlerDeps = common.NewDefaultHandlerDeps(NewDriveActivityService)
+
+// ResolveDriveActivityServiceOrError resolves a Drive Activity service, returning an MCP error result on failure.
+func ResolveDriveActivityServiceOrError(ctx context.Context, request mcp.CallToolRequest, deps *DriveActivityHandlerDeps) (DriveActivityService, *mcp.CallToolResult, bool) {
+	return common.ResolveServiceOrError(ctx, request, deps, DefaultDriveActivityHandlerDeps)
+}

--- a/internal/driveactivity/driveactivity_service.go
+++ b/internal/driveactivity/driveactivity_service.go
@@ -1,0 +1,29 @@
+package driveactivity
+
+import (
+	"context"
+
+	"google.golang.org/api/driveactivity/v2"
+)
+
+// DriveActivityService defines the interface for Google Drive Activity API operations.
+// This interface enables dependency injection and testing with mocks.
+type DriveActivityService interface {
+	// QueryActivity queries drive activity with the given request parameters.
+	QueryActivity(ctx context.Context, req *driveactivity.QueryDriveActivityRequest) (*driveactivity.QueryDriveActivityResponse, error)
+}
+
+// RealDriveActivityService wraps the Drive Activity API client and implements DriveActivityService.
+type RealDriveActivityService struct {
+	service *driveactivity.Service
+}
+
+// NewRealDriveActivityService creates a new RealDriveActivityService wrapping the given API service.
+func NewRealDriveActivityService(service *driveactivity.Service) *RealDriveActivityService {
+	return &RealDriveActivityService{service: service}
+}
+
+// QueryActivity queries drive activity with the given request parameters.
+func (s *RealDriveActivityService) QueryActivity(ctx context.Context, req *driveactivity.QueryDriveActivityRequest) (*driveactivity.QueryDriveActivityResponse, error) {
+	return s.service.Activity.Query(req).Context(ctx).Do()
+}

--- a/internal/driveactivity/driveactivity_service_mock.go
+++ b/internal/driveactivity/driveactivity_service_mock.go
@@ -1,0 +1,117 @@
+package driveactivity
+
+import (
+	"context"
+
+	"google.golang.org/api/driveactivity/v2"
+)
+
+// MockDriveActivityService implements DriveActivityService for testing.
+type MockDriveActivityService struct {
+	// Activities stores mock activity data returned by QueryActivity.
+	Activities []*driveactivity.DriveActivity
+
+	// Errors allows tests to configure specific errors for methods.
+	Errors struct {
+		QueryActivity error
+	}
+
+	// Calls tracks method invocations for verification.
+	Calls struct {
+		QueryActivity []*driveactivity.QueryDriveActivityRequest
+	}
+}
+
+// NewMockDriveActivityService creates a new mock Drive Activity service with default test data.
+func NewMockDriveActivityService() *MockDriveActivityService {
+	m := &MockDriveActivityService{}
+
+	m.Activities = []*driveactivity.DriveActivity{
+		{
+			PrimaryActionDetail: &driveactivity.ActionDetail{
+				Edit: &driveactivity.Edit{},
+			},
+			Actors: []*driveactivity.Actor{
+				{
+					User: &driveactivity.User{
+						KnownUser: &driveactivity.KnownUser{
+							PersonName:    "people/12345",
+							IsCurrentUser: true,
+						},
+					},
+				},
+			},
+			Targets: []*driveactivity.Target{
+				{
+					DriveItem: &driveactivity.DriveItem{
+						Name:     "items/abc123",
+						Title:    "Test Document",
+						MimeType: "application/vnd.google-apps.document",
+					},
+				},
+			},
+			Timestamp: "2024-01-15T10:00:00.000Z",
+		},
+		{
+			PrimaryActionDetail: &driveactivity.ActionDetail{
+				Create: &driveactivity.Create{},
+			},
+			Actors: []*driveactivity.Actor{
+				{
+					User: &driveactivity.User{
+						KnownUser: &driveactivity.KnownUser{
+							PersonName: "people/67890",
+						},
+					},
+				},
+			},
+			Targets: []*driveactivity.Target{
+				{
+					DriveItem: &driveactivity.DriveItem{
+						Name:     "items/def456",
+						Title:    "New Spreadsheet",
+						MimeType: "application/vnd.google-apps.spreadsheet",
+					},
+				},
+			},
+			Timestamp: "2024-01-14T09:30:00.000Z",
+		},
+	}
+
+	return m
+}
+
+// QueryActivity returns mock activity data.
+func (m *MockDriveActivityService) QueryActivity(ctx context.Context, req *driveactivity.QueryDriveActivityRequest) (*driveactivity.QueryDriveActivityResponse, error) {
+	m.Calls.QueryActivity = append(m.Calls.QueryActivity, req)
+
+	if m.Errors.QueryActivity != nil {
+		return nil, m.Errors.QueryActivity
+	}
+
+	// Filter by item name if specified
+	activities := m.Activities
+	if req.ItemName != "" {
+		var filtered []*driveactivity.DriveActivity
+		for _, a := range activities {
+			for _, t := range a.Targets {
+				if t.DriveItem != nil && t.DriveItem.Name == req.ItemName {
+					filtered = append(filtered, a)
+					break
+				}
+			}
+		}
+		activities = filtered
+	}
+
+	if len(activities) == 0 && req.ItemName != "" {
+		// Return empty result (not an error) for unfound items
+		return &driveactivity.QueryDriveActivityResponse{
+			Activities: []*driveactivity.DriveActivity{},
+		}, nil
+	}
+
+	return &driveactivity.QueryDriveActivityResponse{
+		Activities: activities,
+	}, nil
+}

--- a/internal/driveactivity/driveactivity_test.go
+++ b/internal/driveactivity/driveactivity_test.go
@@ -1,0 +1,195 @@
+package driveactivity
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	da "google.golang.org/api/driveactivity/v2"
+)
+
+func TestHandleDriveActivityQuery(t *testing.T) {
+	fixtures := NewDriveActivityTestFixtures()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "query by item_id successfully",
+			args: map[string]any{
+				"item_id": "abc123",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["activity_count"].(float64)
+				if !ok || count < 1 {
+					t.Errorf("expected activity_count >= 1, got %v", result["activity_count"])
+				}
+				activities, ok := result["activities"].([]any)
+				if !ok || len(activities) < 1 {
+					t.Errorf("expected at least 1 activity, got %v", result["activities"])
+				}
+				// Check first activity structure
+				if len(activities) > 0 {
+					activity, ok := activities[0].(map[string]any)
+					if !ok {
+						t.Fatal("expected activity to be a map")
+					}
+					if activity["action"] == nil {
+						t.Error("expected action field in activity")
+					}
+					if activity["actors"] == nil {
+						t.Error("expected actors field in activity")
+					}
+					if activity["targets"] == nil {
+						t.Error("expected targets field in activity")
+					}
+				}
+			},
+		},
+		{
+			name: "query by folder_id successfully",
+			args: map[string]any{
+				"folder_id": "folder123",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["activity_count"].(float64)
+				if !ok || count < 1 {
+					t.Errorf("expected activity_count >= 1, got %v", result["activity_count"])
+				}
+			},
+		},
+		{
+			name: "query with URL extracts ID",
+			args: map[string]any{
+				"item_id": "https://drive.google.com/file/d/abc123/view",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				// Should extract ID from URL and query successfully
+				if result["activity_count"] == nil {
+					t.Error("expected activity_count to be set")
+				}
+			},
+		},
+		{
+			name: "query with filter",
+			args: map[string]any{
+				"item_id": "abc123",
+				"filter":  "detail.action_detail_case:EDIT",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				// Verify the filter was passed to the service
+				calls := fixtures.MockService.Calls.QueryActivity
+				lastCall := calls[len(calls)-1]
+				if lastCall.Filter != "detail.action_detail_case:EDIT" {
+					t.Errorf("expected filter to be passed, got %v", lastCall.Filter)
+				}
+			},
+		},
+		{
+			name:        "missing both item_id and folder_id",
+			args:        map[string]any{},
+			wantErr:     true,
+			errContains: "either item_id or folder_id parameter is required",
+		},
+		{
+			name: "item not found returns empty activities",
+			args: map[string]any{
+				"item_id": "nonexistent",
+			},
+			checkResult: func(t *testing.T, result map[string]any) {
+				count, ok := result["activity_count"].(float64)
+				if !ok || count != 0 {
+					t.Errorf("expected activity_count 0, got %v", result["activity_count"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := common.CreateMCPRequest(tt.args)
+			result, err := testableDriveActivityQuery(context.Background(), request, fixtures.Deps)
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+
+			text := getTextContent(result)
+
+			if tt.wantErr {
+				if !result.IsError {
+					t.Errorf("expected error result, got: %s", text)
+				}
+				if tt.errContains != "" && !strings.Contains(text, tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, text)
+				}
+			} else {
+				if result.IsError {
+					t.Fatalf("unexpected error: %s", text)
+				}
+				var resultData map[string]any
+				if err := json.Unmarshal([]byte(text), &resultData); err != nil {
+					t.Fatalf("failed to parse result: %v", err)
+				}
+				if tt.checkResult != nil {
+					tt.checkResult(t, resultData)
+				}
+			}
+		})
+	}
+}
+
+func TestDriveActivityServiceErrors(t *testing.T) {
+	fixtures := NewDriveActivityTestFixtures()
+
+	t.Run("API error on query", func(t *testing.T) {
+		fixtures.MockService.Errors.QueryActivity = context.DeadlineExceeded
+		defer func() { fixtures.MockService.Errors.QueryActivity = nil }()
+
+		request := common.CreateMCPRequest(map[string]any{"item_id": "abc123"})
+		result, err := testableDriveActivityQuery(context.Background(), request, fixtures.Deps)
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "Drive Activity API error") {
+			t.Errorf("expected Drive Activity API error, got: %s", text)
+		}
+	})
+}
+
+func TestFormatActionDetail(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail *da.ActionDetail
+		want   string
+	}{
+		{"edit", &da.ActionDetail{Edit: &da.Edit{}}, "EDIT"},
+		{"create", &da.ActionDetail{Create: &da.Create{}}, "CREATE"},
+		{"delete", &da.ActionDetail{Delete: &da.Delete{}}, "DELETE"},
+		{"move", &da.ActionDetail{Move: &da.Move{}}, "MOVE"},
+		{"restore", &da.ActionDetail{Restore: &da.Restore{}}, "RESTORE"},
+		{"rename with titles", &da.ActionDetail{Rename: &da.Rename{OldTitle: "A", NewTitle: "B"}}, "RENAME: A -> B"},
+		{"rename without titles", &da.ActionDetail{Rename: &da.Rename{}}, "RENAME"},
+		{"permission_change", &da.ActionDetail{PermissionChange: &da.PermissionChange{}}, "PERMISSION_CHANGE"},
+		{"comment", &da.ActionDetail{Comment: &da.Comment{}}, "COMMENT"},
+		{"unknown", &da.ActionDetail{}, "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatActionDetail(tt.detail)
+			if got != tt.want {
+				t.Errorf("formatActionDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/driveactivity/driveactivity_test_helpers.go
+++ b/internal/driveactivity/driveactivity_test_helpers.go
@@ -1,0 +1,41 @@
+package driveactivity
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Aliases for testable functions used by test files.
+var (
+	testableDriveActivityQuery = TestableDriveActivityQuery
+)
+
+// getTextContent extracts text content from an MCP CallToolResult.
+func getTextContent(result *mcp.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+		return textContent.Text
+	}
+	return ""
+}
+
+// DriveActivityTestFixtures contains test fixtures for Drive Activity tool testing.
+type DriveActivityTestFixtures struct {
+	DefaultEmail string
+	MockService  *MockDriveActivityService
+	Deps         *DriveActivityHandlerDeps
+}
+
+// NewDriveActivityTestFixtures creates a new set of test fixtures.
+func NewDriveActivityTestFixtures() *DriveActivityTestFixtures {
+	mockService := NewMockDriveActivityService()
+	f := common.NewTestFixtures[DriveActivityService](mockService)
+
+	return &DriveActivityTestFixtures{
+		DefaultEmail: f.DefaultEmail,
+		MockService:  mockService,
+		Deps:         f.Deps,
+	}
+}

--- a/internal/driveactivity/driveactivity_testable.go
+++ b/internal/driveactivity/driveactivity_testable.go
@@ -1,0 +1,234 @@
+package driveactivity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/api/driveactivity/v2"
+)
+
+// maxActivityPages limits pagination to prevent unbounded memory growth.
+const maxActivityPages = 10
+
+// TestableDriveActivityQuery queries activity for a Drive item or folder.
+func TestableDriveActivityQuery(ctx context.Context, request mcp.CallToolRequest, deps *DriveActivityHandlerDeps) (*mcp.CallToolResult, error) {
+	srv, errResult, ok := ResolveDriveActivityServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	itemID := common.ParseStringArg(request.Params.Arguments, "item_id", "")
+	folderID := common.ParseStringArg(request.Params.Arguments, "folder_id", "")
+	filter := common.ParseStringArg(request.Params.Arguments, "filter", "")
+	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	pageSize := common.ParseMaxResults(request.Params.Arguments, 20, 100)
+
+	if itemID == "" && folderID == "" {
+		return mcp.NewToolResultError("either item_id or folder_id parameter is required"), nil
+	}
+
+	// Normalize IDs: extract from URLs if needed
+	if itemID != "" {
+		itemID = common.ExtractGoogleResourceID(itemID)
+	}
+	if folderID != "" {
+		folderID = common.ExtractGoogleResourceID(folderID)
+	}
+
+	req := &driveactivity.QueryDriveActivityRequest{
+		PageSize: pageSize,
+	}
+
+	if itemID != "" {
+		req.ItemName = fmt.Sprintf("items/%s", itemID)
+	}
+	if folderID != "" {
+		req.AncestorName = fmt.Sprintf("items/%s", folderID)
+	}
+	if filter != "" {
+		req.Filter = filter
+	}
+	if pageToken != "" {
+		req.PageToken = pageToken
+	}
+
+	// Consolidate related actions for cleaner output
+	req.ConsolidationStrategy = &driveactivity.ConsolidationStrategy{
+		Legacy: &driveactivity.Legacy{},
+	}
+
+	var allActivities []*driveactivity.DriveActivity
+	var nextPageToken string
+
+	for page := 0; page < maxActivityPages; page++ {
+		resp, err := srv.QueryActivity(ctx, req)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Drive Activity API error: %v", err)), nil
+		}
+
+		allActivities = append(allActivities, resp.Activities...)
+		nextPageToken = resp.NextPageToken
+
+		if resp.NextPageToken == "" || int64(len(allActivities)) >= pageSize {
+			break
+		}
+		req.PageToken = resp.NextPageToken
+	}
+
+	// Format activities for output
+	formattedActivities := make([]map[string]any, 0, len(allActivities))
+	for _, activity := range allActivities {
+		formattedActivities = append(formattedActivities, formatActivity(activity))
+	}
+
+	result := map[string]any{
+		"activity_count": len(formattedActivities),
+		"activities":     formattedActivities,
+	}
+
+	if nextPageToken != "" {
+		result["next_page_token"] = nextPageToken
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// formatActivity formats a single DriveActivity for output.
+func formatActivity(activity *driveactivity.DriveActivity) map[string]any {
+	result := map[string]any{}
+
+	// Timestamp
+	if activity.Timestamp != "" {
+		result["timestamp"] = activity.Timestamp
+	}
+	if activity.TimeRange != nil {
+		result["time_range"] = map[string]any{
+			"start_time": activity.TimeRange.StartTime,
+			"end_time":   activity.TimeRange.EndTime,
+		}
+	}
+
+	// Primary action
+	if activity.PrimaryActionDetail != nil {
+		result["action"] = formatActionDetail(activity.PrimaryActionDetail)
+	}
+
+	// Actors
+	if len(activity.Actors) > 0 {
+		actors := make([]map[string]any, 0, len(activity.Actors))
+		for _, actor := range activity.Actors {
+			actors = append(actors, formatActor(actor))
+		}
+		result["actors"] = actors
+	}
+
+	// Targets
+	if len(activity.Targets) > 0 {
+		targets := make([]map[string]any, 0, len(activity.Targets))
+		for _, target := range activity.Targets {
+			targets = append(targets, formatTarget(target))
+		}
+		result["targets"] = targets
+	}
+
+	return result
+}
+
+// formatActionDetail formats an ActionDetail into a human-readable representation.
+func formatActionDetail(detail *driveactivity.ActionDetail) string {
+	switch {
+	case detail.Create != nil:
+		return "CREATE"
+	case detail.Edit != nil:
+		return "EDIT"
+	case detail.Move != nil:
+		return "MOVE"
+	case detail.Rename != nil:
+		action := "RENAME"
+		if detail.Rename.OldTitle != "" && detail.Rename.NewTitle != "" {
+			action = fmt.Sprintf("RENAME: %s -> %s", detail.Rename.OldTitle, detail.Rename.NewTitle)
+		}
+		return action
+	case detail.Delete != nil:
+		return "DELETE"
+	case detail.Restore != nil:
+		return "RESTORE"
+	case detail.PermissionChange != nil:
+		return "PERMISSION_CHANGE"
+	case detail.Comment != nil:
+		return "COMMENT"
+	case detail.DlpChange != nil:
+		return "DLP_CHANGE"
+	case detail.Reference != nil:
+		return "REFERENCE"
+	case detail.SettingsChange != nil:
+		return "SETTINGS_CHANGE"
+	case detail.AppliedLabelChange != nil:
+		return "LABEL_CHANGE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// formatActor formats an Actor for output.
+func formatActor(actor *driveactivity.Actor) map[string]any {
+	result := map[string]any{}
+
+	switch {
+	case actor.User != nil:
+		result["type"] = "user"
+		if actor.User.KnownUser != nil {
+			result["person_name"] = actor.User.KnownUser.PersonName
+			result["is_current_user"] = actor.User.KnownUser.IsCurrentUser
+		} else if actor.User.DeletedUser != nil {
+			result["deleted"] = true
+		} else if actor.User.UnknownUser != nil {
+			result["unknown"] = true
+		}
+	case actor.Administrator != nil:
+		result["type"] = "administrator"
+	case actor.System != nil:
+		result["type"] = "system"
+	case actor.Anonymous != nil:
+		result["type"] = "anonymous"
+	case actor.Impersonation != nil:
+		result["type"] = "impersonation"
+	}
+
+	return result
+}
+
+// formatTarget formats a Target for output.
+func formatTarget(target *driveactivity.Target) map[string]any {
+	result := map[string]any{}
+
+	switch {
+	case target.DriveItem != nil:
+		result["type"] = "drive_item"
+		// Extract item ID from "items/ITEM_ID" format
+		name := target.DriveItem.Name
+		if strings.HasPrefix(name, "items/") {
+			result["item_id"] = strings.TrimPrefix(name, "items/")
+		} else {
+			result["item_id"] = name
+		}
+		result["title"] = target.DriveItem.Title
+		if target.DriveItem.MimeType != "" {
+			result["mime_type"] = target.DriveItem.MimeType
+		}
+	case target.Drive != nil:
+		result["type"] = "shared_drive"
+		result["name"] = target.Drive.Name
+		result["title"] = target.Drive.Title
+	case target.FileComment != nil:
+		result["type"] = "file_comment"
+		if target.FileComment.LegacyDiscussionId != "" {
+			result["discussion_id"] = target.FileComment.LegacyDiscussionId
+		}
+	}
+
+	return result
+}

--- a/internal/driveactivity/driveactivity_tools.go
+++ b/internal/driveactivity/driveactivity_tools.go
@@ -1,0 +1,11 @@
+package driveactivity
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+)
+
+// === Handle functions - generated via WrapHandler ===
+
+var (
+	HandleDriveActivityQuery = common.WrapHandler[DriveActivityService](TestableDriveActivityQuery)
+)

--- a/internal/driveactivity/register.go
+++ b/internal/driveactivity/register.go
@@ -1,0 +1,20 @@
+package driveactivity
+
+import (
+	"github.com/aliwatters/gsuite-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterTools registers all Drive Activity tools with the MCP server.
+func RegisterTools(s *server.MCPServer) {
+	// driveactivity_query - Query activity for a Drive item or folder
+	s.AddTool(mcp.NewTool("driveactivity_query",
+		mcp.WithDescription("Query activity history for a Google Drive file or folder. Returns audit trail including who edited, created, moved, renamed, or shared items. Supports filtering by time range and action type."),
+		mcp.WithString("item_id", mcp.Description("Drive file ID or URL to query activity for (mutually exclusive with folder_id)")),
+		mcp.WithString("folder_id", mcp.Description("Drive folder ID or URL to query activity for all items within (mutually exclusive with item_id)")),
+		mcp.WithString("filter", mcp.Description("Filter string (e.g., 'time > \"2024-01-01T00:00:00Z\"', 'detail.action_detail_case:EDIT', 'detail.action_detail_case:(CREATE EDIT)')")),
+		common.WithPageToken(),
+		common.WithAccountParam(),
+	), HandleDriveActivityQuery)
+}


### PR DESCRIPTION
## Summary
- Add Drive Activity API support for file audit trails (Closes #63)
- Add Google Chat API support for space and message management (Closes #61)

## Changes

### Drive Activity (1 tool)
- `driveactivity_query` — Query activity history for Drive files/folders
- Supports filtering by item ID, folder ID, time range, and action type
- Full service interface pattern: `DriveActivityService` / `RealDriveActivityService` / `MockDriveActivityService`

### Google Chat (9 tools)
- `chat_list_spaces` — List Chat spaces
- `chat_get_space` / `chat_create_space` — Space management
- `chat_list_messages` / `chat_get_message` / `chat_send_message` — Message operations with thread support
- `chat_create_reaction` / `chat_delete_reaction` — Unicode emoji reactions
- `chat_list_members` — Space membership listing
- Full service interface pattern with `chatapi` import alias (avoids package name conflict)

### Documentation
- Updated README.md with new tool counts and reference tables
- Updated docs/AGENTS.md with new service listings and directory structure

## Test plan
- `go test ./...` — all 16 packages pass
- `go vet ./...` — clean
- `gofmt -w .` — formatted