### PR TITLE
refactor: DI, global state removal, DRY unification

### DIFF
--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -135,13 +135,23 @@ func initializeApp() error {
 		AuthManager:       authManager,
 		DriveAccessFilter: driveFilter,
 	}
+	// SetDeps retained for backward compatibility with WithDriveAccessCheck/WithLargeContentHint
+	// middleware that may receive nil deps. All handler factories now use explicit passing below.
 	common.SetDeps(appDeps)
 
-	// Initialize handler deps with explicit dependency passing to avoid global singleton reads.
+	// Initialize ALL handler deps with explicit dependency passing to avoid global singleton reads.
 	drive.InitDefaultDriveHandlerDeps(appDeps)
 	gmail.InitDefaultGmailHandlerDeps(appDeps)
 	docs.InitDefaultDocsHandlerDeps(appDeps)
 	sheets.InitDefaultSheetsHandlerDeps(appDeps)
+	calendar.InitDefaultCalendarHandlerDeps(appDeps)
+	chat.InitDefaultChatHandlerDeps(appDeps)
+	contacts.InitDefaultContactsHandlerDeps(appDeps)
+	driveactivity.InitDefaultDriveActivityHandlerDeps(appDeps)
+	forms.InitDefaultFormsHandlerDeps(appDeps)
+	meet.InitDefaultMeetHandlerDeps(appDeps)
+	slides.InitDefaultSlidesHandlerDeps(appDeps)
+	tasks.InitDefaultTasksHandlerDeps(appDeps)
 
 	return nil
 }

--- a/internal/calendar/calendar_handlers.go
+++ b/internal/calendar/calendar_handlers.go
@@ -22,7 +22,14 @@ func NewCalendarService(ctx context.Context, client *http.Client) (CalendarServi
 	return NewRealCalendarService(srv), nil
 }
 
+// InitDefaultCalendarHandlerDeps initializes the default Calendar handler deps with explicit deps,
+// avoiding reliance on the global singleton at call time.
+func InitDefaultCalendarHandlerDeps(appDeps *common.Deps) {
+	DefaultCalendarHandlerDeps = common.NewDefaultHandlerDeps(NewCalendarService, appDeps)
+}
+
 // DefaultCalendarHandlerDeps holds the default dependencies for production use.
+// Initialize with InitDefaultCalendarHandlerDeps after SetDeps to pass deps explicitly.
 var DefaultCalendarHandlerDeps = common.NewDefaultHandlerDeps(NewCalendarService)
 
 // ResolveCalendarServiceOrError resolves a Calendar service, returning an MCP error result on failure.

--- a/internal/calendar/calendar_service_mock.go
+++ b/internal/calendar/calendar_service_mock.go
@@ -32,13 +32,13 @@ func NewMockCalendarService() *MockCalendarService {
 	}
 }
 
