### PR TITLE
fix: address 7 unresolved Copilot review comments

### DIFF
--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -139,7 +139,7 @@ func initializeApp() error {
 	// middleware that may receive nil deps. All handler factories now use explicit passing below.
 	common.SetDeps(appDeps)
 
-	// Initialize ALL handler deps with explicit dependency passing to avoid global singleton reads.
+	// Initialize handler deps with explicit dependency passing so handler logic does not call GetDeps().
 	drive.InitDefaultDriveHandlerDeps(appDeps)
 	gmail.InitDefaultGmailHandlerDeps(appDeps)
 	docs.InitDefaultDocsHandlerDeps(appDeps)

--- a/internal/citation/chunker.go
+++ b/internal/citation/chunker.go
@@ -250,7 +250,8 @@ func downloadAndChunk(data []byte, file *drive.File) ([]Chunk, error) {
 	return chunkText(file.Id, file.Name, text), nil
 }
 
-// exportSizeLimit limits Drive export downloads.
+// exportSizeLimit limits Drive downloads and exports (applies to both raw file
+// downloads and Google Workspace export conversions).
 // Uses the shared constant from common to prevent divergence.
 const exportSizeLimit = common.DriveMaxExportSize
 

--- a/internal/citation/citation_deps.go
+++ b/internal/citation/citation_deps.go
@@ -23,8 +23,9 @@ type CitationDriveService interface {
 	// ExportFile exports a Google Workspace file to the specified MIME type.
 	ExportFile(ctx context.Context, fileID string, mimeType string) (io.ReadCloser, error)
 
-	// MoveFile moves a file to a new parent folder.
-	MoveFile(ctx context.Context, fileID string, addParents string) (*drive.File, error)
+	// AddParentFolder adds a parent folder to a file (Drive AddParents API).
+	// This does not remove existing parents; use the Drive package's MoveFile for a full move.
+	AddParentFolder(ctx context.Context, fileID string, parentFolderID string) (*drive.File, error)
 }
 
 // CitationSheetsService defines the Sheets operations used by the citation package.
@@ -83,9 +84,9 @@ func (r *realCitationDriveService) ExportFile(ctx context.Context, fileID string
 	return resp.Body, nil
 }
 
-func (r *realCitationDriveService) MoveFile(ctx context.Context, fileID string, addParents string) (*drive.File, error) {
+func (r *realCitationDriveService) AddParentFolder(ctx context.Context, fileID string, parentFolderID string) (*drive.File, error) {
 	return r.svc.Files.Update(fileID, nil).
-		AddParents(addParents).
+		AddParents(parentFolderID).
 		SupportsAllDrives(true).
 		Context(ctx).Do()
 }

--- a/internal/citation/citation_deps_test.go
+++ b/internal/citation/citation_deps_test.go
@@ -37,7 +37,7 @@ func (m *mockCitationDrive) ExportFile(_ context.Context, fileID string, _ strin
 	return nil, io.ErrUnexpectedEOF
 }
 
-func (m *mockCitationDrive) MoveFile(_ context.Context, fileID string, _ string) (*drive.File, error) {
+func (m *mockCitationDrive) AddParentFolder(_ context.Context, fileID string, _ string) (*drive.File, error) {
 	if f, ok := m.files[fileID]; ok {
 		return f, nil
 	}

--- a/internal/citation/index_create.go
+++ b/internal/citation/index_create.go
@@ -28,11 +28,11 @@ func (s *RealCitationService) CreateIndex(ctx context.Context, name, folderID st
 		return nil, fmt.Errorf("creating index sheet: %w", err)
 	}
 
-	// Move to folder if specified
+	// Add the new spreadsheet to the specified folder.
 	if folderID != "" {
-		_, err = s.drive.MoveFile(ctx, created.SpreadsheetId, folderID)
+		_, err = s.drive.AddParentFolder(ctx, created.SpreadsheetId, folderID)
 		if err != nil {
-			return nil, fmt.Errorf("moving sheet to folder: %w", err)
+			return nil, fmt.Errorf("adding sheet to folder: %w", err)
 		}
 	}
 

--- a/internal/citation/index_refresh.go
+++ b/internal/citation/index_refresh.go
@@ -45,9 +45,7 @@ func (s *RealCitationService) RefreshIndex(ctx context.Context, indexID string) 
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("RefreshIndex fetching file metadata: %w", err)
-	}
+	g.Wait() //nolint:errcheck // goroutines return nil unconditionally; partial failures stored in fileResults
 
 	// Process results sequentially (store writes and result mutation are not concurrent-safe).
 	for _, fr := range fileResults {

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -18,8 +18,9 @@ type Deps struct {
 
 // Global instance set during initialization.
 // Deprecated: All service handlers should receive deps explicitly via Init*HandlerDeps.
-// This global is retained only for middleware (WithDriveAccessCheck, WithLargeContentHint)
-// that receive nil deps as a backward-compatibility fallback.
+// This global is retained for middleware (WithDriveAccessCheck, WithLargeContentHint)
+// fallbacks and for callers such as ResolveAccountFromRequest that have not yet been
+// updated to accept deps explicitly.
 var deps *Deps
 
 // SetDeps initializes the global dependencies. Called exactly once during startup.


### PR DESCRIPTION
## Summary

Addresses 7 unresolved Copilot review threads from Phase 2 PRs #128, #129, #130.

- **index_refresh.go**: Remove unreachable `g.Wait()` error check — goroutines return nil unconditionally (partial-failure design). Added clarifying comment.
- **common/deps.go**: Fix misleading "only for middleware" comment; the global is also used by `ResolveAccountFromRequest` and other non-middleware callers.
- **cmd/gsuite-mcp/main.go**: Narrow the `Init*HandlerDeps` comment to accurately say handler logic avoids `GetDeps()`, rather than overstating that no paths read the global.
- **citation_deps.go + index_create.go**: Rename `MoveFile` → `AddParentFolder` in the `CitationDriveService` interface and implementation. The underlying Drive API call only adds a parent (it never removes existing parents), so the old name was misleading.
- **citation_deps_test.go**: Update mock to match renamed method.
- **chunker.go**: Fix `exportSizeLimit` comment — the limit applies to raw file downloads AND export conversions, not just exports.

Note: The 6th item (config.go permission test) was already addressed in #132.

Closes #131

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 17 packages pass