### PR TITLE
refactor: wrap bare return err with error context

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -201,7 +201,7 @@ func (m *Manager) OAuthConfig() *oauth2.Config {
 func NewManager() (*Manager, error) {
 	oauthCfg, err := loadOAuthConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading OAuth config: %w", err)
 	}
 
 	return &Manager{
@@ -366,7 +366,7 @@ func (m *Manager) saveTokenForEmail(email string, oauth2Token *oauth2.Token) err
 func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Client, error) {
 	token, err := loadTokenForEmail(email)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading token for %s: %w", email, err)
 	}
 
 	oauth2Token := &oauth2.Token{
@@ -423,7 +423,7 @@ func (m *Manager) GetClientOrAuthenticate(ctx context.Context, email string, int
 			return client, nil
 		}
 		if !errors.Is(err, ErrNoCredentials) {
-			return nil, err
+			return nil, fmt.Errorf("getting client for %s: %w", email, err)
 		}
 		// No credentials for specified email
 		if !interactive {

--- a/internal/calendar/calendar_handlers.go
+++ b/internal/calendar/calendar_handlers.go
@@ -2,6 +2,7 @@ package calendar
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type CalendarHandlerDeps = common.HandlerDeps[CalendarService]
 func NewCalendarService(ctx context.Context, client *http.Client) (CalendarService, error) {
 	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating calendar service: %w", err)
 	}
 	return NewRealCalendarService(srv), nil
 }

--- a/internal/chat/chat_handlers.go
+++ b/internal/chat/chat_handlers.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type ChatHandlerDeps = common.HandlerDeps[ChatService]
 func NewChatService(ctx context.Context, client *http.Client) (ChatService, error) {
 	srv, err := chatapi.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating chat service: %w", err)
 	}
 	return NewRealChatService(srv), nil
 }

--- a/internal/citation/citation_service.go
+++ b/internal/citation/citation_service.go
@@ -113,7 +113,7 @@ func (s *RealCitationService) getStore(ctx context.Context, indexID string) (*Du
 
 	store, err := NewDualStore(ctx, indexID, entry.SheetID, s.sheetsService)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getStore %s: %w", indexID, err)
 	}
 
 	s.mu.Lock()
@@ -244,7 +244,7 @@ func (s *RealCitationService) chunkFile(ctx context.Context, file *drive.File) (
 func (s *RealCitationService) chunkSlides(ctx context.Context, file *drive.File) ([]Chunk, error) {
 	pres, err := s.slidesService.Presentations.Get(file.Id).Context(ctx).Do()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get slides presentation %s: %w", file.Name, err)
 	}
 	return extractSlidesText(file.Id, file.Name, pres), nil
 }
@@ -276,13 +276,13 @@ func (s *RealCitationService) chunkPptxBytes(file *drive.File, data []byte) ([]C
 func (s *RealCitationService) chunkExportedText(ctx context.Context, file *drive.File) ([]Chunk, error) {
 	resp, err := s.driveService.Files.Export(file.Id, "text/plain").Context(ctx).Download()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exporting %s as text: %w", file.Name, err)
 	}
 	defer resp.Body.Close()
 
 	data, err := limitedRead(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading exported text for %s: %w", file.Name, err)
 	}
 
 	return chunkText(file.Id, file.Name, string(data)), nil
@@ -318,13 +318,13 @@ func (s *RealCitationService) ListIndexes(_ context.Context) ([]IndexInfo, error
 func (s *RealCitationService) GetOverview(ctx context.Context, indexID string) (map[string]any, error) {
 	store, err := s.getStore(ctx, indexID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetOverview: %w", err)
 	}
 
 	// Compute counts from actual data, not metadata (which may be stale)
 	files, err := store.GetIndexedFiles(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetOverview getting indexed files: %w", err)
 	}
 
 	totalChunks := 0
@@ -334,13 +334,13 @@ func (s *RealCitationService) GetOverview(ctx context.Context, indexID string) (
 
 	concepts, err := store.GetConcepts(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetOverview getting concepts: %w", err)
 	}
 
 	// Get corpus summary (level 2)
 	summaries, err := store.GetSummaries(ctx, 2)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetOverview getting summaries: %w", err)
 	}
 
 	conceptNames := make([]string, len(concepts))
@@ -370,7 +370,7 @@ func (s *RealCitationService) GetOverview(ctx context.Context, indexID string) (
 func (s *RealCitationService) Lookup(ctx context.Context, indexID, query string, limit int) ([]Chunk, error) {
 	store, err := s.getStore(ctx, indexID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Lookup: %w", err)
 	}
 	if limit <= 0 {
 		limit = 10
@@ -381,7 +381,7 @@ func (s *RealCitationService) Lookup(ctx context.Context, indexID, query string,
 func (s *RealCitationService) GetChunks(ctx context.Context, indexID string, chunkIDs []string) ([]Chunk, error) {
 	store, err := s.getStore(ctx, indexID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetChunks: %w", err)
 	}
 	return store.GetChunks(ctx, chunkIDs)
 }

--- a/internal/citation/index_refresh.go
+++ b/internal/citation/index_refresh.go
@@ -13,7 +13,7 @@ import (
 func (s *RealCitationService) RefreshIndex(ctx context.Context, indexID string) (*RefreshResult, error) {
 	store, err := s.getStore(ctx, indexID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RefreshIndex: %w", err)
 	}
 
 	// Get currently indexed files
@@ -49,7 +49,7 @@ func (s *RealCitationService) RefreshIndex(ctx context.Context, indexID string) 
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RefreshIndex fetching file metadata: %w", err)
 	}
 
 	// Process results sequentially (store writes and result mutation are not concurrent-safe).

--- a/internal/citation/store_dual.go
+++ b/internal/citation/store_dual.go
@@ -32,7 +32,7 @@ func NewDualStore(ctx context.Context, indexID, sheetID string, sheetsSrv *sheet
 
 	dir, err := cacheDir()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolving cache dir: %w", err)
 	}
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("creating cache dir: %w", err)

--- a/internal/citation/store_sqlite.go
+++ b/internal/citation/store_sqlite.go
@@ -484,7 +484,7 @@ func scanChunks(rows *sql.Rows) ([]Chunk, error) {
 		if err := rows.Scan(&c.ID, &c.FileID, &c.FileName, &c.Content, &summary,
 			&c.Location.PageNumber, &c.Location.SectionHeading, &c.Location.ParagraphIndex,
 			&c.Location.CharStart, &c.Location.CharEnd); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scanning chunk row: %w", err)
 		}
 		if summary.Valid {
 			c.Summary = summary.String

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,7 +173,7 @@ func GetAuthenticatedEmails() ([]string, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("reading credentials dir: %w", err)
 	}
 
 	var emails []string

--- a/internal/contacts/contacts_handlers.go
+++ b/internal/contacts/contacts_handlers.go
@@ -2,6 +2,7 @@ package contacts
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type ContactsHandlerDeps = common.HandlerDeps[ContactsService]
 func NewContactsService(ctx context.Context, client *http.Client) (ContactsService, error) {
 	srv, err := people.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating contacts service: %w", err)
 	}
 	return NewRealContactsService(srv), nil
 }

--- a/internal/docs/docs_handlers.go
+++ b/internal/docs/docs_handlers.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -18,11 +19,11 @@ type DocsHandlerDeps = common.HandlerDeps[DocsService]
 func NewDocsService(ctx context.Context, client *http.Client) (DocsService, error) {
 	srv, err := docs.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating docs service: %w", err)
 	}
 	driveSrv, err := drive.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating drive service for docs: %w", err)
 	}
 	return NewRealDocsServiceWithHTTP(srv, driveSrv, client), nil
 }

--- a/internal/drive/drive_handlers.go
+++ b/internal/drive/drive_handlers.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -21,7 +22,7 @@ func NewDriveServiceConstructor(filter *common.DriveAccessFilter) common.Service
 	return func(ctx context.Context, client *http.Client) (DriveService, error) {
 		srv, err := drive.NewService(ctx, option.WithHTTPClient(client))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("creating drive service: %w", err)
 		}
 		real := NewRealDriveService(srv)
 		if filter != nil && filter.IsActive() {

--- a/internal/drive/drive_service.go
+++ b/internal/drive/drive_service.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"google.golang.org/api/drive/v3"
@@ -179,7 +180,7 @@ func (s *RealDriveService) DownloadFile(ctx context.Context, fileID string) (io.
 	resp, err := s.service.Files.Get(fileID).Context(ctx).
 		SupportsAllDrives(true).Download()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("downloading file %s: %w", fileID, err)
 	}
 	return resp.Body, nil
 }
@@ -188,7 +189,7 @@ func (s *RealDriveService) DownloadFile(ctx context.Context, fileID string) (io.
 func (s *RealDriveService) ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error) {
 	resp, err := s.service.Files.Export(fileID, mimeType).Context(ctx).Download()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exporting file %s as %s: %w", fileID, mimeType, err)
 	}
 	return resp.Body, nil
 }
@@ -331,7 +332,7 @@ func (s *RealDriveService) DownloadRevision(ctx context.Context, fileID string, 
 	resp, err := s.service.Revisions.Get(fileID, revisionID).Context(ctx).
 		AcknowledgeAbuse(true).Download()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("downloading revision %s of file %s: %w", revisionID, fileID, err)
 	}
 	return resp.Body, nil
 }

--- a/internal/drive/drive_shared_helpers.go
+++ b/internal/drive/drive_shared_helpers.go
@@ -38,7 +38,7 @@ func readLimited(r io.Reader) ([]byte, error) {
 	limited := io.LimitReader(r, common.DriveMaxFileSize+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading file content: %w", err)
 	}
 	if int64(len(data)) > common.DriveMaxFileSize {
 		return nil, fmt.Errorf("response body exceeds maximum size of %d bytes", common.DriveMaxFileSize)

--- a/internal/drive/filtered_service.go
+++ b/internal/drive/filtered_service.go
@@ -2,6 +2,7 @@ package drive
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -82,7 +83,7 @@ func (f *FilteredDriveService) ListFiles(ctx context.Context, opts *ListFilesOpt
 
 	result, err := f.inner.ListFiles(ctx, innerOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing files: %w", err)
 	}
 
 	// Filter files by drive access
@@ -102,10 +103,10 @@ func (f *FilteredDriveService) GetFile(ctx context.Context, fileID string, field
 	f.ensureResolved(ctx)
 	file, err := f.inner.GetFile(ctx, fileID, ensureDriveIDField(fields))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting file %s: %w", fileID, err)
 	}
 	if err := f.filter.Check(file.DriveId); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetFile drive access check: %w", err)
 	}
 	return file, nil
 }
@@ -114,7 +115,7 @@ func (f *FilteredDriveService) GetFile(ctx context.Context, fileID string, field
 func (f *FilteredDriveService) CreateFile(ctx context.Context, file *drive.File, content io.Reader) (*drive.File, error) {
 	if len(file.Parents) > 0 {
 		if err := f.checkFileAccess(ctx, file.Parents[0]); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("CreateFile parent access check: %w", err)
 		}
 	}
 	return f.inner.CreateFile(ctx, file, content)
@@ -123,7 +124,7 @@ func (f *FilteredDriveService) CreateFile(ctx context.Context, file *drive.File,
 // UpdateFile checks drive access before updating.
 func (f *FilteredDriveService) UpdateFile(ctx context.Context, fileID string, file *drive.File) (*drive.File, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("UpdateFile access check: %w", err)
 	}
 	return f.inner.UpdateFile(ctx, fileID, file)
 }
@@ -131,10 +132,10 @@ func (f *FilteredDriveService) UpdateFile(ctx context.Context, fileID string, fi
 // MoveFile checks both source file and destination drive.
 func (f *FilteredDriveService) MoveFile(ctx context.Context, fileID string, newParentID string, previousParents string) (*drive.File, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("MoveFile source access check: %w", err)
 	}
 	if err := f.checkFileAccess(ctx, newParentID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("MoveFile destination access check: %w", err)
 	}
 	return f.inner.MoveFile(ctx, fileID, newParentID, previousParents)
 }
@@ -142,11 +143,11 @@ func (f *FilteredDriveService) MoveFile(ctx context.Context, fileID string, newP
 // CopyFile checks the source file's drive before copying.
 func (f *FilteredDriveService) CopyFile(ctx context.Context, fileID string, file *drive.File) (*drive.File, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CopyFile source access check: %w", err)
 	}
 	if len(file.Parents) > 0 {
 		if err := f.checkFileAccess(ctx, file.Parents[0]); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("CopyFile destination access check: %w", err)
 		}
 	}
 	return f.inner.CopyFile(ctx, fileID, file)
@@ -155,7 +156,7 @@ func (f *FilteredDriveService) CopyFile(ctx context.Context, fileID string, file
 // DeleteFile checks drive access before deleting.
 func (f *FilteredDriveService) DeleteFile(ctx context.Context, fileID string) error {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return err
+		return fmt.Errorf("DeleteFile access check: %w", err)
 	}
 	return f.inner.DeleteFile(ctx, fileID)
 }
@@ -163,7 +164,7 @@ func (f *FilteredDriveService) DeleteFile(ctx context.Context, fileID string) er
 // DownloadFile checks drive access before downloading.
 func (f *FilteredDriveService) DownloadFile(ctx context.Context, fileID string) (io.ReadCloser, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("DownloadFile access check: %w", err)
 	}
 	return f.inner.DownloadFile(ctx, fileID)
 }
@@ -171,7 +172,7 @@ func (f *FilteredDriveService) DownloadFile(ctx context.Context, fileID string) 
 // ExportFile checks drive access before exporting.
 func (f *FilteredDriveService) ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ExportFile access check: %w", err)
 	}
 	return f.inner.ExportFile(ctx, fileID, mimeType)
 }
@@ -182,7 +183,7 @@ func (f *FilteredDriveService) ExportFile(ctx context.Context, fileID string, mi
 func (f *FilteredDriveService) GetDrive(ctx context.Context, driveID string) (*drive.Drive, error) {
 	f.ensureResolved(ctx)
 	if err := f.filter.Check(driveID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetDrive access check: %w", err)
 	}
 	return f.inner.GetDrive(ctx, driveID)
 }
@@ -196,21 +197,21 @@ func (f *FilteredDriveService) ListDrives(ctx context.Context, pageSize int64, p
 
 func (f *FilteredDriveService) ListPermissions(ctx context.Context, fileID string) (*drive.PermissionList, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ListPermissions access check: %w", err)
 	}
 	return f.inner.ListPermissions(ctx, fileID)
 }
 
 func (f *FilteredDriveService) CreatePermission(ctx context.Context, fileID string, permission *drive.Permission, sendNotification bool) (*drive.Permission, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CreatePermission access check: %w", err)
 	}
 	return f.inner.CreatePermission(ctx, fileID, permission, sendNotification)
 }
 
 func (f *FilteredDriveService) DeletePermission(ctx context.Context, fileID string, permissionID string) error {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return err
+		return fmt.Errorf("DeletePermission access check: %w", err)
 	}
 	return f.inner.DeletePermission(ctx, fileID, permissionID)
 }
@@ -219,35 +220,35 @@ func (f *FilteredDriveService) DeletePermission(ctx context.Context, fileID stri
 
 func (f *FilteredDriveService) ListComments(ctx context.Context, fileID string, fields string, pageSize int64, pageToken string, includeDeleted bool) (*drive.CommentList, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ListComments access check: %w", err)
 	}
 	return f.inner.ListComments(ctx, fileID, fields, pageSize, pageToken, includeDeleted)
 }
 
 func (f *FilteredDriveService) GetComment(ctx context.Context, fileID string, commentID string, fields string, includeDeleted bool) (*drive.Comment, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetComment access check: %w", err)
 	}
 	return f.inner.GetComment(ctx, fileID, commentID, fields, includeDeleted)
 }
 
 func (f *FilteredDriveService) CreateComment(ctx context.Context, fileID string, comment *drive.Comment, fields string) (*drive.Comment, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CreateComment access check: %w", err)
 	}
 	return f.inner.CreateComment(ctx, fileID, comment, fields)
 }
 
 func (f *FilteredDriveService) UpdateComment(ctx context.Context, fileID string, commentID string, comment *drive.Comment, fields string) (*drive.Comment, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("UpdateComment access check: %w", err)
 	}
 	return f.inner.UpdateComment(ctx, fileID, commentID, comment, fields)
 }
 
 func (f *FilteredDriveService) DeleteComment(ctx context.Context, fileID string, commentID string) error {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return err
+		return fmt.Errorf("DeleteComment access check: %w", err)
 	}
 	return f.inner.DeleteComment(ctx, fileID, commentID)
 }
