### PR TITLE
fix: tighten existing config.json permissions to 0600

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -103,8 +104,16 @@ func WriteDefaultConfig() (bool, error) {
 
 // writeDefaultConfigTo creates config.json at the given path with defaults.
 // Returns true if the file was created, false if it already existed.
+// If the file exists with broader permissions than configFileMode, they are tightened.
 func writeDefaultConfigTo(path string) (bool, error) {
-	if _, err := os.Stat(path); err == nil {
+	if info, err := os.Stat(path); err == nil {
+		// File exists — tighten permissions if broader than configFileMode.
+		if mode := info.Mode().Perm(); mode&^configFileMode != 0 {
+			log.Printf("config: tightening %s permissions from %04o to %04o", path, mode, configFileMode)
+			if chmodErr := os.Chmod(path, configFileMode); chmodErr != nil {
+				return false, fmt.Errorf("tightening config.json permissions: %w", chmodErr)
+			}
+		}
 		return false, nil
 	} else if !os.IsNotExist(err) {
 		return false, fmt.Errorf("checking config.json: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -269,6 +269,23 @@ func TestWriteDefaultConfigTo(t *testing.T) {
 		}
 	})
 
+	t.Run("new file has 0600 permissions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "config.json")
+
+		if _, err := writeDefaultConfigTo(path); err != nil {
+			t.Fatalf("writeDefaultConfigTo() error = %v", err)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("os.Stat() error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != configFileMode {
+			t.Errorf("new config.json permissions = %04o, want %04o", got, configFileMode)
+		}
+	})
+
 	t.Run("does not overwrite existing", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		path := filepath.Join(tmpDir, "config.json")
@@ -291,6 +308,73 @@ func TestWriteDefaultConfigTo(t *testing.T) {
 		}
 		if cfg.OAuthPort != 5555 {
 			t.Errorf("OAuthPort = %d, want 5555 (original)", cfg.OAuthPort)
+		}
+	})
+
+	t.Run("tightens 0644 to 0600", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "config.json")
+		if err := os.WriteFile(path, []byte(`{"oauth_port": 5555}`), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		// Confirm the file starts at 0644.
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("os.Stat() error = %v", err)
+		}
+		if info.Mode().Perm() != 0644 {
+			t.Fatalf("precondition failed: expected 0644, got %04o", info.Mode().Perm())
+		}
+
+		created, err := writeDefaultConfigTo(path)
+		if err != nil {
+			t.Fatalf("writeDefaultConfigTo() error = %v", err)
+		}
+		if created {
+			t.Error("writeDefaultConfigTo() returned true, want false")
+		}
+
+		// Permissions must now be 0600.
+		info, err = os.Stat(path)
+		if err != nil {
+			t.Fatalf("os.Stat() after chmod error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != configFileMode {
+			t.Errorf("after tightening, config.json permissions = %04o, want %04o", got, configFileMode)
+		}
+
+		// Content must be unchanged.
+		cfg, err := loadConfigFromPath(path)
+		if err != nil {
+			t.Fatalf("loadConfigFromPath() error = %v", err)
+		}
+		if cfg.OAuthPort != 5555 {
+			t.Errorf("OAuthPort = %d, want 5555 (original content preserved)", cfg.OAuthPort)
+		}
+	})
+
+	t.Run("already 0600 stays unchanged", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "config.json")
+		if err := os.WriteFile(path, []byte(`{"oauth_port": 7777}`), 0600); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		created, err := writeDefaultConfigTo(path)
+		if err != nil {
+			t.Fatalf("writeDefaultConfigTo() error = %v", err)
+		}
+		if created {
+			t.Error("writeDefaultConfigTo() returned true, want false")
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("os.Stat() error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != configFileMode {
+			t.Errorf("config.json permissions = %04o, want %04o", got, configFileMode)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
Address Copilot review feedback from PR #130: existing config.json files with
permissive (0644) permissions were not being tightened to 0600 on startup.

Now detects and fixes overly permissive config files automatically.

## Changes
- Check existing file permissions in writeDefaultConfigTo
- Chmod to 0600 if broader than expected
- Add test coverage for permission enforcement