### PR TITLE
refactor: config permissions fix and constant dedup

### DIFF
--- a/internal/citation/chunker.go
+++ b/internal/citation/chunker.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aliwatters/gsuite-mcp/internal/common"
 	"google.golang.org/api/drive/v3"
 	gslides "google.golang.org/api/slides/v1"
 )
@@ -249,9 +250,9 @@ func downloadAndChunk(data []byte, file *drive.File) ([]Chunk, error) {
 	return chunkText(file.Id, file.Name, text), nil
 }
 
-// maxExportSize limits Drive export downloads to 50MB.
-// Declared here to avoid duplication; the service references this constant.
-const exportSizeLimit = 50 * 1024 * 1024
+// exportSizeLimit limits Drive export downloads.
+// Uses the shared constant from common to prevent divergence.
+const exportSizeLimit = common.DriveMaxExportSize
 
 // limitedRead reads at most exportSizeLimit bytes from r.
 func limitedRead(r io.Reader) ([]byte, error) {

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -46,6 +46,7 @@ const (
 	DriveListDefaultMaxResults   = 100
 	DriveListMaxResultsLimit     = 1000
 	DriveMaxFileSize             = 10 * 1024 * 1024 // 10MB
+	DriveMaxExportSize           = 50 * 1024 * 1024 // 50MB — shared by citation indexing and doc export
 )
 
 // Sheets value input options.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,10 @@ import (
 // DefaultOAuthPort is the default port used for the OAuth callback server.
 const DefaultOAuthPort = 38917
 
+// configFileMode restricts config.json to owner-only access (matches credential files).
+// Config may contain organizational metadata (drive access rules, sheet IDs, feature flags).
+const configFileMode = 0600
+
 // DriveAccess configures which shared drives are accessible via MCP tools.
 // Set either Allowed (allowlist) or Blocked (blocklist), not both.
 // My Drive is always accessible. If neither is set, all drives are accessible.
@@ -113,7 +117,7 @@ func writeDefaultConfigTo(path string) (bool, error) {
 	}
 	data = append(data, '\n')
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, configFileMode); err != nil {
 		return false, fmt.Errorf("writing config.json: %w", err)
 	}
 

--- a/internal/docs/docs_tools.go
+++ b/internal/docs/docs_tools.go
@@ -8,8 +8,9 @@ import (
 	"google.golang.org/api/docs/v1"
 )
 
-// maxExportSize is the maximum size for PDF exports (50MB).
-const maxExportSize = 50 * 1024 * 1024
+// maxExportSize is the maximum size for Drive exports (50MB).
+// Uses the shared constant from common to prevent divergence.
+const maxExportSize = common.DriveMaxExportSize
 
 // extractDocumentText extracts plain text from a Google Docs document structure.
 func extractDocumentText(doc *docs.Document) string {


### PR DESCRIPTION
## Summary
- Fix config.json permissions from 0644 to 0600 (owner-only access)
- Deduplicate maxExportSize constant into common.DriveMaxExportSize

Note: Issue #125 (strconv.Atoi error handling) was already resolved in PR #117.

Closes aliwatters/gsuite-mcp#124
Closes aliwatters/gsuite-mcp#120