@@ -256,14 +257,14 @@ func (f *FilteredDriveService) DeleteComment(ctx context.Context, fileID string,
 
 func (f *FilteredDriveService) ListReplies(ctx context.Context, fileID string, commentID string, fields string, pageSize int64, pageToken string, includeDeleted bool) (*drive.ReplyList, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ListReplies access check: %w", err)
 	}
 	return f.inner.ListReplies(ctx, fileID, commentID, fields, pageSize, pageToken, includeDeleted)
 }
 
 func (f *FilteredDriveService) CreateReply(ctx context.Context, fileID string, commentID string, reply *drive.Reply, fields string) (*drive.Reply, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CreateReply access check: %w", err)
 	}
 	return f.inner.CreateReply(ctx, fileID, commentID, reply, fields)
 }
@@ -272,21 +273,21 @@ func (f *FilteredDriveService) CreateReply(ctx context.Context, fileID string, c
 
 func (f *FilteredDriveService) ListRevisions(ctx context.Context, fileID string, fields string, pageSize int64, pageToken string) (*drive.RevisionList, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ListRevisions access check: %w", err)
 	}
 	return f.inner.ListRevisions(ctx, fileID, fields, pageSize, pageToken)
 }
 
 func (f *FilteredDriveService) GetRevision(ctx context.Context, fileID string, revisionID string, fields string) (*drive.Revision, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetRevision access check: %w", err)
 	}
 	return f.inner.GetRevision(ctx, fileID, revisionID, fields)
 }
 
 func (f *FilteredDriveService) DownloadRevision(ctx context.Context, fileID string, revisionID string) (io.ReadCloser, error) {
 	if err := f.checkFileAccess(ctx, fileID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("DownloadRevision access check: %w", err)
 	}
 	return f.inner.DownloadRevision(ctx, fileID, revisionID)
 }