-func (m *MockCalendarService) recordCall(method string, args map[string]any) {
+func (m *MockCalendarService) recordCall(method string, args ...any) {
 	m.MethodCalls = append(m.MethodCalls, MethodCall{Method: method, Args: args})
 }
 
 // ListCalendars returns all calendars.
 func (m *MockCalendarService) ListCalendars(ctx context.Context, fields string) (*calendar.CalendarList, error) {
-	m.recordCall("ListCalendars", map[string]any{"fields": fields})
+	m.recordCall("ListCalendars", fields)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -53,7 +53,7 @@ func (m *MockCalendarService) ListCalendars(ctx context.Context, fields string) 
 
 // ListEvents returns events from a calendar.
 func (m *MockCalendarService) ListEvents(ctx context.Context, calendarID string, opts *ListEventsOptions) (*calendar.Events, error) {
-	m.recordCall("ListEvents", map[string]any{"calendarID": calendarID, "opts": opts})
+	m.recordCall("ListEvents", calendarID, opts)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -73,7 +73,7 @@ func (m *MockCalendarService) ListEvents(ctx context.Context, calendarID string,
 
 // GetEvent returns an event by ID.
 func (m *MockCalendarService) GetEvent(ctx context.Context, calendarID string, eventID string, fields string) (*calendar.Event, error) {
-	m.recordCall("GetEvent", map[string]any{"calendarID": calendarID, "eventID": eventID, "fields": fields})
+	m.recordCall("GetEvent", calendarID, eventID, fields)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -93,7 +93,7 @@ func (m *MockCalendarService) GetEvent(ctx context.Context, calendarID string, e
 
 // CreateEvent creates a new event.
 func (m *MockCalendarService) CreateEvent(ctx context.Context, calendarID string, event *calendar.Event, conferenceDataVersion int) (*calendar.Event, error) {
-	m.recordCall("CreateEvent", map[string]any{"calendarID": calendarID, "summary": event.Summary, "conferenceDataVersion": conferenceDataVersion})
+	m.recordCall("CreateEvent", calendarID, event.Summary, conferenceDataVersion)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -116,7 +116,7 @@ func (m *MockCalendarService) CreateEvent(ctx context.Context, calendarID string
 
 // UpdateEvent updates an existing event.
 func (m *MockCalendarService) UpdateEvent(ctx context.Context, calendarID string, eventID string, event *calendar.Event) (*calendar.Event, error) {
-	m.recordCall("UpdateEvent", map[string]any{"calendarID": calendarID, "eventID": eventID})
+	m.recordCall("UpdateEvent", calendarID, eventID)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -140,7 +140,7 @@ func (m *MockCalendarService) UpdateEvent(ctx context.Context, calendarID string
 
 // DeleteEvent deletes an event.
 func (m *MockCalendarService) DeleteEvent(ctx context.Context, calendarID string, eventID string) error {
-	m.recordCall("DeleteEvent", map[string]any{"calendarID": calendarID, "eventID": eventID})
+	m.recordCall("DeleteEvent", calendarID, eventID)
 	if m.Error != nil {
 		return m.Error
 	}
@@ -160,7 +160,7 @@ func (m *MockCalendarService) DeleteEvent(ctx context.Context, calendarID string
 
 // QuickAddEvent creates an event from text.
 func (m *MockCalendarService) QuickAddEvent(ctx context.Context, calendarID string, text string) (*calendar.Event, error) {
-	m.recordCall("QuickAddEvent", map[string]any{"calendarID": calendarID, "text": text})
+	m.recordCall("QuickAddEvent", calendarID, text)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -174,7 +174,7 @@ func (m *MockCalendarService) QuickAddEvent(ctx context.Context, calendarID stri
 
 // ListInstances lists instances of a recurring event.
 func (m *MockCalendarService) ListInstances(ctx context.Context, calendarID string, eventID string, opts *ListInstancesOptions) (*calendar.Events, error) {
-	m.recordCall("ListInstances", map[string]any{"calendarID": calendarID, "eventID": eventID, "opts": opts})
+	m.recordCall("ListInstances", calendarID, eventID, opts)
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -197,7 +197,7 @@ func (m *MockCalendarService) ListInstances(ctx context.Context, calendarID stri
 
 // GetFreeBusy queries free/busy information.
 func (m *MockCalendarService) GetFreeBusy(ctx context.Context, req *calendar.FreeBusyRequest) (*calendar.FreeBusyResponse, error) {
-	m.recordCall("GetFreeBusy", map[string]any{"timeMin": req.TimeMin, "timeMax": req.TimeMax})
+	m.recordCall("GetFreeBusy", req.TimeMin, req.TimeMax)
 	if m.Error != nil {
 		return nil, m.Error
 	}

--- a/internal/chat/chat_handlers.go
+++ b/internal/chat/chat_handlers.go
@@ -22,6 +22,11 @@ func NewChatService(ctx context.Context, client *http.Client) (ChatService, erro
 	return NewRealChatService(srv), nil
 }
 
+// InitDefaultChatHandlerDeps initializes the default Chat handler deps with explicit deps.
+func InitDefaultChatHandlerDeps(appDeps *common.Deps) {
+	DefaultChatHandlerDeps = common.NewDefaultHandlerDeps(NewChatService, appDeps)
+}
+
 // DefaultChatHandlerDeps holds the default dependencies for production use.
 var DefaultChatHandlerDeps = common.NewDefaultHandlerDeps(NewChatService)
 

--- a/internal/citation/citation_deps.go
+++ b/internal/citation/citation_deps.go
@@ -1,0 +1,136 @@
+package citation
+
+import (
+	"context"
+	"io"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/sheets/v4"
+	gslides "google.golang.org/api/slides/v1"
+)
+
+// CitationDriveService defines the Drive operations used by the citation package.
+// Keeping this interface minimal (only methods actually called) enables testability
+// without mocking the entire Drive API.
+type CitationDriveService interface {
+	// GetFile retrieves file metadata by ID.
+	GetFile(ctx context.Context, fileID string, fields string) (*drive.File, error)
+
+	// DownloadFile downloads a file's raw content.
+	DownloadFile(ctx context.Context, fileID string) (io.ReadCloser, error)
+
+	// ExportFile exports a Google Workspace file to the specified MIME type.
+	ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error)
+
+	// MoveFile moves a file to a new parent folder.
+	MoveFile(ctx context.Context, fileID string, addParents string) (*drive.File, error)
+}
+
+// CitationSheetsService defines the Sheets operations used by the citation package.
+type CitationSheetsService interface {
+	// CreateSpreadsheet creates a new spreadsheet.
+	CreateSpreadsheet(ctx context.Context, ss *sheets.Spreadsheet) (*sheets.Spreadsheet, error)
+
+	// BatchUpdateValues writes multiple ranges of values.
+	BatchUpdateValues(ctx context.Context, sheetID string, req *sheets.BatchUpdateValuesRequest) error
+
+	// AppendValues appends rows to a sheet range.
+	AppendValues(ctx context.Context, sheetID, rangeStr string, vr *sheets.ValueRange) error
+
+	// GetValues reads values from a sheet range.
+	GetValues(ctx context.Context, sheetID, rangeStr string) (*sheets.ValueRange, error)
+
+	// UpdateValues writes values to a specific range (overwrites existing data).
+	UpdateValues(ctx context.Context, sheetID, rangeStr string, vr *sheets.ValueRange) error
+
+	// ClearValues clears values from a sheet range.
+	ClearValues(ctx context.Context, sheetID, rangeStr string) error
+}
+
+// CitationSlidesService defines the Slides operations used by the citation package.
+type CitationSlidesService interface {
+	// GetPresentation retrieves a presentation by ID.
+	GetPresentation(ctx context.Context, presentationID string) (*gslides.Presentation, error)
+}
+
+// realCitationDriveService wraps *drive.Service to implement CitationDriveService.
+type realCitationDriveService struct {
+	svc *drive.Service
+}
+
+func (r *realCitationDriveService) GetFile(ctx context.Context, fileID string, fields string) (*drive.File, error) {
+	call := r.svc.Files.Get(fileID).SupportsAllDrives(true).Context(ctx)
+	if fields != "" {
+		call = call.Fields(googleapi.Field(fields))
+	}
+	return call.Do()
+}
+
+func (r *realCitationDriveService) DownloadFile(ctx context.Context, fileID string) (io.ReadCloser, error) {
+	resp, err := r.svc.Files.Get(fileID).SupportsAllDrives(true).Context(ctx).Download()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+func (r *realCitationDriveService) ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error) {
+	resp, err := r.svc.Files.Export(fileID, mimeType).Context(ctx).Download()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+func (r *realCitationDriveService) MoveFile(ctx context.Context, fileID string, addParents string) (*drive.File, error) {
+	return r.svc.Files.Update(fileID, nil).
+		AddParents(addParents).
+		SupportsAllDrives(true).
+		Context(ctx).Do()
+}
+
+// realCitationSheetsService wraps *sheets.Service to implement CitationSheetsService.
+type realCitationSheetsService struct {
+	svc *sheets.Service
+}
+
+func (r *realCitationSheetsService) CreateSpreadsheet(ctx context.Context, ss *sheets.Spreadsheet) (*sheets.Spreadsheet, error) {
+	return r.svc.Spreadsheets.Create(ss).Context(ctx).Do()
+}
+
+func (r *realCitationSheetsService) BatchUpdateValues(ctx context.Context, sheetID string, req *sheets.BatchUpdateValuesRequest) error {
+	_, err := r.svc.Spreadsheets.Values.BatchUpdate(sheetID, req).Context(ctx).Do()
+	return err
+}
+
+func (r *realCitationSheetsService) AppendValues(ctx context.Context, sheetID, rangeStr string, vr *sheets.ValueRange) error {
+	_, err := r.svc.Spreadsheets.Values.Append(sheetID, rangeStr, vr).
+		ValueInputOption("RAW").Context(ctx).Do()
+	return err
+}
+
+func (r *realCitationSheetsService) GetValues(ctx context.Context, sheetID, rangeStr string) (*sheets.ValueRange, error) {
+	return r.svc.Spreadsheets.Values.Get(sheetID, rangeStr).Context(ctx).Do()
+}
+
+func (r *realCitationSheetsService) UpdateValues(ctx context.Context, sheetID, rangeStr string, vr *sheets.ValueRange) error {
+	_, err := r.svc.Spreadsheets.Values.Update(sheetID, rangeStr, vr).
+		ValueInputOption("RAW").Context(ctx).Do()
+	return err
+}
+
+func (r *realCitationSheetsService) ClearValues(ctx context.Context, sheetID, rangeStr string) error {
+	_, err := r.svc.Spreadsheets.Values.Clear(sheetID, rangeStr, &sheets.ClearValuesRequest{}).
+		Context(ctx).Do()
+	return err
+}
+
+// realCitationSlidesService wraps *gslides.Service to implement CitationSlidesService.
+type realCitationSlidesService struct {
+	svc *gslides.Service
+}
+
+func (r *realCitationSlidesService) GetPresentation(ctx context.Context, presentationID string) (*gslides.Presentation, error) {
+	return r.svc.Presentations.Get(presentationID).Context(ctx).Do()
+}

--- a/internal/citation/citation_deps_test.go
+++ b/internal/citation/citation_deps_test.go
@@ -1,0 +1,178 @@
+package citation
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/sheets/v4"
+	gslides "google.golang.org/api/slides/v1"
+)
+
+// mockCitationDrive implements CitationDriveService for tests.
+type mockCitationDrive struct {
+	files map[string]*drive.File
+}
+
+func (m *mockCitationDrive) GetFile(_ context.Context, fileID string, _ string) (*drive.File, error) {
+	if f, ok := m.files[fileID]; ok {
+		return f, nil
+	}
+	return nil, io.ErrUnexpectedEOF
+}
+
+func (m *mockCitationDrive) DownloadFile(_ context.Context, fileID string) (io.ReadCloser, error) {
+	if f, ok := m.files[fileID]; ok {
+		return io.NopCloser(strings.NewReader("content of " + f.Name)), nil
+	}
+	return nil, io.ErrUnexpectedEOF
+}
+
+func (m *mockCitationDrive) ExportFile(_ context.Context, fileID string, _ string) (io.ReadCloser, error) {
+	if f, ok := m.files[fileID]; ok {
+		return io.NopCloser(strings.NewReader("exported " + f.Name)), nil
+	}
+	return nil, io.ErrUnexpectedEOF
+}
+
+func (m *mockCitationDrive) MoveFile(_ context.Context, fileID string, _ string) (*drive.File, error) {
+	if f, ok := m.files[fileID]; ok {
+		return f, nil
+	}
+	return nil, io.ErrUnexpectedEOF
+}
+
+// mockCitationSheets implements CitationSheetsService for tests.
+type mockCitationSheets struct {
+	created *sheets.Spreadsheet
+}
+
+func (m *mockCitationSheets) CreateSpreadsheet(_ context.Context, ss *sheets.Spreadsheet) (*sheets.Spreadsheet, error) {
+	ss.SpreadsheetId = "mock-sheet-id"
+	m.created = ss
+	return ss, nil
+}
+
+func (m *mockCitationSheets) BatchUpdateValues(_ context.Context, _ string, _ *sheets.BatchUpdateValuesRequest) error {
+	return nil
+}
+
+func (m *mockCitationSheets) AppendValues(_ context.Context, _, _ string, _ *sheets.ValueRange) error {
+	return nil
+}
+
+func (m *mockCitationSheets) GetValues(_ context.Context, _, _ string) (*sheets.ValueRange, error) {
+	return &sheets.ValueRange{}, nil
+}
+
+func (m *mockCitationSheets) UpdateValues(_ context.Context, _, _ string, _ *sheets.ValueRange) error {
+	return nil
+}
+
+func (m *mockCitationSheets) ClearValues(_ context.Context, _, _ string) error {
+	return nil
+}
+
+// mockCitationSlides implements CitationSlidesService for tests.
+type mockCitationSlides struct{}
+
+func (m *mockCitationSlides) GetPresentation(_ context.Context, _ string) (*gslides.Presentation, error) {
+	return &gslides.Presentation{
+		Slides: []*gslides.Page{
+			{
+				PageElements: []*gslides.PageElement{
+					{Shape: &gslides.Shape{Text: &gslides.TextContent{
+						TextElements: []*gslides.TextElement{
+							{TextRun: &gslides.TextRun{Content: "Slide 1 content"}},
+						},
+					}}},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestNewRealCitationServiceWithDeps_AddDocuments(t *testing.T) {
+	ctx := context.Background()
+
+	mockDrive := &mockCitationDrive{
+		files: map[string]*drive.File{
+			"f1": {Id: "f1", Name: "report.txt", MimeType: "text/plain", ModifiedTime: "2026-01-01T00:00:00Z"},
+		},
+	}
+	mockSheets := &mockCitationSheets{}
+
+	svc := NewRealCitationServiceWithDeps(mockDrive, mockSheets, &mockCitationSlides{}, &CitationConfig{
+		Indexes: map[string]IndexEntry{"idx1": {SheetID: "sheet1"}},
+	})
+
+	// Pre-populate a store so we don't hit real Sheets for DualStore creation
+	sqlite, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer sqlite.Close()
+	svc.stores["idx1"] = &DualStore{indexID: "idx1", sheets: NewSheetsStore(mockSheets, "sheet1"), sqlite: sqlite}
+
+	count, err := svc.AddDocuments(ctx, "idx1", []string{"f1"})
+	if err != nil {
+		t.Fatalf("AddDocuments: %v", err)
+	}
+	if count == 0 {
+		t.Error("expected at least 1 chunk from text file")
+	}
+}
+
+func TestNewRealCitationServiceWithDeps_CreateIndex(t *testing.T) {
+	ctx := context.Background()
+
+	mockDrive := &mockCitationDrive{files: make(map[string]*drive.File)}
+	mockSheets := &mockCitationSheets{}
+
+	svc := NewRealCitationServiceWithDeps(mockDrive, mockSheets, &mockCitationSlides{}, nil)
+
+	info, err := svc.CreateIndex(ctx, "test-index", "")
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if info.IndexID != "test-index" {
+		t.Errorf("expected index_id=test-index, got %q", info.IndexID)
+	}
+	if info.SheetID != "mock-sheet-id" {
+		t.Errorf("expected sheet_id=mock-sheet-id, got %q", info.SheetID)
+	}
+}
+
+func TestNewRealCitationServiceWithDeps_ChunkSlides(t *testing.T) {
+	ctx := context.Background()
+
+	mockDrive := &mockCitationDrive{
+		files: map[string]*drive.File{
+			"pres1": {Id: "pres1", Name: "deck.gslides", MimeType: "application/vnd.google-apps.presentation", ModifiedTime: "2026-01-01T00:00:00Z"},
+		},
+	}
+	mockSheets := &mockCitationSheets{}
+	mockSlides := &mockCitationSlides{}
+
+	svc := NewRealCitationServiceWithDeps(mockDrive, mockSheets, mockSlides, &CitationConfig{
+		Indexes: map[string]IndexEntry{"idx1": {SheetID: "sheet1"}},
+	})
+
+	// Pre-populate store
+	sqlite, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer sqlite.Close()
+	svc.stores["idx1"] = &DualStore{indexID: "idx1", sheets: NewSheetsStore(mockSheets, "sheet1"), sqlite: sqlite}
+
+	count, err := svc.AddDocuments(ctx, "idx1", []string{"pres1"})
+	if err != nil {
+		t.Fatalf("AddDocuments (slides): %v", err)
+	}
+	if count == 0 {
+		t.Error("expected at least 1 chunk from slides presentation")
+	}
+}

--- a/internal/citation/citation_service.go
+++ b/internal/citation/citation_service.go
@@ -14,6 +14,13 @@ import (
 	gslides "google.golang.org/api/slides/v1"
 )
 
+// Compile-time interface satisfaction checks.
+var (
+	_ CitationDriveService  = (*realCitationDriveService)(nil)
+	_ CitationSheetsService = (*realCitationSheetsService)(nil)
+	_ CitationSlidesService = (*realCitationSlidesService)(nil)
+)
+
 // CitationService is the interface for all citation operations.
 type CitationService interface {
 	// CreateIndex creates a new index Sheet in the given folder.
@@ -52,12 +59,12 @@ type CitationService interface {
 
 // RealCitationService implements CitationService using Google APIs.
 type RealCitationService struct {
-	driveService  *drive.Service
-	sheetsService *sheets.Service
-	slidesService *gslides.Service
-	mu            sync.RWMutex
-	stores        map[string]*DualStore // indexID → store
-	config        *CitationConfig
+	drive  CitationDriveService
+	sheets CitationSheetsService
+	slides CitationSlidesService
+	mu     sync.RWMutex
+	stores map[string]*DualStore // indexID → store
+	config *CitationConfig
 }
 
 // CitationConfig holds citation-specific configuration.
@@ -90,12 +97,27 @@ func NewRealCitationService(ctx context.Context, client *http.Client, cfg *Citat
 	}
 
 	return &RealCitationService{
-		driveService:  driveSrv,
-		sheetsService: sheetsSrv,
-		slidesService: slidesSrv,
-		stores:        make(map[string]*DualStore),
-		config:        cfg,
+		drive:  &realCitationDriveService{svc: driveSrv},
+		sheets: &realCitationSheetsService{svc: sheetsSrv},
+		slides: &realCitationSlidesService{svc: slidesSrv},
+		stores: make(map[string]*DualStore),
+		config: cfg,
 	}, nil
+}
+
+// NewRealCitationServiceWithDeps creates a citation service from pre-built interface
+// implementations. This constructor is used in tests with mocked dependencies.
+func NewRealCitationServiceWithDeps(driveSvc CitationDriveService, sheetsSvc CitationSheetsService, slidesSvc CitationSlidesService, cfg *CitationConfig) *RealCitationService {
+	if cfg == nil {
+		cfg = &CitationConfig{Indexes: make(map[string]IndexEntry)}
+	}
+	return &RealCitationService{
+		drive:  driveSvc,
+		sheets: sheetsSvc,
+		slides: slidesSvc,
+		stores: make(map[string]*DualStore),
+		config: cfg,
+	}
 }
 
 func (s *RealCitationService) getStore(ctx context.Context, indexID string) (*DualStore, error) {
@@ -111,7 +133,7 @@ func (s *RealCitationService) getStore(ctx context.Context, indexID string) (*Du
 		return nil, fmt.Errorf("unknown index %q — add it to config", indexID)
 	}
 
-	store, err := NewDualStore(ctx, indexID, entry.SheetID, s.sheetsService)
+	store, err := NewDualStore(ctx, indexID, entry.SheetID, s.sheets)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +172,7 @@ func (s *RealCitationService) AddDocuments(ctx context.Context, indexID string, 
 	for i, fileID := range fileIDs {
 		i, fileID := i, fileID // capture loop vars
 		g.Go(func() error {
-			file, err := s.driveService.Files.Get(fileID).
-				Fields("id,name,mimeType,modifiedTime").
-				SupportsAllDrives(true).
-				Context(gCtx).Do()
+			file, err := s.drive.GetFile(gCtx, fileID, "id,name,mimeType,modifiedTime")
 			if err != nil {
 				results[i] = addDocResult{fileID: fileID, err: fmt.Errorf("getting file %s: %w", fileID, err)}
 				return nil // partial failure — keep going
@@ -242,7 +261,7 @@ func (s *RealCitationService) chunkFile(ctx context.Context, file *drive.File) (
 
 // chunkSlides extracts per-slide text from a Google Slides presentation via the Slides API.
 func (s *RealCitationService) chunkSlides(ctx context.Context, file *drive.File) ([]Chunk, error) {
-	pres, err := s.slidesService.Presentations.Get(file.Id).Context(ctx).Do()
+	pres, err := s.slides.GetPresentation(ctx, file.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -252,13 +271,13 @@ func (s *RealCitationService) chunkSlides(ctx context.Context, file *drive.File)
 // chunkDownloadedFile downloads a non-Google-native file and extracts text.
 // For .pptx files, reads text from XML inside the zip. For others, treats content as plain text.
 func (s *RealCitationService) chunkDownloadedFile(ctx context.Context, file *drive.File) ([]Chunk, error) {
-	resp, err := s.driveService.Files.Get(file.Id).SupportsAllDrives(true).Context(ctx).Download()
+	body, err := s.drive.DownloadFile(ctx, file.Id)
 	if err != nil {
 		return nil, fmt.Errorf("downloading %s: %w", file.Name, err)
 	}
-	defer resp.Body.Close()
+	defer body.Close()
 
-	data, err := limitedRead(resp.Body)
+	data, err := limitedRead(body)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", file.Name, err)
 	}
@@ -274,13 +293,13 @@ func (s *RealCitationService) chunkPptxBytes(file *drive.File, data []byte) ([]C
 
 // chunkExportedText exports a Google-native file as plain text and splits into chunks.
 func (s *RealCitationService) chunkExportedText(ctx context.Context, file *drive.File) ([]Chunk, error) {
-	resp, err := s.driveService.Files.Export(file.Id, "text/plain").Context(ctx).Download()
+	body, err := s.drive.ExportFile(ctx, file.Id, "text/plain")
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer body.Close()
 
-	data, err := limitedRead(resp.Body)
+	data, err := limitedRead(body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/citation/index_create.go
+++ b/internal/citation/index_create.go
@@ -23,17 +23,14 @@ func (s *RealCitationService) CreateIndex(ctx context.Context, name, folderID st
 			{Properties: &sheets.SheetProperties{Title: "metadata"}},
 		},
 	}
-	created, err := s.sheetsService.Spreadsheets.Create(ss).Context(ctx).Do()
+	created, err := s.sheets.CreateSpreadsheet(ctx, ss)
 	if err != nil {
 		return nil, fmt.Errorf("creating index sheet: %w", err)
 	}
 
 	// Move to folder if specified
 	if folderID != "" {
-		_, err = s.driveService.Files.Update(created.SpreadsheetId, nil).
-			AddParents(folderID).
-			SupportsAllDrives(true).
-			Context(ctx).Do()
+		_, err = s.drive.MoveFile(ctx, created.SpreadsheetId, folderID)
 		if err != nil {
 			return nil, fmt.Errorf("moving sheet to folder: %w", err)
 		}
@@ -51,10 +48,10 @@ func (s *RealCitationService) CreateIndex(ctx context.Context, name, folderID st
 	for r, v := range headers {
 		data = append(data, &sheets.ValueRange{Range: r, Values: v})
 	}
-	_, err = s.sheetsService.Spreadsheets.Values.BatchUpdate(created.SpreadsheetId, &sheets.BatchUpdateValuesRequest{
+	err = s.sheets.BatchUpdateValues(ctx, created.SpreadsheetId, &sheets.BatchUpdateValuesRequest{
 		ValueInputOption: "RAW",
 		Data:             data,
-	}).Context(ctx).Do()
+	})
 	if err != nil {
 		return nil, fmt.Errorf("writing headers: %w", err)
 	}
@@ -68,9 +65,9 @@ func (s *RealCitationService) CreateIndex(ctx context.Context, name, folderID st
 		{"doc_count", "0"},
 		{"chunk_count", "0"},
 	}
-	_, err = s.sheetsService.Spreadsheets.Values.Append(created.SpreadsheetId, "metadata!A2", &sheets.ValueRange{
+	err = s.sheets.AppendValues(ctx, created.SpreadsheetId, "metadata!A2", &sheets.ValueRange{
 		Values: metaRows,
-	}).ValueInputOption("RAW").Context(ctx).Do()
+	})
 	if err != nil {
 		return nil, fmt.Errorf("writing metadata: %w", err)
 	}

--- a/internal/citation/index_refresh.go
+++ b/internal/citation/index_refresh.go
@@ -39,10 +39,7 @@ func (s *RealCitationService) RefreshIndex(ctx context.Context, indexID string) 
 	for i, prev := range indexed {
 		i, prev := i, prev
 		g.Go(func() error {
-			current, err := s.driveService.Files.Get(prev.FileID).
-				Fields("id,name,mimeType,modifiedTime,trashed").
-				SupportsAllDrives(true).
-				Context(gCtx).Do()
+			current, err := s.drive.GetFile(gCtx, prev.FileID, "id,name,mimeType,modifiedTime,trashed")
 			fileResults[i] = refreshFileResult{prev: prev, current: current, err: err}
 			return nil // partial failure — keep going
 		})

--- a/internal/citation/store_dual.go
+++ b/internal/citation/store_dual.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"google.golang.org/api/sheets/v4"
 )
 
 // DualStore writes to both Sheets (source of truth) and SQLite (fast local cache).
@@ -27,8 +25,8 @@ func cacheDir() (string, error) {
 }
 
 // NewDualStore creates a DualStore, rebuilding the SQLite cache from Sheets if needed.
-func NewDualStore(ctx context.Context, indexID, sheetID string, sheetsSrv *sheets.Service) (*DualStore, error) {
-	sheetsStore := NewSheetsStore(sheetsSrv, sheetID)
+func NewDualStore(ctx context.Context, indexID, sheetID string, sheetsSvc CitationSheetsService) (*DualStore, error) {
+	sheetsStore := NewSheetsStore(sheetsSvc, sheetID)
 
 	dir, err := cacheDir()
 	if err != nil {

--- a/internal/citation/store_sheets.go
+++ b/internal/citation/store_sheets.go
@@ -14,13 +14,13 @@ import (
 // SheetsStore reads/writes citation data to a Google Sheet.
 // Not a full IndexStore — used by DualStore for the write path and rebuild.
 type SheetsStore struct {
-	sheetsSrv *sheets.Service
-	sheetID   string
+	svc     CitationSheetsService
+	sheetID string
 }
 
 // NewSheetsStore creates a SheetsStore for the given spreadsheet.
-func NewSheetsStore(srv *sheets.Service, sheetID string) *SheetsStore {
-	return &SheetsStore{sheetsSrv: srv, sheetID: sheetID}
+func NewSheetsStore(svc CitationSheetsService, sheetID string) *SheetsStore {
+	return &SheetsStore{svc: svc, sheetID: sheetID}
 }
 
 // AppendChunks appends chunk rows to the chunks tab.
@@ -29,10 +29,7 @@ func (s *SheetsStore) AppendChunks(ctx context.Context, chunks []Chunk) error {
 	for _, c := range chunks {
 		rows = append(rows, ChunkToSheetRow(c))
 	}
-	_, err := s.sheetsSrv.Spreadsheets.Values.Append(s.sheetID, "chunks!A2", &sheets.ValueRange{
-		Values: rows,
-	}).ValueInputOption("RAW").Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.AppendValues(ctx, s.sheetID, "chunks!A2", &sheets.ValueRange{Values: rows}); err != nil {
 		return fmt.Errorf("appending chunks to sheet: %w", err)
 	}
 	return nil
@@ -45,10 +42,7 @@ func (s *SheetsStore) AppendConcepts(ctx context.Context, mappings []ConceptMapp
 		chunkIDsJSON, _ := json.Marshal(m.ChunkIDs)
 		rows = append(rows, []any{m.Concept, string(chunkIDsJSON)})
 	}
-	_, err := s.sheetsSrv.Spreadsheets.Values.Append(s.sheetID, "concepts!A2", &sheets.ValueRange{
-		Values: rows,
-	}).ValueInputOption("RAW").Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.AppendValues(ctx, s.sheetID, "concepts!A2", &sheets.ValueRange{Values: rows}); err != nil {
 		return fmt.Errorf("appending concepts to sheet: %w", err)
 	}
 	return nil
@@ -57,10 +51,7 @@ func (s *SheetsStore) AppendConcepts(ctx context.Context, mappings []ConceptMapp
 // AppendSummary appends a summary row to the summaries tab.
 func (s *SheetsStore) AppendSummary(ctx context.Context, summary LevelSummary) error {
 	row := [][]any{{summary.Level, summary.ParentID, summary.Summary}}
-	_, err := s.sheetsSrv.Spreadsheets.Values.Append(s.sheetID, "summaries!A2", &sheets.ValueRange{
-		Values: row,
-	}).ValueInputOption("RAW").Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.AppendValues(ctx, s.sheetID, "summaries!A2", &sheets.ValueRange{Values: row}); err != nil {
 		return fmt.Errorf("appending summary to sheet: %w", err)
 	}
 	return nil
@@ -68,7 +59,7 @@ func (s *SheetsStore) AppendSummary(ctx context.Context, summary LevelSummary) e
 
 // ReadAllChunks reads all chunk rows from the Sheet.
 func (s *SheetsStore) ReadAllChunks(ctx context.Context) ([]Chunk, error) {
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "chunks!A2:K").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "chunks!A2:K")
 	if err != nil {
 		return nil, fmt.Errorf("reading chunks: %w", err)
 	}
@@ -82,7 +73,7 @@ func (s *SheetsStore) ReadAllChunks(ctx context.Context) ([]Chunk, error) {
 
 // ReadAllConcepts reads all concept rows from the Sheet.
 func (s *SheetsStore) ReadAllConcepts(ctx context.Context) ([]ConceptMapping, error) {
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "concepts!A2:B").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "concepts!A2:B")
 	if err != nil {
 		return nil, fmt.Errorf("reading concepts: %w", err)
 	}
@@ -103,7 +94,7 @@ func (s *SheetsStore) ReadAllConcepts(ctx context.Context) ([]ConceptMapping, er
 
 // ReadAllSummaries reads all summary rows from the Sheet.
 func (s *SheetsStore) ReadAllSummaries(ctx context.Context) ([]LevelSummary, error) {
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "summaries!A2:C").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "summaries!A2:C")
 	if err != nil {
 		return nil, fmt.Errorf("reading summaries: %w", err)
 	}
@@ -136,7 +127,7 @@ func (s *SheetsStore) ReadAllSummaries(ctx context.Context) ([]LevelSummary, err
 
 // ReadAllMetadata reads all metadata rows from the Sheet.
 func (s *SheetsStore) ReadAllMetadata(ctx context.Context) (map[string]string, error) {
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "metadata!A2:B").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "metadata!A2:B")
 	if err != nil {
 		return nil, fmt.Errorf("reading metadata: %w", err)
 	}
@@ -159,10 +150,7 @@ func (s *SheetsStore) AppendFiles(ctx context.Context, files []IndexedFile) erro
 	for _, f := range files {
 		rows = append(rows, []any{f.FileID, f.FileName, f.MimeType, f.ModifiedTime, f.ChunkCount})
 	}
-	_, err := s.sheetsSrv.Spreadsheets.Values.Append(s.sheetID, "files!A2", &sheets.ValueRange{
-		Values: rows,
-	}).ValueInputOption("RAW").Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.AppendValues(ctx, s.sheetID, "files!A2", &sheets.ValueRange{Values: rows}); err != nil {
 		return fmt.Errorf("appending files to sheet: %w", err)
 	}
 	return nil
@@ -170,7 +158,7 @@ func (s *SheetsStore) AppendFiles(ctx context.Context, files []IndexedFile) erro
 
 // ReadAllFiles reads all indexed file tracking rows from the Sheet.
 func (s *SheetsStore) ReadAllFiles(ctx context.Context) ([]IndexedFile, error) {
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "files!A2:E").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "files!A2:E")
 	if err != nil {
 		return nil, fmt.Errorf("reading files: %w", err)
 	}
@@ -208,9 +196,7 @@ func (s *SheetsStore) ReadAllFiles(ctx context.Context) ([]IndexedFile, error) {
 
 // RewriteFilesTab clears and rewrites the files tab (used after refresh).
 func (s *SheetsStore) RewriteFilesTab(ctx context.Context, files []IndexedFile) error {
-	// Clear existing data
-	_, err := s.sheetsSrv.Spreadsheets.Values.Clear(s.sheetID, "files!A2:E", &sheets.ClearValuesRequest{}).Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.ClearValues(ctx, s.sheetID, "files!A2:E"); err != nil {
 		return fmt.Errorf("clearing files tab: %w", err)
 	}
 	if len(files) == 0 {
@@ -237,8 +223,7 @@ func (s *SheetsStore) RewriteChunksForFile(ctx context.Context, fileID string) e
 	}
 
 	// Clear and rewrite
-	_, err = s.sheetsSrv.Spreadsheets.Values.Clear(s.sheetID, "chunks!A2:K", &sheets.ClearValuesRequest{}).Context(ctx).Do()
-	if err != nil {
+	if err := s.svc.ClearValues(ctx, s.sheetID, "chunks!A2:K"); err != nil {
 		return fmt.Errorf("clearing chunks tab: %w", err)
 	}
 	if len(remaining) > 0 {
@@ -251,7 +236,7 @@ func (s *SheetsStore) RewriteChunksForFile(ctx context.Context, fileID string) e
 // or appends if not found.
 func (s *SheetsStore) UpdateMetadata(ctx context.Context, key, value string) error {
 	// Read existing metadata to find the row
-	resp, err := s.sheetsSrv.Spreadsheets.Values.Get(s.sheetID, "metadata!A2:B").Context(ctx).Do()
+	resp, err := s.svc.GetValues(ctx, s.sheetID, "metadata!A2:B")
 	if err != nil {
 		return fmt.Errorf("reading metadata: %w", err)
 	}
@@ -262,10 +247,9 @@ func (s *SheetsStore) UpdateMetadata(ctx context.Context, key, value string) err
 			if strings.EqualFold(k, key) {
 				rowNum := i + 2 // 1-indexed, skip header
 				updateRange := fmt.Sprintf("metadata!B%d", rowNum)
-				_, err := s.sheetsSrv.Spreadsheets.Values.Update(s.sheetID, updateRange, &sheets.ValueRange{
+				if err := s.svc.UpdateValues(ctx, s.sheetID, updateRange, &sheets.ValueRange{
 					Values: [][]any{{value}},
-				}).ValueInputOption("RAW").Context(ctx).Do()
-				if err != nil {
+				}); err != nil {
 					return fmt.Errorf("updating metadata %q: %w", key, err)
 				}
 				return nil
@@ -274,10 +258,9 @@ func (s *SheetsStore) UpdateMetadata(ctx context.Context, key, value string) err
 	}
 
 	// Not found — append
-	_, err = s.sheetsSrv.Spreadsheets.Values.Append(s.sheetID, "metadata!A2", &sheets.ValueRange{
+	if err := s.svc.AppendValues(ctx, s.sheetID, "metadata!A2", &sheets.ValueRange{
 		Values: [][]any{{key, value}},
-	}).ValueInputOption("RAW").Context(ctx).Do()
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("appending metadata %q: %w", key, err)
 	}
 	return nil

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -16,15 +16,20 @@ type Deps struct {
 	CitationEnabled   bool // true when large_doc_indexing feature is on
 }
 
-// Global instance set during initialization
+// Global instance set during initialization.
+// Deprecated: All service handlers should receive deps explicitly via Init*HandlerDeps.
+// This global is retained only for middleware (WithDriveAccessCheck, WithLargeContentHint)
+// that receive nil deps as a backward-compatibility fallback.
 var deps *Deps
 
-// SetDeps initializes the global dependencies.
+// SetDeps initializes the global dependencies. Called exactly once during startup.
+// Deprecated: Prefer passing *Deps explicitly to Init*HandlerDeps functions.
 func SetDeps(d *Deps) {
 	deps = d
 }
 
 // GetDeps returns the global dependencies.
+// Deprecated: Prefer receiving *Deps explicitly. This remains for middleware fallback paths.
 func GetDeps() *Deps {
 	return deps
 }

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -5,9 +5,30 @@ import (
 )
 
 // MethodCall records a method call for test verification.
+// Args is a slice to support both positional and named arguments:
+// positional: Args = []any{arg1, arg2}
+// named: Args = []any{map[string]any{"key": value}}
 type MethodCall struct {
 	Method string
-	Args   map[string]any
+	Args   []any
+}
+
+// GetLastCall returns the last call from a slice of MethodCalls, or nil if empty.
+func GetLastCall(calls []MethodCall) *MethodCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	return &calls[len(calls)-1]
+}
+
+// WasMethodCalled checks if a method was called in the given call slice.
+func WasMethodCalled(calls []MethodCall, method string) bool {
+	for _, call := range calls {
+		if call.Method == method {
+			return true
+		}
+	}
+	return false
 }
 
 // CreateMCPRequest creates an MCP request with the given arguments.

--- a/internal/contacts/contacts_handlers.go
+++ b/internal/contacts/contacts_handlers.go
@@ -22,6 +22,11 @@ func NewContactsService(ctx context.Context, client *http.Client) (ContactsServi
 	return NewRealContactsService(srv), nil
 }
 
+// InitDefaultContactsHandlerDeps initializes the default Contacts handler deps with explicit deps.
+func InitDefaultContactsHandlerDeps(appDeps *common.Deps) {
+	DefaultContactsHandlerDeps = common.NewDefaultHandlerDeps(NewContactsService, appDeps)
+}
+
 // DefaultContactsHandlerDeps holds the default dependencies for production use.
 var DefaultContactsHandlerDeps = common.NewDefaultHandlerDeps(NewContactsService)
 

--- a/internal/drive/drive_handlers.go
+++ b/internal/drive/drive_handlers.go
@@ -32,8 +32,9 @@ func NewDriveServiceConstructor(filter *common.DriveAccessFilter) common.Service
 }
 
 // NewDriveService creates a DriveService from an authenticated HTTP client.
-// If a DriveAccessFilter is configured in the global deps, the service is wrapped
-// with access control. Prefer NewDriveServiceConstructor for explicit dependency passing.
+// Deprecated: This function reads from the global deps singleton. Prefer
+// NewDriveServiceConstructor with explicit filter for new code. Retained for
+// backward compatibility with tests that don't call InitDefaultDriveHandlerDeps.
 func NewDriveService(ctx context.Context, client *http.Client) (DriveService, error) {
 	d := common.GetDeps()
 	var filter *common.DriveAccessFilter

--- a/internal/driveactivity/driveactivity_handlers.go
+++ b/internal/driveactivity/driveactivity_handlers.go
@@ -22,6 +22,11 @@ func NewDriveActivityService(ctx context.Context, client *http.Client) (DriveAct
 	return NewRealDriveActivityService(srv), nil
 }
 
+// InitDefaultDriveActivityHandlerDeps initializes the default DriveActivity handler deps with explicit deps.
+func InitDefaultDriveActivityHandlerDeps(appDeps *common.Deps) {
+	DefaultDriveActivityHandlerDeps = common.NewDefaultHandlerDeps(NewDriveActivityService, appDeps)
+}
+
 // DefaultDriveActivityHandlerDeps holds the default dependencies for production use.
 var DefaultDriveActivityHandlerDeps = common.NewDefaultHandlerDeps(NewDriveActivityService)
 

--- a/internal/forms/forms_handlers.go
+++ b/internal/forms/forms_handlers.go
@@ -22,6 +22,11 @@ func NewFormsService(ctx context.Context, client *http.Client) (FormsService, er
 	return NewRealFormsService(srv), nil
 }
 
+// InitDefaultFormsHandlerDeps initializes the default Forms handler deps with explicit deps.
+func InitDefaultFormsHandlerDeps(appDeps *common.Deps) {
+	DefaultFormsHandlerDeps = common.NewDefaultHandlerDeps(NewFormsService, appDeps)
+}
+
 // DefaultFormsHandlerDeps holds the default dependencies for production use.
 var DefaultFormsHandlerDeps = common.NewDefaultHandlerDeps(NewFormsService)
 

--- a/internal/gmail/gmail_service_mock.go
+++ b/internal/gmail/gmail_service_mock.go
@@ -8,11 +8,8 @@ import (
 	"google.golang.org/api/gmail/v1"
 )
 
-// MethodCall records a method invocation for verification in tests.
-type MethodCall struct {
-	Method string
-	Args   []any
-}
+// MethodCall is an alias to common.MethodCall for backward compatibility in tests.
+type MethodCall = common.MethodCall
 
 // MockGmailService is a mock implementation of GmailService for testing.
 type MockGmailService struct {

--- a/internal/meet/meet_handlers.go
+++ b/internal/meet/meet_handlers.go
@@ -22,6 +22,11 @@ func NewMeetService(ctx context.Context, client *http.Client) (MeetService, erro
 	return NewRealMeetService(srv), nil
 }
 
+// InitDefaultMeetHandlerDeps initializes the default Meet handler deps with explicit deps.
+func InitDefaultMeetHandlerDeps(appDeps *common.Deps) {
+	DefaultMeetHandlerDeps = common.NewDefaultHandlerDeps(NewMeetService, appDeps)
+}
+
 // DefaultMeetHandlerDeps holds the default dependencies for production use.
 var DefaultMeetHandlerDeps = common.NewDefaultHandlerDeps(NewMeetService)
 

--- a/internal/slides/slides_handlers.go
+++ b/internal/slides/slides_handlers.go
@@ -22,6 +22,11 @@ func NewSlidesService(ctx context.Context, client *http.Client) (SlidesService, 
 	return NewRealSlidesService(srv), nil
 }
 
+// InitDefaultSlidesHandlerDeps initializes the default Slides handler deps with explicit deps.
+func InitDefaultSlidesHandlerDeps(appDeps *common.Deps) {
+	DefaultSlidesHandlerDeps = common.NewDefaultHandlerDeps(NewSlidesService, appDeps)
+}
+
 // DefaultSlidesHandlerDeps holds the default dependencies for production use.
 var DefaultSlidesHandlerDeps = common.NewDefaultHandlerDeps(NewSlidesService)
 

--- a/internal/tasks/tasks_handlers.go
+++ b/internal/tasks/tasks_handlers.go
@@ -22,6 +22,11 @@ func NewTasksService(ctx context.Context, client *http.Client) (TasksService, er
 	return NewRealTasksService(srv), nil
 }
 
+// InitDefaultTasksHandlerDeps initializes the default Tasks handler deps with explicit deps.
+func InitDefaultTasksHandlerDeps(appDeps *common.Deps) {
+	DefaultTasksHandlerDeps = common.NewDefaultHandlerDeps(NewTasksService, appDeps)
+}
+
 // DefaultTasksHandlerDeps holds the default dependencies for production use.
 var DefaultTasksHandlerDeps = common.NewDefaultHandlerDeps(NewTasksService)
 


### PR DESCRIPTION
## Summary
- Replace raw Google API types (`*drive.Service`, `*sheets.Service`, `*slides.Service`) with testable interfaces in CitationService, enabling unit tests without real API calls
- Replace global `SetDeps`/`GetDeps` with explicit dependency passing — all 12 service packages now have `Init*HandlerDeps` functions wired in main.go
- Unify `MethodCall` type: single definition in `common/types.go` with `Args []any`, aliased by gmail and calendar mocks

## Issues addressed
- #123: CitationService DI gap (interfaces + mock-based tests)
- #126: Global state removal (explicit passing for all packages)
- #119: DRY MethodCall unification (single source of truth)

## Issues already fixed by PR #117 (skipped)
- #121: Interface segregation — GmailService and DriveService already composed from sub-interfaces
- #127: drive_tools_testable.go split — already split into 5 domain files (max 452 lines)

Closes aliwatters/gsuite-mcp#123
Closes aliwatters/gsuite-mcp#126
Closes aliwatters/gsuite-mcp#119
Closes aliwatters/gsuite-mcp#121
Closes aliwatters/gsuite-mcp#127