--- a/internal/driveactivity/driveactivity_handlers.go
+++ b/internal/driveactivity/driveactivity_handlers.go
@@ -2,6 +2,7 @@ package driveactivity
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type DriveActivityHandlerDeps = common.HandlerDeps[DriveActivityService]
 func NewDriveActivityService(ctx context.Context, client *http.Client) (DriveActivityService, error) {
 	srv, err := driveactivity.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating drive activity service: %w", err)
 	}
 	return NewRealDriveActivityService(srv), nil
 }

--- a/internal/forms/forms_handlers.go
+++ b/internal/forms/forms_handlers.go
@@ -2,6 +2,7 @@ package forms
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type FormsHandlerDeps = common.HandlerDeps[FormsService]
 func NewFormsService(ctx context.Context, client *http.Client) (FormsService, error) {
 	srv, err := forms.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating forms service: %w", err)
 	}
 	return NewRealFormsService(srv), nil
 }

--- a/internal/forms/forms_service.go
+++ b/internal/forms/forms_service.go
@@ -3,6 +3,7 @@ package forms
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"google.golang.org/api/forms/v1"
 )
@@ -74,7 +75,7 @@ func (s *RealFormsService) ListResponses(ctx context.Context, formID string) ([]
 		}
 		resp, err := call.Do()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("listing form responses for %s: %w", formID, err)
 		}
 		allResponses = append(allResponses, resp.Responses...)
 		if resp.NextPageToken == "" {
@@ -199,7 +200,7 @@ func formatResponse(resp *forms.FormResponse) map[string]any {
 func parseBatchUpdateRequests(requestsJSON string) ([]*forms.Request, error) {
 	var requests []*forms.Request
 	if err := json.Unmarshal([]byte(requestsJSON), &requests); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing forms batch update requests: %w", err)
 	}
 	return requests, nil
 }

--- a/internal/gmail/gmail_handlers.go
+++ b/internal/gmail/gmail_handlers.go
@@ -2,6 +2,7 @@ package gmail
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type GmailHandlerDeps = common.HandlerDeps[GmailService]
 func NewGmailService(ctx context.Context, client *http.Client) (GmailService, error) {
 	srv, err := gmail.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating gmail service: %w", err)
 	}
 	return NewRealGmailService(srv), nil
 }

--- a/internal/gmail/gmail_service.go
+++ b/internal/gmail/gmail_service.go
@@ -2,6 +2,7 @@ package gmail
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
 	"google.golang.org/api/gmail/v1"
@@ -251,7 +252,7 @@ func (s *RealGmailService) UpdateVacationSettings(ctx context.Context, settings 
 func (s *RealGmailService) ListSendAs(ctx context.Context) ([]*gmail.SendAs, error) {
 	resp, err := s.service.Users.Settings.SendAs.List(common.GmailUserMe).Context(ctx).Do()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing send-as addresses: %w", err)
 	}
 	return resp.SendAs, nil
 }
@@ -281,7 +282,7 @@ func (s *RealGmailService) VerifySendAs(ctx context.Context, sendAsEmail string)
 func (s *RealGmailService) ListDelegates(ctx context.Context) ([]*gmail.Delegate, error) {
 	resp, err := s.service.Users.Settings.Delegates.List(common.GmailUserMe).Context(ctx).Do()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing delegates: %w", err)
 	}
 	return resp.Delegates, nil
 }

--- a/internal/meet/meet_handlers.go
+++ b/internal/meet/meet_handlers.go
@@ -2,6 +2,7 @@ package meet
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type MeetHandlerDeps = common.HandlerDeps[MeetService]
 func NewMeetService(ctx context.Context, client *http.Client) (MeetService, error) {
 	srv, err := meet.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating meet service: %w", err)
 	}
 	return NewRealMeetService(srv), nil
 }

--- a/internal/sheets/sheets_handlers.go
+++ b/internal/sheets/sheets_handlers.go
@@ -2,6 +2,7 @@ package sheets
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type SheetsHandlerDeps = common.HandlerDeps[SheetsService]
 func NewSheetsService(ctx context.Context, client *http.Client) (SheetsService, error) {
 	srv, err := sheets.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating sheets service: %w", err)
 	}
 	return NewRealSheetsService(srv), nil
 }

--- a/internal/slides/slides_handlers.go
+++ b/internal/slides/slides_handlers.go
@@ -2,6 +2,7 @@ package slides
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type SlidesHandlerDeps = common.HandlerDeps[SlidesService]
 func NewSlidesService(ctx context.Context, client *http.Client) (SlidesService, error) {
 	srv, err := slides.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating slides service: %w", err)
 	}
 	return NewRealSlidesService(srv), nil
 }

--- a/internal/slides/slides_service.go
+++ b/internal/slides/slides_service.go
@@ -3,6 +3,7 @@ package slides
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"google.golang.org/api/slides/v1"
 )
@@ -155,7 +156,7 @@ func formatPage(page *slides.Page) map[string]any {
 func parseBatchUpdateRequests(requestsJSON string) ([]*slides.Request, error) {
 	var requests []*slides.Request
 	if err := json.Unmarshal([]byte(requestsJSON), &requests); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing slides batch update requests: %w", err)
 	}
 	return requests, nil
 }

--- a/internal/tasks/tasks_handlers.go
+++ b/internal/tasks/tasks_handlers.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -17,7 +18,7 @@ type TasksHandlerDeps = common.HandlerDeps[TasksService]
 func NewTasksService(ctx context.Context, client *http.Client) (TasksService, error) {
 	srv, err := tasks.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating tasks service: %w", err)
 	}
 	return NewRealTasksService(srv), nil
 }


### PR DESCRIPTION
## Summary
- Wrap all remaining bare `return err` and `return nil, err` statements with `fmt.Errorf` context across 24 files
- Adds operation names to error chains for diagnosis without debug logging
- check.go probe functions left as-is since `makeAPICheck` already wraps them

Closes aliwatters/gsuite-mcp#118
Closes aliwatters/gsuite-mcp#122

Note: #122 (extract chunker from CitationService god class) was already fully addressed by PR #117. Verified: `chunker.go` exists (259 lines), `citation_service.go` is 409 lines (under 500), `DocumentChunker` interface + `chunking_test.go` present.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 17 packages pass
- [x] Zero remaining `return nil, err` in non-test, non-mock code
- [x] Only 7 remaining `return err` — all in check.go probes (already wrapped by caller)