### PR TITLE
feat: migrate mark3labs/mcp-go to v0.52.0 (#140)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/aliwatters/gsuite-mcp
 
-go 1.25.0
+go 1.25.5
 
 require (
-	github.com/mark3labs/mcp-go v0.23.1
+	github.com/mark3labs/mcp-go v0.52.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.264.0
@@ -19,6 +19,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
@@ -26,6 +27,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -23,6 +25,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
@@ -39,8 +43,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/mark3labs/mcp-go v0.23.1 h1:RzTzZ5kJ+HxwnutKA4rll8N/pKV6Wh5dhCmiJUu5S9I=
-github.com/mark3labs/mcp-go v0.23.1/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.52.0 h1:uRSzupNSUyPGDpF4owY5X4zEpACPwBnlM3FAFuXN6gQ=
+github.com/mark3labs/mcp-go v0.52.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
@@ -51,6 +55,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/calendar/testable_events.go
+++ b/internal/calendar/testable_events.go
@@ -17,42 +17,42 @@ func TestableCalendarListEvents(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", "primary")
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", "primary")
 
 	opts := &ListEventsOptions{
 		Fields: CalendarEventListFields,
 	}
 
 	// Default to showing future events if no time range specified
-	if timeMin := common.ParseStringArg(request.Params.Arguments, "time_min", ""); timeMin != "" {
+	if timeMin := common.ParseStringArg(request.GetArguments(), "time_min", ""); timeMin != "" {
 		opts.TimeMin = timeMin
 	} else {
 		// Default to now
 		opts.TimeMin = time.Now().Format(time.RFC3339)
 	}
 
-	if timeMax := common.ParseStringArg(request.Params.Arguments, "time_max", ""); timeMax != "" {
+	if timeMax := common.ParseStringArg(request.GetArguments(), "time_max", ""); timeMax != "" {
 		opts.TimeMax = timeMax
 	}
 
-	opts.MaxResults = common.ParseMaxResults(request.Params.Arguments, common.CalendarDefaultMaxResults, common.CalendarMaxResultsLimit)
+	opts.MaxResults = common.ParseMaxResults(request.GetArguments(), common.CalendarDefaultMaxResults, common.CalendarMaxResultsLimit)
 
-	if pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", ""); pageToken != "" {
+	if pageToken := common.ParseStringArg(request.GetArguments(), "page_token", ""); pageToken != "" {
 		opts.PageToken = pageToken
 	}
 
-	if query := common.ParseStringArg(request.Params.Arguments, "query", ""); query != "" {
+	if query := common.ParseStringArg(request.GetArguments(), "query", ""); query != "" {
 		opts.Query = query
 	}
 
 	// Expand recurring events into individual instances
-	if common.ParseBoolArg(request.Params.Arguments, "single_events", false) {
+	if common.ParseBoolArg(request.GetArguments(), "single_events", false) {
 		opts.SingleEvents = true
 		opts.OrderBy = "startTime"
 	}
 
 	// Filter by event types (e.g., "focusTime", "outOfOffice")
-	if eventTypesRaw, ok := request.Params.Arguments["event_types"].([]any); ok && len(eventTypesRaw) > 0 {
+	if eventTypesRaw, ok := request.GetArguments()["event_types"].([]any); ok && len(eventTypesRaw) > 0 {
 		eventTypes := make([]string, 0, len(eventTypesRaw))
 		for _, et := range eventTypesRaw {
 			if etStr, ok := et.(string); ok && etStr != "" {
@@ -90,12 +90,12 @@ func TestableCalendarGetEvent(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	eventID, errResult := common.RequireStringArg(request.GetArguments(), "event_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	event, err := srv.GetEvent(ctx, calendarID, eventID, CalendarEventGetFields)
 	if err != nil {
@@ -114,45 +114,45 @@ func TestableCalendarCreateEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	summary, errResult := common.RequireStringArg(request.Params.Arguments, "summary")
+	summary, errResult := common.RequireStringArg(request.GetArguments(), "summary")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	event := &calendar.Event{
 		Summary: summary,
 	}
 
-	if desc := common.ParseStringArg(request.Params.Arguments, "description", ""); desc != "" {
+	if desc := common.ParseStringArg(request.GetArguments(), "description", ""); desc != "" {
 		event.Description = desc
 	}
 
-	if loc := common.ParseStringArg(request.Params.Arguments, "location", ""); loc != "" {
+	if loc := common.ParseStringArg(request.GetArguments(), "location", ""); loc != "" {
 		event.Location = loc
 	}
 
 	// Set start/end times (required start_time, optional end_time/all_day/timezone)
-	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+	if errResult := setNewEventTimes(event, request.GetArguments()); errResult != nil {
 		return errResult, nil
 	}
 
 	// Attendees
-	if attendees := parseAttendees(request.Params.Arguments); attendees != nil {
+	if attendees := parseAttendees(request.GetArguments()); attendees != nil {
 		event.Attendees = attendees
 	}
 
 	// Reminders
-	if reminders := parseReminders(request.Params.Arguments); reminders != nil {
+	if reminders := parseReminders(request.GetArguments()); reminders != nil {
 		event.Reminders = reminders
 	}
 
 	// Google Meet conferencing
-	addConferencing := common.ParseBoolArg(request.Params.Arguments, "add_conferencing", false)
+	addConferencing := common.ParseBoolArg(request.GetArguments(), "add_conferencing", false)
 
 	if addConferencing {
-		startTime := common.ParseStringArg(request.Params.Arguments, "start_time", "")
+		startTime := common.ParseStringArg(request.GetArguments(), "start_time", "")
 		event.ConferenceData = buildConferenceData(calendarID, startTime, summary)
 	}
 
@@ -184,12 +184,12 @@ func TestableCalendarUpdateEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	eventID, errResult := common.RequireStringArg(request.GetArguments(), "event_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	// First, get the existing event
 	event, err := srv.GetEvent(ctx, calendarID, eventID, "")
@@ -198,23 +198,23 @@ func TestableCalendarUpdateEvent(ctx context.Context, request mcp.CallToolReques
 	}
 
 	// Update fields that are provided
-	if summary := common.ParseStringArg(request.Params.Arguments, "summary", ""); summary != "" {
+	if summary := common.ParseStringArg(request.GetArguments(), "summary", ""); summary != "" {
 		event.Summary = summary
 	}
-	if val, ok := request.Params.Arguments["description"].(string); ok {
+	if val, ok := request.GetArguments()["description"].(string); ok {
 		event.Description = val
 	}
-	if val, ok := request.Params.Arguments["location"].(string); ok {
+	if val, ok := request.GetArguments()["location"].(string); ok {
 		event.Location = val
 	}
 
 	// Update times if provided
-	if errResult := updateEventTimes(event, request.Params.Arguments); errResult != nil {
+	if errResult := updateEventTimes(event, request.GetArguments()); errResult != nil {
 		return errResult, nil
 	}
 
 	// Update attendees if provided
-	if attendees := parseAttendees(request.Params.Arguments); attendees != nil {
+	if attendees := parseAttendees(request.GetArguments()); attendees != nil {
 		event.Attendees = attendees
 	}
 
@@ -236,12 +236,12 @@ func TestableCalendarDeleteEvent(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	eventID, errResult := common.RequireStringArg(request.GetArguments(), "event_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	err := srv.DeleteEvent(ctx, calendarID, eventID)
 	if err != nil {
@@ -265,12 +265,12 @@ func TestableCalendarQuickAdd(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	text, errResult := common.RequireStringArg(request.GetArguments(), "text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	event, err := srv.QuickAddEvent(ctx, calendarID, text)
 	if err != nil {

--- a/internal/calendar/testable_lists.go
+++ b/internal/calendar/testable_lists.go
@@ -59,12 +59,12 @@ func TestableCalendarFreeBusy(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	timeMin := common.ParseStringArg(request.Params.Arguments, "time_min", "")
+	timeMin := common.ParseStringArg(request.GetArguments(), "time_min", "")
 	if timeMin == "" {
 		return mcp.NewToolResultError("time_min parameter is required (RFC3339 format)"), nil
 	}
 
-	timeMax := common.ParseStringArg(request.Params.Arguments, "time_max", "")
+	timeMax := common.ParseStringArg(request.GetArguments(), "time_max", "")
 	if timeMax == "" {
 		return mcp.NewToolResultError("time_max parameter is required (RFC3339 format)"), nil
 	}
@@ -73,7 +73,7 @@ func TestableCalendarFreeBusy(ctx context.Context, request mcp.CallToolRequest, 
 	var items []*calendar.FreeBusyRequestItem
 
 	// Check for calendar_ids parameter (array)
-	if calendarIDsRaw, ok := request.Params.Arguments["calendar_ids"].([]any); ok && len(calendarIDsRaw) > 0 {
+	if calendarIDsRaw, ok := request.GetArguments()["calendar_ids"].([]any); ok && len(calendarIDsRaw) > 0 {
 		for _, id := range calendarIDsRaw {
 			if calID, ok := id.(string); ok && calID != "" {
 				items = append(items, &calendar.FreeBusyRequestItem{Id: calID})
@@ -126,27 +126,27 @@ func TestableCalendarListInstances(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	eventID, errResult := common.RequireStringArg(request.Params.Arguments, "event_id")
+	eventID, errResult := common.RequireStringArg(request.GetArguments(), "event_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	opts := &ListInstancesOptions{
 		Fields: CalendarEventListFields,
 	}
 
-	if timeMin := common.ParseStringArg(request.Params.Arguments, "time_min", ""); timeMin != "" {
+	if timeMin := common.ParseStringArg(request.GetArguments(), "time_min", ""); timeMin != "" {
 		opts.TimeMin = timeMin
 	}
 
-	if timeMax := common.ParseStringArg(request.Params.Arguments, "time_max", ""); timeMax != "" {
+	if timeMax := common.ParseStringArg(request.GetArguments(), "time_max", ""); timeMax != "" {
 		opts.TimeMax = timeMax
 	}
 
-	opts.MaxResults = common.ParseMaxResults(request.Params.Arguments, common.CalendarDefaultMaxResults, common.CalendarMaxResultsLimit)
-	opts.PageToken = common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	opts.MaxResults = common.ParseMaxResults(request.GetArguments(), common.CalendarDefaultMaxResults, common.CalendarMaxResultsLimit)
+	opts.PageToken = common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	resp, err := srv.ListInstances(ctx, calendarID, eventID, opts)
 	if err != nil {
@@ -174,12 +174,12 @@ func TestableCalendarUpdateInstance(ctx context.Context, request mcp.CallToolReq
 		return errResult, nil
 	}
 
-	instanceID, errResult := common.RequireStringArg(request.Params.Arguments, "instance_id")
+	instanceID, errResult := common.RequireStringArg(request.GetArguments(), "instance_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	// First, get the existing instance
 	event, err := srv.GetEvent(ctx, calendarID, instanceID, "")
@@ -188,18 +188,18 @@ func TestableCalendarUpdateInstance(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Update fields that are provided
-	if summary := common.ParseStringArg(request.Params.Arguments, "summary", ""); summary != "" {
+	if summary := common.ParseStringArg(request.GetArguments(), "summary", ""); summary != "" {
 		event.Summary = summary
 	}
-	if val, ok := request.Params.Arguments["description"].(string); ok {
+	if val, ok := request.GetArguments()["description"].(string); ok {
 		event.Description = val
 	}
-	if val, ok := request.Params.Arguments["location"].(string); ok {
+	if val, ok := request.GetArguments()["location"].(string); ok {
 		event.Location = val
 	}
 
 	// Update times if provided
-	if errResult := updateEventTimes(event, request.Params.Arguments); errResult != nil {
+	if errResult := updateEventTimes(event, request.GetArguments()); errResult != nil {
 		return errResult, nil
 	}
 

--- a/internal/calendar/testable_special_events.go
+++ b/internal/calendar/testable_special_events.go
@@ -16,27 +16,27 @@ func TestableCalendarCreateFocusTime(ctx context.Context, request mcp.CallToolRe
 		return errResult, nil
 	}
 
-	summary := common.ParseStringArg(request.Params.Arguments, "summary", "Focus Time")
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	summary := common.ParseStringArg(request.GetArguments(), "summary", "Focus Time")
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	event := &calendar.Event{
 		Summary:   summary,
 		EventType: "focusTime",
 	}
 
-	if desc := common.ParseStringArg(request.Params.Arguments, "description", ""); desc != "" {
+	if desc := common.ParseStringArg(request.GetArguments(), "description", ""); desc != "" {
 		event.Description = desc
 	}
 
 	// Set start/end times
-	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+	if errResult := setNewEventTimes(event, request.GetArguments()); errResult != nil {
 		return errResult, nil
 	}
 
 	// Focus Time uses FocusTimeProperties for auto-decline
-	autoDecline := common.ParseBoolArg(request.Params.Arguments, "auto_decline", true)
-	declineMessage := common.ParseStringArg(request.Params.Arguments, "decline_message", "Declined because I am in focus time.")
-	chatStatus := common.ParseStringArg(request.Params.Arguments, "chat_status", "doNotDisturb")
+	autoDecline := common.ParseBoolArg(request.GetArguments(), "auto_decline", true)
+	declineMessage := common.ParseStringArg(request.GetArguments(), "decline_message", "Declined because I am in focus time.")
+	chatStatus := common.ParseStringArg(request.GetArguments(), "chat_status", "doNotDisturb")
 
 	event.FocusTimeProperties = &calendar.EventFocusTimeProperties{
 		AutoDeclineMode: boolToDeclineMode(autoDecline),
@@ -45,7 +45,7 @@ func TestableCalendarCreateFocusTime(ctx context.Context, request mcp.CallToolRe
 	}
 
 	// Recurrence
-	if rrule := common.ParseStringArg(request.Params.Arguments, "recurrence", ""); rrule != "" {
+	if rrule := common.ParseStringArg(request.GetArguments(), "recurrence", ""); rrule != "" {
 		event.Recurrence = []string{rrule}
 	}
 
@@ -68,26 +68,26 @@ func TestableCalendarCreateOutOfOffice(ctx context.Context, request mcp.CallTool
 		return errResult, nil
 	}
 
-	summary := common.ParseStringArg(request.Params.Arguments, "summary", "Out of office")
-	calendarID := common.ParseStringArg(request.Params.Arguments, "calendar_id", common.DefaultCalendarID)
+	summary := common.ParseStringArg(request.GetArguments(), "summary", "Out of office")
+	calendarID := common.ParseStringArg(request.GetArguments(), "calendar_id", common.DefaultCalendarID)
 
 	event := &calendar.Event{
 		Summary:   summary,
 		EventType: "outOfOffice",
 	}
 
-	if desc := common.ParseStringArg(request.Params.Arguments, "description", ""); desc != "" {
+	if desc := common.ParseStringArg(request.GetArguments(), "description", ""); desc != "" {
 		event.Description = desc
 	}
 
 	// Set start/end times
-	if errResult := setNewEventTimes(event, request.Params.Arguments); errResult != nil {
+	if errResult := setNewEventTimes(event, request.GetArguments()); errResult != nil {
 		return errResult, nil
 	}
 
 	// Out of Office uses OutOfOfficeProperties for auto-decline
-	autoDecline := common.ParseBoolArg(request.Params.Arguments, "auto_decline", true)
-	declineMessage := common.ParseStringArg(request.Params.Arguments, "decline_message", "I am out of office and unable to attend.")
+	autoDecline := common.ParseBoolArg(request.GetArguments(), "auto_decline", true)
+	declineMessage := common.ParseStringArg(request.GetArguments(), "decline_message", "I am out of office and unable to attend.")
 
 	event.OutOfOfficeProperties = &calendar.EventOutOfOfficeProperties{
 		AutoDeclineMode: boolToDeclineMode(autoDecline),
@@ -95,7 +95,7 @@ func TestableCalendarCreateOutOfOffice(ctx context.Context, request mcp.CallTool
 	}
 
 	// Recurrence
-	if rrule := common.ParseStringArg(request.Params.Arguments, "recurrence", ""); rrule != "" {
+	if rrule := common.ParseStringArg(request.GetArguments(), "recurrence", ""); rrule != "" {
 		event.Recurrence = []string{rrule}
 	}
 

--- a/internal/chat/chat_testable.go
+++ b/internal/chat/chat_testable.go
@@ -16,8 +16,8 @@ func TestableChatListSpaces(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	pageSize := common.ParseMaxResults(request.Params.Arguments, 20, 100)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), 20, 100)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	spaces, nextPageToken, err := srv.ListSpaces(ctx, pageSize, pageToken)
 	if err != nil {
@@ -47,7 +47,7 @@ func TestableChatGetSpace(ctx context.Context, request mcp.CallToolRequest, deps
 		return errResult, nil
 	}
 
-	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	spaceName, errResult := common.RequireStringArg(request.GetArguments(), "space_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -69,12 +69,12 @@ func TestableChatCreateSpace(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	displayName, errResult := common.RequireStringArg(request.Params.Arguments, "display_name")
+	displayName, errResult := common.RequireStringArg(request.GetArguments(), "display_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	spaceType := common.ParseStringArg(request.Params.Arguments, "space_type", "SPACE")
+	spaceType := common.ParseStringArg(request.GetArguments(), "space_type", "SPACE")
 
 	space, err := srv.CreateSpace(ctx, displayName, spaceType)
 	if err != nil {
@@ -91,15 +91,15 @@ func TestableChatListMessages(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	spaceName, errResult := common.RequireStringArg(request.GetArguments(), "space_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
 	spaceName = normalizeSpaceName(spaceName)
-	pageSize := common.ParseMaxResults(request.Params.Arguments, 25, 100)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	filter := common.ParseStringArg(request.Params.Arguments, "filter", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), 25, 100)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	filter := common.ParseStringArg(request.GetArguments(), "filter", "")
 
 	messages, nextPageToken, err := srv.ListMessages(ctx, spaceName, pageSize, pageToken, filter)
 	if err != nil {
@@ -129,7 +129,7 @@ func TestableChatGetMessage(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	messageName, errResult := common.RequireStringArg(request.Params.Arguments, "message_name")
+	messageName, errResult := common.RequireStringArg(request.GetArguments(), "message_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -149,18 +149,18 @@ func TestableChatSendMessage(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	spaceName, errResult := common.RequireStringArg(request.GetArguments(), "space_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	text, errResult := common.RequireStringArg(request.GetArguments(), "text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
 	spaceName = normalizeSpaceName(spaceName)
-	threadName := common.ParseStringArg(request.Params.Arguments, "thread_name", "")
+	threadName := common.ParseStringArg(request.GetArguments(), "thread_name", "")
 
 	msg, err := srv.SendMessage(ctx, spaceName, text, threadName)
 	if err != nil {
@@ -177,12 +177,12 @@ func TestableChatCreateReaction(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	messageName, errResult := common.RequireStringArg(request.Params.Arguments, "message_name")
+	messageName, errResult := common.RequireStringArg(request.GetArguments(), "message_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	emoji, errResult := common.RequireStringArg(request.Params.Arguments, "emoji")
+	emoji, errResult := common.RequireStringArg(request.GetArguments(), "emoji")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -209,7 +209,7 @@ func TestableChatDeleteReaction(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	reactionName, errResult := common.RequireStringArg(request.Params.Arguments, "reaction_name")
+	reactionName, errResult := common.RequireStringArg(request.GetArguments(), "reaction_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -231,14 +231,14 @@ func TestableChatListMembers(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	spaceName, errResult := common.RequireStringArg(request.Params.Arguments, "space_name")
+	spaceName, errResult := common.RequireStringArg(request.GetArguments(), "space_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
 	spaceName = normalizeSpaceName(spaceName)
-	pageSize := common.ParseMaxResults(request.Params.Arguments, 100, 1000)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), 100, 1000)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	members, nextPageToken, err := srv.ListMembers(ctx, spaceName, pageSize, pageToken)
 	if err != nil {

--- a/internal/citation/citation_tools_test.go
+++ b/internal/citation/citation_tools_test.go
@@ -106,13 +106,7 @@ func (m *mockCitationService) RefreshIndex(_ context.Context, _ string) (*Refres
 // makeToolRequest creates a CallToolRequest with the given arguments.
 func makeToolRequest(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	}

--- a/internal/citation/citation_tools_testable.go
+++ b/internal/citation/citation_tools_testable.go
@@ -17,11 +17,11 @@ func TestableCitationCreateIndex(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	name := common.ParseStringArg(request.Params.Arguments, "name", "")
+	name := common.ParseStringArg(request.GetArguments(), "name", "")
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
 	}
-	folderID := common.ParseStringArg(request.Params.Arguments, "folder_id", "")
+	folderID := common.ParseStringArg(request.GetArguments(), "folder_id", "")
 
 	info, err := srv.CreateIndex(ctx, name, folderID)
 	if err != nil {
@@ -38,12 +38,12 @@ func TestableCitationAddDocuments(ctx context.Context, request mcp.CallToolReque
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
 
-	fileIDsRaw := common.ParseStringArg(request.Params.Arguments, "file_ids", "")
+	fileIDsRaw := common.ParseStringArg(request.GetArguments(), "file_ids", "")
 	if fileIDsRaw == "" {
 		return mcp.NewToolResultError("file_ids is required (comma-separated or JSON array)"), nil
 	}
@@ -71,12 +71,12 @@ func TestableCitationSaveConcepts(ctx context.Context, request mcp.CallToolReque
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
 
-	mappingsJSON := common.ParseStringArg(request.Params.Arguments, "mappings", "")
+	mappingsJSON := common.ParseStringArg(request.GetArguments(), "mappings", "")
 	if mappingsJSON == "" {
 		return mcp.NewToolResultError("mappings is required (JSON array of {concept, chunk_ids})"), nil
 	}
@@ -100,12 +100,12 @@ func TestableCitationSaveSummary(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
 
-	args := request.Params.Arguments
+	args := request.GetArguments()
 	level := 0
 	if v, ok := args["level"].(float64); ok {
 		level = int(v)
@@ -145,7 +145,7 @@ func TestableCitationGetOverview(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
@@ -165,17 +165,17 @@ func TestableCitationLookup(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
-	query := common.ParseStringArg(request.Params.Arguments, "query", "")
+	query := common.ParseStringArg(request.GetArguments(), "query", "")
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
 	}
 
 	limit := 10
-	if v, ok := request.Params.Arguments["limit"].(float64); ok && v > 0 {
+	if v, ok := request.GetArguments()["limit"].(float64); ok && v > 0 {
 		limit = int(v)
 	}
 
@@ -213,12 +213,12 @@ func TestableCitationGetChunks(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
 
-	chunkIDsRaw := common.ParseStringArg(request.Params.Arguments, "chunk_ids", "")
+	chunkIDsRaw := common.ParseStringArg(request.GetArguments(), "chunk_ids", "")
 	if chunkIDsRaw == "" {
 		return mcp.NewToolResultError("chunk_ids is required"), nil
 	}
@@ -239,17 +239,17 @@ func TestableCitationVerifyClaim(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
-	claim := common.ParseStringArg(request.Params.Arguments, "claim", "")
+	claim := common.ParseStringArg(request.GetArguments(), "claim", "")
 	if claim == "" {
 		return mcp.NewToolResultError("claim is required"), nil
 	}
 
 	limit := 5
-	if v, ok := request.Params.Arguments["limit"].(float64); ok && v > 0 {
+	if v, ok := request.GetArguments()["limit"].(float64); ok && v > 0 {
 		limit = int(v)
 	}
 
@@ -282,11 +282,11 @@ func TestableCitationFormatCitation(ctx context.Context, request mcp.CallToolReq
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}
-	chunkID := common.ParseStringArg(request.Params.Arguments, "chunk_id", "")
+	chunkID := common.ParseStringArg(request.GetArguments(), "chunk_id", "")
 	if chunkID == "" {
 		return mcp.NewToolResultError("chunk_id is required"), nil
 	}
@@ -330,7 +330,7 @@ func TestableCitationRefresh(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	indexID := common.ParseStringArg(request.Params.Arguments, "index_id", "")
+	indexID := common.ParseStringArg(request.GetArguments(), "index_id", "")
 	if indexID == "" {
 		return mcp.NewToolResultError("index_id is required"), nil
 	}

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -48,7 +48,7 @@ func ResolveAccountFromRequestWithDeps(request mcp.CallToolRequest, d *Deps) (st
 	if d == nil {
 		d = GetDeps()
 	}
-	accountParam := ParseStringArg(request.Params.Arguments, "account", "")
+	accountParam := ParseStringArg(request.GetArguments(), "account", "")
 
 	if accountParam == "" {
 		// No account specified - use first authenticated email

--- a/internal/common/drive_access.go
+++ b/internal/common/drive_access.go
@@ -218,7 +218,7 @@ func WithDriveAccessCheck(handler func(context.Context, mcp.CallToolRequest) (*m
 			return handler(ctx, request)
 		}
 
-		fileID := ParseStringArg(request.Params.Arguments, paramName, "")
+		fileID := ParseStringArg(request.GetArguments(), paramName, "")
 		if fileID == "" {
 			return handler(ctx, request)
 		}

--- a/internal/common/handler_deps.go
+++ b/internal/common/handler_deps.go
@@ -137,7 +137,7 @@ type TestFixtures[S any] struct {
 func NewTestFixtures[S any](mockService S) *TestFixtures[S] {
 	defaultEmail := TestEmail
 	emailResolver := func(request mcp.CallToolRequest) (string, error) {
-		if accountParam, ok := request.Params.Arguments["account"].(string); ok && accountParam != "" {
+		if accountParam, ok := request.GetArguments()["account"].(string); ok && accountParam != "" {
 			return accountParam, nil
 		}
 		return defaultEmail, nil

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -35,13 +35,7 @@ func WasMethodCalled(calls []MethodCall, method string) bool {
 // This helper function is used across test files.
 func CreateMCPRequest(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	}

--- a/internal/contacts/contacts_tools_testable.go
+++ b/internal/contacts/contacts_tools_testable.go
@@ -23,14 +23,14 @@ func TestableContactsList(ctx context.Context, request mcp.CallToolRequest, deps
 
 	// Person fields
 	personFields := DefaultPersonFields
-	if pf, ok := request.Params.Arguments["person_fields"].(string); ok && pf != "" {
+	if pf, ok := request.GetArguments()["person_fields"].(string); ok && pf != "" {
 		personFields = pf
 	}
 	opts.PersonFields = personFields
 
 	// Page size (default 100, max 1000)
 	pageSize := int32(common.ContactsDefaultPageSize)
-	if ps, ok := request.Params.Arguments["page_size"].(float64); ok && ps > 0 {
+	if ps, ok := request.GetArguments()["page_size"].(float64); ok && ps > 0 {
 		pageSize = int32(ps)
 		if pageSize > common.ContactsMaxPageSize {
 			pageSize = common.ContactsMaxPageSize
@@ -39,12 +39,12 @@ func TestableContactsList(ctx context.Context, request mcp.CallToolRequest, deps
 	opts.PageSize = pageSize
 
 	// Page token for pagination
-	if pageToken, ok := request.Params.Arguments["page_token"].(string); ok && pageToken != "" {
+	if pageToken, ok := request.GetArguments()["page_token"].(string); ok && pageToken != "" {
 		opts.PageToken = pageToken
 	}
 
 	// Sort order
-	if sortOrder, ok := request.Params.Arguments["sort_order"].(string); ok && sortOrder != "" {
+	if sortOrder, ok := request.GetArguments()["sort_order"].(string); ok && sortOrder != "" {
 		opts.SortOrder = sortOrder
 	}
 
@@ -75,7 +75,7 @@ func TestableContactsGet(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -84,7 +84,7 @@ func TestableContactsGet(ctx context.Context, request mcp.CallToolRequest, deps 
 
 	// Person fields
 	personFields := DefaultPersonFields
-	if pf, ok := request.Params.Arguments["person_fields"].(string); ok && pf != "" {
+	if pf, ok := request.GetArguments()["person_fields"].(string); ok && pf != "" {
 		personFields = pf
 	}
 
@@ -109,7 +109,7 @@ func TestableContactsSearch(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	query, errResult := common.RequireStringArg(request.GetArguments(), "query")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -118,14 +118,14 @@ func TestableContactsSearch(ctx context.Context, request mcp.CallToolRequest, de
 
 	// Read mask (default person fields)
 	readMask := DefaultPersonFields
-	if rm, ok := request.Params.Arguments["read_mask"].(string); ok && rm != "" {
+	if rm, ok := request.GetArguments()["read_mask"].(string); ok && rm != "" {
 		readMask = rm
 	}
 	opts.ReadMask = readMask
 
 	// Page size (default 30, max 30 for search)
 	pageSize := int32(common.ContactsSearchDefaultPageSize)
-	if ps, ok := request.Params.Arguments["page_size"].(float64); ok && ps > 0 {
+	if ps, ok := request.GetArguments()["page_size"].(float64); ok && ps > 0 {
 		pageSize = int32(ps)
 		if pageSize > common.ContactsSearchMaxPageSize {
 			pageSize = common.ContactsSearchMaxPageSize
@@ -167,36 +167,36 @@ func TestableContactsCreate(ctx context.Context, request mcp.CallToolRequest, de
 	person := &people.Person{}
 
 	// Names (given_name is required)
-	givenName, errResult := common.RequireStringArg(request.Params.Arguments, "given_name")
+	givenName, errResult := common.RequireStringArg(request.GetArguments(), "given_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 	person.Names = []*people.Name{{GivenName: givenName}}
-	if familyName, ok := request.Params.Arguments["family_name"].(string); ok && familyName != "" {
+	if familyName, ok := request.GetArguments()["family_name"].(string); ok && familyName != "" {
 		person.Names[0].FamilyName = familyName
 	}
 
 	// Email addresses
-	if emails := parseEmailsFromRequest(request.Params.Arguments); emails != nil {
+	if emails := parseEmailsFromRequest(request.GetArguments()); emails != nil {
 		person.EmailAddresses = emails
 	}
 
 	// Phone numbers
-	if phones := parsePhonesFromRequest(request.Params.Arguments); phones != nil {
+	if phones := parsePhonesFromRequest(request.GetArguments()); phones != nil {
 		person.PhoneNumbers = phones
 	}
 
 	// Organization
-	if company, ok := request.Params.Arguments["company"].(string); ok && company != "" {
+	if company, ok := request.GetArguments()["company"].(string); ok && company != "" {
 		org := &people.Organization{Name: company}
-		if title, ok := request.Params.Arguments["job_title"].(string); ok {
+		if title, ok := request.GetArguments()["job_title"].(string); ok {
 			org.Title = title
 		}
 		person.Organizations = []*people.Organization{org}
 	}
 
 	// Notes/biography
-	if notes, ok := request.Params.Arguments["notes"].(string); ok && notes != "" {
+	if notes, ok := request.GetArguments()["notes"].(string); ok && notes != "" {
 		person.Biographies = []*people.Biography{{Value: notes}}
 	}
 
@@ -218,7 +218,7 @@ func TestableContactsUpdate(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -230,7 +230,7 @@ func TestableContactsUpdate(ctx context.Context, request mcp.CallToolRequest, de
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get contact: %v", err)), nil
 	}
 
-	updateFields := applyContactUpdates(existing, request.Params.Arguments)
+	updateFields := applyContactUpdates(existing, request.GetArguments())
 	if len(updateFields) == 0 {
 		return mcp.NewToolResultError("No fields to update - provide at least one field to modify"), nil
 	}
@@ -253,7 +253,7 @@ func TestableContactsDelete(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -287,18 +287,18 @@ func TestableContactsListGroups(ctx context.Context, request mcp.CallToolRequest
 
 	// Group fields
 	groupFields := DefaultGroupFields
-	if gf, ok := request.Params.Arguments["group_fields"].(string); ok && gf != "" {
+	if gf, ok := request.GetArguments()["group_fields"].(string); ok && gf != "" {
 		groupFields = gf
 	}
 	opts.GroupFields = groupFields
 
 	// Page size
-	if pageSize, ok := request.Params.Arguments["page_size"].(float64); ok && pageSize > 0 {
+	if pageSize, ok := request.GetArguments()["page_size"].(float64); ok && pageSize > 0 {
 		opts.PageSize = int32(pageSize)
 	}
 
 	// Page token
-	if pageToken, ok := request.Params.Arguments["page_token"].(string); ok && pageToken != "" {
+	if pageToken, ok := request.GetArguments()["page_token"].(string); ok && pageToken != "" {
 		opts.PageToken = pageToken
 	}
 
@@ -331,7 +331,7 @@ func TestableContactsGetGroup(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -342,13 +342,13 @@ func TestableContactsGetGroup(ctx context.Context, request mcp.CallToolRequest, 
 
 	// Group fields
 	groupFields := DefaultGroupFields + ",memberResourceNames"
-	if gf, ok := request.Params.Arguments["group_fields"].(string); ok && gf != "" {
+	if gf, ok := request.GetArguments()["group_fields"].(string); ok && gf != "" {
 		groupFields = gf
 	}
 	opts.GroupFields = groupFields
 
 	// Max members
-	if maxMembers, ok := request.Params.Arguments["max_members"].(float64); ok && maxMembers > 0 {
+	if maxMembers, ok := request.GetArguments()["max_members"].(float64); ok && maxMembers > 0 {
 		opts.MaxMembers = int32(maxMembers)
 	}
 
@@ -369,7 +369,7 @@ func TestableContactsCreateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -392,12 +392,12 @@ func TestableContactsUpdateGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -422,7 +422,7 @@ func TestableContactsDeleteGroup(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -450,7 +450,7 @@ func TestableContactsModifyGroupMembers(ctx context.Context, request mcp.CallToo
 		return errResult, nil
 	}
 
-	resourceName, errResult := common.RequireStringArg(request.Params.Arguments, "resource_name")
+	resourceName, errResult := common.RequireStringArg(request.GetArguments(), "resource_name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -460,7 +460,7 @@ func TestableContactsModifyGroupMembers(ctx context.Context, request mcp.CallToo
 	var addMembers, removeMembers []string
 
 	// Add members
-	if addRaw, ok := request.Params.Arguments["add_members"].([]any); ok && len(addRaw) > 0 {
+	if addRaw, ok := request.GetArguments()["add_members"].([]any); ok && len(addRaw) > 0 {
 		addMembers = make([]string, 0, len(addRaw))
 		for _, m := range addRaw {
 			if memberStr, ok := m.(string); ok {
@@ -470,7 +470,7 @@ func TestableContactsModifyGroupMembers(ctx context.Context, request mcp.CallToo
 	}
 
 	// Remove members
-	if removeRaw, ok := request.Params.Arguments["remove_members"].([]any); ok && len(removeRaw) > 0 {
+	if removeRaw, ok := request.GetArguments()["remove_members"].([]any); ok && len(removeRaw) > 0 {
 		removeMembers = make([]string, 0, len(removeRaw))
 		for _, m := range removeRaw {
 			if memberStr, ok := m.(string); ok {

--- a/internal/docs/docs_content_testable.go
+++ b/internal/docs/docs_content_testable.go
@@ -17,7 +17,7 @@ const docsEditURLFormat = "https://docs.google.com/document/d/%s/edit"
 // extractRequiredDocID extracts, validates, and normalizes the document_id parameter.
 // Returns the cleaned ID or an error result if missing.
 func extractRequiredDocID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	docID := common.ParseStringArg(request.Params.Arguments, "document_id", "")
+	docID := common.ParseStringArg(request.GetArguments(), "document_id", "")
 	if docID == "" {
 		return "", mcp.NewToolResultError("document_id parameter is required")
 	}
@@ -27,7 +27,7 @@ func extractRequiredDocID(request mcp.CallToolRequest) (string, *mcp.CallToolRes
 // extractIndexRange extracts and validates start_index and end_index from a request.
 // Both must be present, start_index >= 1, and end_index > start_index.
 func extractIndexRange(request mcp.CallToolRequest) (startIndex, endIndex int64, errResult *mcp.CallToolResult) {
-	startIndexFloat, ok := request.Params.Arguments["start_index"].(float64)
+	startIndexFloat, ok := request.GetArguments()["start_index"].(float64)
 	if !ok {
 		return 0, 0, mcp.NewToolResultError("start_index parameter is required (1-based position in document)")
 	}
@@ -36,7 +36,7 @@ func extractIndexRange(request mcp.CallToolRequest) (startIndex, endIndex int64,
 		return 0, 0, mcp.NewToolResultError("start_index must be at least 1")
 	}
 
-	endIndexFloat, ok := request.Params.Arguments["end_index"].(float64)
+	endIndexFloat, ok := request.GetArguments()["end_index"].(float64)
 	if !ok {
 		return 0, 0, mcp.NewToolResultError("end_index parameter is required (1-based position in document)")
 	}
@@ -55,7 +55,7 @@ func TestableDocsCreate(ctx context.Context, request mcp.CallToolRequest, deps *
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -149,7 +149,7 @@ func TestableDocsAppendText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	text, errResult := common.RequireStringArg(request.GetArguments(), "text")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -209,12 +209,12 @@ func TestableDocsInsertText(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	text, errResult := common.RequireStringArg(request.GetArguments(), "text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	indexFloat, ok := request.Params.Arguments["index"].(float64)
+	indexFloat, ok := request.GetArguments()["index"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("index parameter is required (1-based position in document)"), nil
 	}
@@ -256,15 +256,15 @@ func TestableDocsReplaceText(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	findText, errResult := common.RequireStringArg(request.Params.Arguments, "find_text")
+	findText, errResult := common.RequireStringArg(request.GetArguments(), "find_text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	replaceText := common.ParseStringArg(request.Params.Arguments, "replace_text", "")
+	replaceText := common.ParseStringArg(request.GetArguments(), "replace_text", "")
 	// replace_text can be empty (to delete matched text)
 
-	matchCase := common.ParseBoolArg(request.Params.Arguments, "match_case", false)
+	matchCase := common.ParseBoolArg(request.GetArguments(), "match_case", false)
 
 	replaceReq := &docs.ReplaceAllTextRequest{
 		ContainsText: &docs.SubstringMatchCriteria{
@@ -351,7 +351,7 @@ func TestableDocsBatchUpdate(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	requestsJSON := common.ParseStringArg(request.Params.Arguments, "requests", "")
+	requestsJSON := common.ParseStringArg(request.GetArguments(), "requests", "")
 	if requestsJSON == "" {
 		return mcp.NewToolResultError("requests parameter is required (JSON array of batch update requests)"), nil
 	}

--- a/internal/docs/docs_find_replace.go
+++ b/internal/docs/docs_find_replace.go
@@ -22,13 +22,13 @@ func TestableDocsFindAndReplace(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	findText, errResult := common.RequireStringArg(request.Params.Arguments, "find_text")
+	findText, errResult := common.RequireStringArg(request.GetArguments(), "find_text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	replaceText := common.ParseStringArg(request.Params.Arguments, "replace_text", "")
-	matchCase := common.ParseBoolArg(request.Params.Arguments, "match_case", true)
+	replaceText := common.ParseStringArg(request.GetArguments(), "replace_text", "")
+	matchCase := common.ParseBoolArg(request.GetArguments(), "match_case", true)
 
 	replaceReq := &docs.ReplaceAllTextRequest{
 		ContainsText: &docs.SubstringMatchCriteria{

--- a/internal/docs/docs_format_by_find.go
+++ b/internal/docs/docs_format_by_find.go
@@ -131,16 +131,16 @@ func TestableDocsFormatByFind(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	findText, errResult := common.RequireStringArg(request.Params.Arguments, "find_text")
+	findText, errResult := common.RequireStringArg(request.GetArguments(), "find_text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	matchCase := common.ParseBoolArg(request.Params.Arguments, "match_case", true)
-	matchAll := common.ParseBoolArg(request.Params.Arguments, "match_all", true)
+	matchCase := common.ParseBoolArg(request.GetArguments(), "match_case", true)
+	matchAll := common.ParseBoolArg(request.GetArguments(), "match_all", true)
 
 	// Validate and collect formatting fields
-	fields, validationErr := collectFields(request.Params.Arguments, textFormatFields)
+	fields, validationErr := collectFields(request.GetArguments(), textFormatFields)
 	if validationErr != nil {
 		return validationErr, nil
 	}
@@ -161,7 +161,7 @@ func TestableDocsFormatByFind(ctx context.Context, request mcp.CallToolRequest, 
 	}
 
 	// Build formatting requests for each match
-	textStyle := buildTextStyle(request.Params.Arguments)
+	textStyle := buildTextStyle(request.GetArguments())
 	fieldMask := strings.Join(fields, ",")
 
 	var requests []*docs.Request

--- a/internal/docs/docs_formatting_testable.go
+++ b/internal/docs/docs_formatting_testable.go
@@ -135,7 +135,7 @@ func TestableDocsFormatText(ctx context.Context, request mcp.CallToolRequest, de
 		return idxErrResult, nil
 	}
 
-	fields, validationErr := collectFields(request.Params.Arguments, textFormatFields)
+	fields, validationErr := collectFields(request.GetArguments(), textFormatFields)
 	if validationErr != nil {
 		return validationErr, nil
 	}
@@ -143,7 +143,7 @@ func TestableDocsFormatText(ctx context.Context, request mcp.CallToolRequest, de
 		return mcp.NewToolResultError("at least one formatting option must be specified"), nil
 	}
 
-	textStyle := buildTextStyle(request.Params.Arguments)
+	textStyle := buildTextStyle(request.GetArguments())
 	requests := []*docs.Request{{
 		UpdateTextStyle: &docs.UpdateTextStyleRequest{
 			Range: &docs.Range{
@@ -229,7 +229,7 @@ func TestableDocsSetParagraphStyle(ctx context.Context, request mcp.CallToolRequ
 		return idxErrResult, nil
 	}
 
-	fields, validationErr := collectFields(request.Params.Arguments, paragraphStyleFields)
+	fields, validationErr := collectFields(request.GetArguments(), paragraphStyleFields)
 	if validationErr != nil {
 		return validationErr, nil
 	}
@@ -237,7 +237,7 @@ func TestableDocsSetParagraphStyle(ctx context.Context, request mcp.CallToolRequ
 		return mcp.NewToolResultError("at least one paragraph style option must be specified"), nil
 	}
 
-	paraStyle := buildParagraphStyle(request.Params.Arguments)
+	paraStyle := buildParagraphStyle(request.GetArguments())
 	requests := []*docs.Request{{
 		UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
 			Range: &docs.Range{
@@ -282,7 +282,7 @@ func TestableDocsCreateList(ctx context.Context, request mcp.CallToolRequest, de
 	}
 
 	bulletPreset := "BULLET_DISC_CIRCLE_SQUARE"
-	if preset, ok := request.Params.Arguments["bullet_preset"].(string); ok && preset != "" {
+	if preset, ok := request.GetArguments()["bullet_preset"].(string); ok && preset != "" {
 		validPresets := map[string]bool{
 			"BULLET_DISC_CIRCLE_SQUARE":              true,
 			"BULLET_DIAMONDX_ARROW3D_SQUARE":         true,

--- a/internal/docs/docs_import.go
+++ b/internal/docs/docs_import.go
@@ -18,17 +18,17 @@ func TestableDocsImportToGoogleDoc(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	content, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	content, errResult := common.RequireStringArg(request.GetArguments(), "content")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	contentType := common.ParseStringArg(request.Params.Arguments, "content_type", "text/plain")
+	contentType := common.ParseStringArg(request.GetArguments(), "content_type", "text/plain")
 
 	// Validate content type
 	validTypes := map[string]bool{
@@ -48,7 +48,7 @@ func TestableDocsImportToGoogleDoc(ctx context.Context, request mcp.CallToolRequ
 	}
 
 	parentID := ""
-	if pid := common.ParseStringArg(request.Params.Arguments, "parent_id", ""); pid != "" {
+	if pid := common.ParseStringArg(request.GetArguments(), "parent_id", ""); pid != "" {
 		parentID = common.ExtractGoogleResourceID(pid)
 	}
 

--- a/internal/docs/docs_named_ranges.go
+++ b/internal/docs/docs_named_ranges.go
@@ -70,7 +70,7 @@ func TestableDocsCreateNamedRange(ctx context.Context, request mcp.CallToolReque
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -128,7 +128,7 @@ func TestableDocsDeleteNamedRange(ctx context.Context, request mcp.CallToolReque
 		return errResult, nil
 	}
 
-	namedRangeID, errResult := common.RequireStringArg(request.Params.Arguments, "named_range_id")
+	namedRangeID, errResult := common.RequireStringArg(request.GetArguments(), "named_range_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/docs/docs_structure_testable.go
+++ b/internal/docs/docs_structure_testable.go
@@ -21,13 +21,13 @@ func TestableDocsInsertTable(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	rowsFloat, ok := request.Params.Arguments["rows"].(float64)
+	rowsFloat, ok := request.GetArguments()["rows"].(float64)
 	if !ok || rowsFloat < 1 {
 		return mcp.NewToolResultError("rows parameter is required and must be at least 1"), nil
 	}
 	rows := int64(rowsFloat)
 
-	columnsFloat, ok := request.Params.Arguments["columns"].(float64)
+	columnsFloat, ok := request.GetArguments()["columns"].(float64)
 	if !ok || columnsFloat < 1 {
 		return mcp.NewToolResultError("columns parameter is required and must be at least 1"), nil
 	}
@@ -35,7 +35,7 @@ func TestableDocsInsertTable(ctx context.Context, request mcp.CallToolRequest, d
 
 	// Default index to 1 (beginning of document)
 	index := int64(1)
-	if indexFloat, ok := request.Params.Arguments["index"].(float64); ok {
+	if indexFloat, ok := request.GetArguments()["index"].(float64); ok {
 		index = int64(indexFloat)
 		if index < 1 {
 			return mcp.NewToolResultError("index must be at least 1"), nil
@@ -78,17 +78,17 @@ func TestableDocsInsertLink(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	text, errResult := common.RequireStringArg(request.Params.Arguments, "text")
+	text, errResult := common.RequireStringArg(request.GetArguments(), "text")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	linkURL, errResult := common.RequireStringArg(request.Params.Arguments, "url")
+	linkURL, errResult := common.RequireStringArg(request.GetArguments(), "url")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	indexFloat, ok := request.Params.Arguments["index"].(float64)
+	indexFloat, ok := request.GetArguments()["index"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("index parameter is required (1-based position in document)"), nil
 	}
@@ -156,7 +156,7 @@ func TestableDocsInsertPageBreak(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	indexFloat, ok := request.Params.Arguments["index"].(float64)
+	indexFloat, ok := request.GetArguments()["index"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("index parameter is required (1-based position in document)"), nil
 	}
@@ -197,12 +197,12 @@ func TestableDocsInsertImage(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	imageURI := common.ParseStringArg(request.Params.Arguments, "uri", "")
+	imageURI := common.ParseStringArg(request.GetArguments(), "uri", "")
 	if imageURI == "" {
 		return mcp.NewToolResultError("uri parameter is required (URL of the image)"), nil
 	}
 
-	indexFloat, ok := request.Params.Arguments["index"].(float64)
+	indexFloat, ok := request.GetArguments()["index"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("index parameter is required (1-based position in document)"), nil
 	}
@@ -288,7 +288,7 @@ func handleDocsCreateHeaderOrFooter(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Optionally insert content
-	content, hasContent := request.Params.Arguments["content"].(string)
+	content, hasContent := request.GetArguments()["content"].(string)
 	if hasContent && content != "" && sectionID != "" {
 		contentRequests := []*docs.Request{{
 			InsertText: &docs.InsertTextRequest{

--- a/internal/drive/drive_comments_testable.go
+++ b/internal/drive/drive_comments_testable.go
@@ -79,9 +79,9 @@ func TestableDriveListComments(ctx context.Context, request mcp.CallToolRequest,
 		return idErrResult, nil
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	includeDeleted := common.ParseBoolArg(request.Params.Arguments, "include_deleted", false)
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	includeDeleted := common.ParseBoolArg(request.GetArguments(), "include_deleted", false)
 
 	resp, err := srv.ListComments(ctx, fileID, DriveCommentListFields, maxResults, pageToken, includeDeleted)
 	if err != nil {
@@ -115,12 +115,12 @@ func TestableDriveGetComment(ctx context.Context, request mcp.CallToolRequest, d
 		return idErrResult, nil
 	}
 
-	commentID, errResult := common.RequireStringArg(request.Params.Arguments, "comment_id")
+	commentID, errResult := common.RequireStringArg(request.GetArguments(), "comment_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	includeDeleted := common.ParseBoolArg(request.Params.Arguments, "include_deleted", false)
+	includeDeleted := common.ParseBoolArg(request.GetArguments(), "include_deleted", false)
 
 	comment, err := srv.GetComment(ctx, fileID, commentID, DriveCommentFields, includeDeleted)
 	if err != nil {
@@ -145,7 +145,7 @@ func TestableDriveCreateComment(ctx context.Context, request mcp.CallToolRequest
 		return idErrResult, nil
 	}
 
-	content, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	content, errResult := common.RequireStringArg(request.GetArguments(), "content")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -177,12 +177,12 @@ func TestableDriveUpdateComment(ctx context.Context, request mcp.CallToolRequest
 		return idErrResult, nil
 	}
 
-	commentID, errResult := common.RequireStringArg(request.Params.Arguments, "comment_id")
+	commentID, errResult := common.RequireStringArg(request.GetArguments(), "comment_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	content, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	content, errResult := common.RequireStringArg(request.GetArguments(), "content")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -214,7 +214,7 @@ func TestableDriveDeleteComment(ctx context.Context, request mcp.CallToolRequest
 		return idErrResult, nil
 	}
 
-	commentID, errResult := common.RequireStringArg(request.Params.Arguments, "comment_id")
+	commentID, errResult := common.RequireStringArg(request.GetArguments(), "comment_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -246,14 +246,14 @@ func TestableDriveListReplies(ctx context.Context, request mcp.CallToolRequest, 
 		return idErrResult, nil
 	}
 
-	commentID, errResult := common.RequireStringArg(request.Params.Arguments, "comment_id")
+	commentID, errResult := common.RequireStringArg(request.GetArguments(), "comment_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	includeDeleted := common.ParseBoolArg(request.Params.Arguments, "include_deleted", false)
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	includeDeleted := common.ParseBoolArg(request.GetArguments(), "include_deleted", false)
 
 	resp, err := srv.ListReplies(ctx, fileID, commentID, DriveReplyListFields, maxResults, pageToken, includeDeleted)
 	if err != nil {
@@ -288,12 +288,12 @@ func TestableDriveCreateReply(ctx context.Context, request mcp.CallToolRequest, 
 		return idErrResult, nil
 	}
 
-	commentID, errResult := common.RequireStringArg(request.Params.Arguments, "comment_id")
+	commentID, errResult := common.RequireStringArg(request.GetArguments(), "comment_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	content, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	content, errResult := common.RequireStringArg(request.GetArguments(), "content")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -303,7 +303,7 @@ func TestableDriveCreateReply(ctx context.Context, request mcp.CallToolRequest, 
 	}
 
 	// Support resolve/reopen action
-	action := common.ParseStringArg(request.Params.Arguments, "action", "")
+	action := common.ParseStringArg(request.GetArguments(), "action", "")
 	if action != "" {
 		if action != "resolve" && action != "reopen" {
 			return mcp.NewToolResultError("invalid action: must be 'resolve' or 'reopen'"), nil

--- a/internal/drive/drive_files_testable.go
+++ b/internal/drive/drive_files_testable.go
@@ -19,13 +19,13 @@ func TestableDriveSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	query, errResult := common.RequireStringArg(request.GetArguments(), "query")
 	if errResult != nil {
 		return errResult, nil
 	}
 
 	// Apply friendly file_type filter if provided
-	fileType := common.ParseStringArg(request.Params.Arguments, "file_type", "")
+	fileType := common.ParseStringArg(request.GetArguments(), "file_type", "")
 	if fileType != "" {
 		mimeType, ok := friendlyFileTypes[strings.ToLower(fileType)]
 		if !ok {
@@ -43,9 +43,9 @@ func TestableDriveSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 		}
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	corpora := common.ParseStringArg(request.Params.Arguments, "corpora", "allDrives")
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	corpora := common.ParseStringArg(request.GetArguments(), "corpora", "allDrives")
 
 	resp, err := srv.ListFiles(ctx, &ListFilesOptions{
 		Query:     query,
@@ -160,12 +160,12 @@ func TestableDriveUpload(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	contentStr, errResult := common.RequireStringArg(request.Params.Arguments, "content")
+	contentStr, errResult := common.RequireStringArg(request.GetArguments(), "content")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -177,7 +177,7 @@ func TestableDriveUpload(ctx context.Context, request mcp.CallToolRequest, deps 
 
 	// Decode content if base64 encoded
 	var data []byte
-	encoding := common.ParseStringArg(request.Params.Arguments, "encoding", "")
+	encoding := common.ParseStringArg(request.GetArguments(), "encoding", "")
 	if encoding == "base64" {
 		var err error
 		data, err = base64.StdEncoding.DecodeString(contentStr)
@@ -196,15 +196,15 @@ func TestableDriveUpload(ctx context.Context, request mcp.CallToolRequest, deps 
 		Name: name,
 	}
 
-	if parentID := common.ParseStringArg(request.Params.Arguments, "parent_id", ""); parentID != "" {
+	if parentID := common.ParseStringArg(request.GetArguments(), "parent_id", ""); parentID != "" {
 		file.Parents = []string{common.ExtractGoogleResourceID(parentID)}
 	}
 
-	if mimeType := common.ParseStringArg(request.Params.Arguments, "mime_type", ""); mimeType != "" {
+	if mimeType := common.ParseStringArg(request.GetArguments(), "mime_type", ""); mimeType != "" {
 		file.MimeType = mimeType
 	}
 
-	if description := common.ParseStringArg(request.Params.Arguments, "description", ""); description != "" {
+	if description := common.ParseStringArg(request.GetArguments(), "description", ""); description != "" {
 		file.Description = description
 	}
 
@@ -232,15 +232,15 @@ func TestableDriveList(ctx context.Context, request mcp.CallToolRequest, deps *D
 		return errResult, nil
 	}
 
-	folderID := common.ParseStringArg(request.Params.Arguments, "folder_id", "root")
+	folderID := common.ParseStringArg(request.GetArguments(), "folder_id", "root")
 	if folderID != "root" {
 		folderID = common.ExtractGoogleResourceID(folderID)
 	}
 
 	query := fmt.Sprintf("'%s' in parents and trashed = false", folderID)
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveListDefaultMaxResults, common.DriveListMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	orderBy := common.ParseStringArg(request.Params.Arguments, "order_by", "name")
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.DriveListDefaultMaxResults, common.DriveListMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	orderBy := common.ParseStringArg(request.GetArguments(), "order_by", "name")
 
 	resp, err := srv.ListFiles(ctx, &ListFilesOptions{
 		Query:     query,
@@ -281,7 +281,7 @@ func TestableDriveCreateFolder(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -291,11 +291,11 @@ func TestableDriveCreateFolder(ctx context.Context, request mcp.CallToolRequest,
 		MimeType: "application/vnd.google-apps.folder",
 	}
 
-	if parentID := common.ParseStringArg(request.Params.Arguments, "parent_id", ""); parentID != "" {
+	if parentID := common.ParseStringArg(request.GetArguments(), "parent_id", ""); parentID != "" {
 		folder.Parents = []string{common.ExtractGoogleResourceID(parentID)}
 	}
 
-	if description := common.ParseStringArg(request.Params.Arguments, "description", ""); description != "" {
+	if description := common.ParseStringArg(request.GetArguments(), "description", ""); description != "" {
 		folder.Description = description
 	}
 
@@ -326,7 +326,7 @@ func TestableDriveMove(ctx context.Context, request mcp.CallToolRequest, deps *D
 		return idErrResult, nil
 	}
 
-	newParentID, errResult := common.RequireStringArg(request.Params.Arguments, "new_parent_id")
+	newParentID, errResult := common.RequireStringArg(request.GetArguments(), "new_parent_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -371,11 +371,11 @@ func TestableDriveCopy(ctx context.Context, request mcp.CallToolRequest, deps *D
 
 	copyFile := &drive.File{}
 
-	if name := common.ParseStringArg(request.Params.Arguments, "name", ""); name != "" {
+	if name := common.ParseStringArg(request.GetArguments(), "name", ""); name != "" {
 		copyFile.Name = name
 	}
 
-	if parentID := common.ParseStringArg(request.Params.Arguments, "parent_id", ""); parentID != "" {
+	if parentID := common.ParseStringArg(request.GetArguments(), "parent_id", ""); parentID != "" {
 		copyFile.Parents = []string{common.ExtractGoogleResourceID(parentID)}
 	}
 

--- a/internal/drive/drive_revisions_testable.go
+++ b/internal/drive/drive_revisions_testable.go
@@ -54,8 +54,8 @@ func TestableDriveListRevisions(ctx context.Context, request mcp.CallToolRequest
 		return idErrResult, nil
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.DriveSearchDefaultMaxResults, common.DriveSearchMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	resp, err := srv.ListRevisions(ctx, fileID, DriveRevisionListFields, maxResults, pageToken)
 	if err != nil {
@@ -89,7 +89,7 @@ func TestableDriveGetRevision(ctx context.Context, request mcp.CallToolRequest, 
 		return idErrResult, nil
 	}
 
-	revisionID, errResult := common.RequireStringArg(request.Params.Arguments, "revision_id")
+	revisionID, errResult := common.RequireStringArg(request.GetArguments(), "revision_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -117,7 +117,7 @@ func TestableDriveDownloadRevision(ctx context.Context, request mcp.CallToolRequ
 		return idErrResult, nil
 	}
 
-	revisionID, errResult := common.RequireStringArg(request.Params.Arguments, "revision_id")
+	revisionID, errResult := common.RequireStringArg(request.GetArguments(), "revision_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/drive/drive_shared_helpers.go
+++ b/internal/drive/drive_shared_helpers.go
@@ -25,7 +25,7 @@ var googleWorkspaceExportMIME = map[string]string{
 // extractRequiredFileID extracts, validates, and normalizes the file_id parameter.
 // Returns the cleaned ID or an error result if missing.
 func extractRequiredFileID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	fileID := common.ParseStringArg(request.Params.Arguments, "file_id", "")
+	fileID := common.ParseStringArg(request.GetArguments(), "file_id", "")
 	if fileID == "" {
 		return "", mcp.NewToolResultError("file_id parameter is required")
 	}

--- a/internal/drive/drive_sharing_testable.go
+++ b/internal/drive/drive_sharing_testable.go
@@ -21,13 +21,13 @@ func TestableDriveShare(ctx context.Context, request mcp.CallToolRequest, deps *
 		return idErrResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "email")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	role := common.ParseStringArg(request.Params.Arguments, "role", "reader")
-	permType := common.ParseStringArg(request.Params.Arguments, "type", "user")
+	role := common.ParseStringArg(request.GetArguments(), "role", "reader")
+	permType := common.ParseStringArg(request.GetArguments(), "type", "user")
 
 	permission := &drive.Permission{
 		Type:         permType,
@@ -35,7 +35,7 @@ func TestableDriveShare(ctx context.Context, request mcp.CallToolRequest, deps *
 		EmailAddress: email,
 	}
 
-	sendNotification := common.ParseBoolArg(request.Params.Arguments, "send_notification", true)
+	sendNotification := common.ParseBoolArg(request.GetArguments(), "send_notification", true)
 
 	created, err := srv.CreatePermission(ctx, fileID, permission, sendNotification)
 	if err != nil {

--- a/internal/driveactivity/driveactivity_testable.go
+++ b/internal/driveactivity/driveactivity_testable.go
@@ -20,11 +20,11 @@ func TestableDriveActivityQuery(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	itemID := common.ParseStringArg(request.Params.Arguments, "item_id", "")
-	folderID := common.ParseStringArg(request.Params.Arguments, "folder_id", "")
-	filter := common.ParseStringArg(request.Params.Arguments, "filter", "")
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	pageSize := common.ParseMaxResults(request.Params.Arguments, 20, 100)
+	itemID := common.ParseStringArg(request.GetArguments(), "item_id", "")
+	folderID := common.ParseStringArg(request.GetArguments(), "folder_id", "")
+	filter := common.ParseStringArg(request.GetArguments(), "filter", "")
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), 20, 100)
 
 	if itemID == "" && folderID == "" {
 		return mcp.NewToolResultError("either item_id or folder_id parameter is required"), nil

--- a/internal/forms/forms_testable.go
+++ b/internal/forms/forms_testable.go
@@ -13,7 +13,7 @@ const formsEditURLFormat = "https://docs.google.com/forms/d/%s/edit"
 
 // extractRequiredFormID extracts, validates, and normalizes the form_id parameter.
 func extractRequiredFormID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	formID := common.ParseStringArg(request.Params.Arguments, "form_id", "")
+	formID := common.ParseStringArg(request.GetArguments(), "form_id", "")
 	if formID == "" {
 		return "", mcp.NewToolResultError("form_id parameter is required")
 	}
@@ -74,7 +74,7 @@ func TestableFormsCreate(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -109,7 +109,7 @@ func TestableFormsBatchUpdate(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	requestsJSON, errResult := common.RequireStringArg(request.Params.Arguments, "requests")
+	requestsJSON, errResult := common.RequireStringArg(request.GetArguments(), "requests")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -175,7 +175,7 @@ func TestableFormsGetResponse(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	responseID, errResult := common.RequireStringArg(request.Params.Arguments, "response_id")
+	responseID, errResult := common.RequireStringArg(request.GetArguments(), "response_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/gmail/gmail_helpers.go
+++ b/internal/gmail/gmail_helpers.go
@@ -91,7 +91,7 @@ func buildEmailMessage(msg EmailMessage) string {
 // operations (archive, star, mark read, spam, etc.). It extracts message_id from
 // the request, applies the specified label changes, and returns a standard result.
 func modifyMessageLabels(ctx context.Context, svc GmailService, request mcp.CallToolRequest, addLabels, removeLabels []string) (*mcp.CallToolResult, error) {
-	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -113,7 +113,7 @@ func modifyMessageLabels(ctx context.Context, svc GmailService, request mcp.Call
 // operations (batch archive, batch trash). It extracts message_ids from the
 // request, applies the specified label changes, and returns a standard result.
 func batchModifyLabels(ctx context.Context, svc GmailService, request mcp.CallToolRequest, addLabels, removeLabels []string, countKey string) (*mcp.CallToolResult, error) {
-	messageIDs := extractStringArray(request.Params.Arguments["message_ids"])
+	messageIDs := extractStringArray(request.GetArguments()["message_ids"])
 	if len(messageIDs) == 0 {
 		return mcp.NewToolResultError("message_ids parameter is required"), nil
 	}

--- a/internal/gmail/gmail_tools_test.go
+++ b/internal/gmail/gmail_tools_test.go
@@ -14,13 +14,7 @@ import (
 // Helper function to create a CallToolRequest from a map
 func makeRequest(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	}

--- a/internal/gmail/testable_drafts.go
+++ b/internal/gmail/testable_drafts.go
@@ -16,8 +16,8 @@ func TestableGmailListDrafts(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.GmailDefaultMaxResults, common.GmailMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.GmailDefaultMaxResults, common.GmailMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	resp, err := svc.ListDrafts(ctx, maxResults, pageToken)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestableGmailListDrafts(ctx context.Context, request mcp.CallToolRequest, d
 
 // TestableGmailGetDraft retrieves a draft by ID.
 func TestableGmailGetDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	draftID, errResult := common.RequireStringArg(request.GetArguments(), "draft_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -63,7 +63,7 @@ func TestableGmailGetDraft(ctx context.Context, request mcp.CallToolRequest, dep
 		return errResult, nil
 	}
 
-	format := common.ParseStringArg(request.Params.Arguments, "format", "full")
+	format := common.ParseStringArg(request.GetArguments(), "format", "full")
 
 	draft, err := svc.GetDraft(ctx, draftID, format)
 	if err != nil {
@@ -83,7 +83,7 @@ func TestableGmailGetDraft(ctx context.Context, request mcp.CallToolRequest, dep
 
 // TestableGmailUpdateDraft updates an existing draft.
 func TestableGmailUpdateDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	draftID, errResult := common.RequireStringArg(request.GetArguments(), "draft_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -94,7 +94,7 @@ func TestableGmailUpdateDraft(ctx context.Context, request mcp.CallToolRequest, 
 	}
 
 	draft := &gmail.Draft{
-		Message: buildMessageFromArgs(request.Params.Arguments),
+		Message: buildMessageFromArgs(request.GetArguments()),
 	}
 
 	updated, err := svc.UpdateDraft(ctx, draftID, draft)
@@ -115,7 +115,7 @@ func TestableGmailUpdateDraft(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailDeleteDraft deletes a draft.
 func TestableGmailDeleteDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	draftID, errResult := common.RequireStringArg(request.GetArguments(), "draft_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -140,7 +140,7 @@ func TestableGmailDeleteDraft(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailSendDraft sends a draft.
 func TestableGmailSendDraft(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	draftID, errResult := common.RequireStringArg(request.Params.Arguments, "draft_id")
+	draftID, errResult := common.RequireStringArg(request.GetArguments(), "draft_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -175,10 +175,10 @@ func TestableGmailDraft(ctx context.Context, request mcp.CallToolRequest, deps *
 		return errResult, nil
 	}
 
-	message := buildMessageFromArgs(request.Params.Arguments)
+	message := buildMessageFromArgs(request.GetArguments())
 
 	// Support creating draft as reply
-	if threadID := common.ParseStringArg(request.Params.Arguments, "thread_id", ""); threadID != "" {
+	if threadID := common.ParseStringArg(request.GetArguments(), "thread_id", ""); threadID != "" {
 		message.ThreadId = threadID
 	}
 

--- a/internal/gmail/testable_filters.go
+++ b/internal/gmail/testable_filters.go
@@ -85,38 +85,38 @@ func TestableGmailCreateFilter(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Criteria
-	if val := common.ParseStringArg(request.Params.Arguments, "from", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "from", ""); val != "" {
 		filter.Criteria.From = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "to", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "to", ""); val != "" {
 		filter.Criteria.To = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "subject", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "subject", ""); val != "" {
 		filter.Criteria.Subject = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "query", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "query", ""); val != "" {
 		filter.Criteria.Query = val
 	}
-	if val := common.ParseBoolArg(request.Params.Arguments, "has_attachment", false); val {
+	if val := common.ParseBoolArg(request.GetArguments(), "has_attachment", false); val {
 		filter.Criteria.HasAttachment = true
 	}
 
 	// Action
-	if add, ok := request.Params.Arguments["add_label_ids"].([]any); ok {
+	if add, ok := request.GetArguments()["add_label_ids"].([]any); ok {
 		for _, l := range add {
 			if s, ok := l.(string); ok {
 				filter.Action.AddLabelIds = append(filter.Action.AddLabelIds, s)
 			}
 		}
 	}
-	if remove, ok := request.Params.Arguments["remove_label_ids"].([]any); ok {
+	if remove, ok := request.GetArguments()["remove_label_ids"].([]any); ok {
 		for _, l := range remove {
 			if s, ok := l.(string); ok {
 				filter.Action.RemoveLabelIds = append(filter.Action.RemoveLabelIds, s)
 			}
 		}
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "forward", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "forward", ""); val != "" {
 		filter.Action.Forward = val
 	}
 
@@ -134,7 +134,7 @@ func TestableGmailCreateFilter(ctx context.Context, request mcp.CallToolRequest,
 
 // TestableGmailDeleteFilter deletes a filter.
 func TestableGmailDeleteFilter(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	filterID, errResult := common.RequireStringArg(request.Params.Arguments, "filter_id")
+	filterID, errResult := common.RequireStringArg(request.GetArguments(), "filter_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/gmail/testable_labels.go
+++ b/internal/gmail/testable_labels.go
@@ -12,7 +12,7 @@ import (
 // extractRequiredMessageIDs extracts and validates the message_ids parameter from the request.
 // Returns the raw slice for early validation and the parsed string IDs.
 func extractRequiredMessageIDs(request mcp.CallToolRequest) ([]string, *mcp.CallToolResult) {
-	messageIDsRaw, ok := request.Params.Arguments["message_ids"].([]any)
+	messageIDsRaw, ok := request.GetArguments()["message_ids"].([]any)
 	if !ok || len(messageIDsRaw) == 0 {
 		return nil, mcp.NewToolResultError("message_ids parameter is required (array)")
 	}
@@ -83,7 +83,7 @@ func TestableGmailListLabels(ctx context.Context, request mcp.CallToolRequest, d
 
 // TestableGmailCreateLabel creates a new label.
 func TestableGmailCreateLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -97,10 +97,10 @@ func TestableGmailCreateLabel(ctx context.Context, request mcp.CallToolRequest, 
 		Name: name,
 	}
 
-	if vis := common.ParseStringArg(request.Params.Arguments, "label_list_visibility", ""); vis != "" {
+	if vis := common.ParseStringArg(request.GetArguments(), "label_list_visibility", ""); vis != "" {
 		label.LabelListVisibility = vis
 	}
-	if vis := common.ParseStringArg(request.Params.Arguments, "message_list_visibility", ""); vis != "" {
+	if vis := common.ParseStringArg(request.GetArguments(), "message_list_visibility", ""); vis != "" {
 		label.MessageListVisibility = vis
 	}
 
@@ -120,7 +120,7 @@ func TestableGmailCreateLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailDeleteLabel deletes a label.
 func TestableGmailDeleteLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	labelID, errResult := common.RequireStringArg(request.Params.Arguments, "label_id")
+	labelID, errResult := common.RequireStringArg(request.GetArguments(), "label_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -145,7 +145,7 @@ func TestableGmailDeleteLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailUpdateLabel updates a label.
 func TestableGmailUpdateLabel(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	labelID, errResult := common.RequireStringArg(request.Params.Arguments, "label_id")
+	labelID, errResult := common.RequireStringArg(request.GetArguments(), "label_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -159,13 +159,13 @@ func TestableGmailUpdateLabel(ctx context.Context, request mcp.CallToolRequest, 
 		Id: labelID,
 	}
 
-	if name := common.ParseStringArg(request.Params.Arguments, "name", ""); name != "" {
+	if name := common.ParseStringArg(request.GetArguments(), "name", ""); name != "" {
 		label.Name = name
 	}
-	if vis := common.ParseStringArg(request.Params.Arguments, "label_list_visibility", ""); vis != "" {
+	if vis := common.ParseStringArg(request.GetArguments(), "label_list_visibility", ""); vis != "" {
 		label.LabelListVisibility = vis
 	}
-	if vis := common.ParseStringArg(request.Params.Arguments, "message_list_visibility", ""); vis != "" {
+	if vis := common.ParseStringArg(request.GetArguments(), "message_list_visibility", ""); vis != "" {
 		label.MessageListVisibility = vis
 	}
 
@@ -185,7 +185,7 @@ func TestableGmailUpdateLabel(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailModifyMessage modifies labels on a message.
 func TestableGmailModifyMessage(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	if _, errResult := common.RequireStringArg(request.Params.Arguments, "message_id"); errResult != nil {
+	if _, errResult := common.RequireStringArg(request.GetArguments(), "message_id"); errResult != nil {
 		return errResult, nil
 	}
 
@@ -194,13 +194,13 @@ func TestableGmailModifyMessage(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	addLabels, removeLabels := extractAddRemoveLabels(request.Params.Arguments)
+	addLabels, removeLabels := extractAddRemoveLabels(request.GetArguments())
 	return modifyMessageLabels(ctx, svc, request, addLabels, removeLabels)
 }
 
 // TestableGmailModifyThread modifies labels on a thread.
 func TestableGmailModifyThread(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	threadID, errResult := common.RequireStringArg(request.GetArguments(), "thread_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -210,7 +210,7 @@ func TestableGmailModifyThread(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	addLabels, removeLabels := extractAddRemoveLabels(request.Params.Arguments)
+	addLabels, removeLabels := extractAddRemoveLabels(request.GetArguments())
 	modifyRequest := &gmail.ModifyThreadRequest{
 		AddLabelIds:    addLabels,
 		RemoveLabelIds: removeLabels,
@@ -236,7 +236,7 @@ func TestableGmailBatchModify(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	addLabels, removeLabels := extractAddRemoveLabels(request.Params.Arguments)
+	addLabels, removeLabels := extractAddRemoveLabels(request.GetArguments())
 	req := &gmail.BatchModifyMessagesRequest{
 		Ids:            ids,
 		AddLabelIds:    addLabels,

--- a/internal/gmail/testable_messages.go
+++ b/internal/gmail/testable_messages.go
@@ -12,7 +12,7 @@ import (
 
 // TestableGmailSearch performs a Gmail search using the provided service.
 func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	query, errResult := common.RequireStringArg(request.Params.Arguments, "query")
+	query, errResult := common.RequireStringArg(request.GetArguments(), "query")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -22,8 +22,8 @@ func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	maxResults := common.ParseMaxResults(request.Params.Arguments, common.GmailDefaultMaxResults, common.GmailMaxResultsLimit)
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	maxResults := common.ParseMaxResults(request.GetArguments(), common.GmailDefaultMaxResults, common.GmailMaxResultsLimit)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	resp, err := svc.ListMessages(ctx, query, maxResults, pageToken)
 	if err != nil {
@@ -54,7 +54,7 @@ func TestableGmailSearch(ctx context.Context, request mcp.CallToolRequest, deps 
 
 // TestableGmailGetMessage retrieves a single message using the provided service.
 func TestableGmailGetMessage(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -64,20 +64,20 @@ func TestableGmailGetMessage(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	format := common.ParseStringArg(request.Params.Arguments, "format", "full")
+	format := common.ParseStringArg(request.GetArguments(), "format", "full")
 
 	msg, err := svc.GetMessage(ctx, messageID, format)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
 	}
 
-	result := FormatMessageWithOptions(msg, FormatMessageOptions{BodyFormat: parseBodyFormat(request.Params.Arguments)})
+	result := FormatMessageWithOptions(msg, FormatMessageOptions{BodyFormat: parseBodyFormat(request.GetArguments())})
 	return common.MarshalToolResult(result)
 }
 
 // TestableGmailGetMessages retrieves multiple messages using the provided service.
 func TestableGmailGetMessages(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageIDsRaw, ok := request.Params.Arguments["message_ids"].([]any)
+	messageIDsRaw, ok := request.GetArguments()["message_ids"].([]any)
 	if !ok || len(messageIDsRaw) == 0 {
 		return mcp.NewToolResultError("message_ids parameter is required (array of message IDs)"), nil
 	}
@@ -91,12 +91,12 @@ func TestableGmailGetMessages(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	format := common.ParseStringArg(request.Params.Arguments, "format", "full")
+	format := common.ParseStringArg(request.GetArguments(), "format", "full")
 
 	messages := make([]map[string]any, 0, len(messageIDsRaw))
 	var errors []string
 
-	opts := FormatMessageOptions{BodyFormat: parseBodyFormat(request.Params.Arguments)}
+	opts := FormatMessageOptions{BodyFormat: parseBodyFormat(request.GetArguments())}
 	for _, idRaw := range messageIDsRaw {
 		messageID, ok := idRaw.(string)
 		if !ok {
@@ -125,7 +125,7 @@ func TestableGmailGetMessages(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailSend sends a new email using the provided service.
 func TestableGmailSend(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	if _, errResult := common.RequireStringArg(request.Params.Arguments, "to"); errResult != nil {
+	if _, errResult := common.RequireStringArg(request.GetArguments(), "to"); errResult != nil {
 		return errResult, nil
 	}
 
@@ -134,7 +134,7 @@ func TestableGmailSend(ctx context.Context, request mcp.CallToolRequest, deps *G
 		return errResult, nil
 	}
 
-	message := buildMessageFromArgs(request.Params.Arguments)
+	message := buildMessageFromArgs(request.GetArguments())
 
 	sent, err := svc.SendMessage(ctx, message)
 	if err != nil {
@@ -152,12 +152,12 @@ func TestableGmailSend(ctx context.Context, request mcp.CallToolRequest, deps *G
 
 // TestableGmailReply replies to an email using the provided service.
 func TestableGmailReply(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID := common.ParseStringArg(request.Params.Arguments, "message_id", "")
+	messageID := common.ParseStringArg(request.GetArguments(), "message_id", "")
 	if messageID == "" {
 		return mcp.NewToolResultError("message_id parameter is required (the message you're replying to)"), nil
 	}
 
-	body, bodyErr := common.RequireStringArg(request.Params.Arguments, "body")
+	body, bodyErr := common.RequireStringArg(request.GetArguments(), "body")
 	if bodyErr != nil {
 		return bodyErr, nil
 	}
@@ -194,11 +194,11 @@ func TestableGmailReply(ctx context.Context, request mcp.CallToolRequest, deps *
 	}
 
 	replyTo := origFrom
-	if to := common.ParseStringArg(request.Params.Arguments, "to", ""); to != "" {
+	if to := common.ParseStringArg(request.GetArguments(), "to", ""); to != "" {
 		replyTo = to
 	}
 
-	replyAll := common.ParseBoolArg(request.Params.Arguments, "reply_all", false)
+	replyAll := common.ParseBoolArg(request.GetArguments(), "reply_all", false)
 
 	var cc string
 	if replyAll {
@@ -211,7 +211,7 @@ func TestableGmailReply(ctx context.Context, request mcp.CallToolRequest, deps *
 		}
 		cc = strings.Join(ccList, ", ")
 	}
-	if ccOverride := common.ParseStringArg(request.Params.Arguments, "cc", ""); ccOverride != "" {
+	if ccOverride := common.ParseStringArg(request.GetArguments(), "cc", ""); ccOverride != "" {
 		cc = ccOverride
 	}
 
@@ -277,7 +277,7 @@ func TestableGmailNotSpam(ctx context.Context, request mcp.CallToolRequest, deps
 
 // TestableGmailTrash moves a message to trash.
 func TestableGmailTrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -303,7 +303,7 @@ func TestableGmailTrash(ctx context.Context, request mcp.CallToolRequest, deps *
 
 // TestableGmailUntrash removes a message from trash.
 func TestableGmailUntrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -329,12 +329,12 @@ func TestableGmailUntrash(ctx context.Context, request mcp.CallToolRequest, deps
 
 // TestableGmailGetAttachment downloads an attachment.
 func TestableGmailGetAttachment(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	messageID, errResult := common.RequireStringArg(request.Params.Arguments, "message_id")
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	attachmentID, errResult := common.RequireStringArg(request.Params.Arguments, "attachment_id")
+	attachmentID, errResult := common.RequireStringArg(request.GetArguments(), "attachment_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/gmail/testable_sendas_delegates.go
+++ b/internal/gmail/testable_sendas_delegates.go
@@ -41,7 +41,7 @@ func TestableGmailGetSendAs(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "send_as_email")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -61,7 +61,7 @@ func TestableGmailCreateSendAs(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "send_as_email")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -70,35 +70,35 @@ func TestableGmailCreateSendAs(ctx context.Context, request mcp.CallToolRequest,
 		SendAsEmail: email,
 	}
 
-	if val := common.ParseStringArg(request.Params.Arguments, "display_name", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "display_name", ""); val != "" {
 		sendAs.DisplayName = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "reply_to_address", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "reply_to_address", ""); val != "" {
 		sendAs.ReplyToAddress = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "signature", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "signature", ""); val != "" {
 		sendAs.Signature = val
 	}
-	if val, ok := request.Params.Arguments["is_default"].(bool); ok && val {
+	if val, ok := request.GetArguments()["is_default"].(bool); ok && val {
 		sendAs.IsDefault = val
 	}
 
 	// SMTP configuration for external send-as
-	smtpHost := common.ParseStringArg(request.Params.Arguments, "smtp_host", "")
+	smtpHost := common.ParseStringArg(request.GetArguments(), "smtp_host", "")
 	if smtpHost != "" {
 		sendAs.SmtpMsa = &gmail.SmtpMsa{
 			Host: smtpHost,
 		}
-		if port, ok := request.Params.Arguments["smtp_port"].(float64); ok {
+		if port, ok := request.GetArguments()["smtp_port"].(float64); ok {
 			sendAs.SmtpMsa.Port = int64(port)
 		}
-		if val := common.ParseStringArg(request.Params.Arguments, "smtp_username", ""); val != "" {
+		if val := common.ParseStringArg(request.GetArguments(), "smtp_username", ""); val != "" {
 			sendAs.SmtpMsa.Username = val
 		}
-		if val := common.ParseStringArg(request.Params.Arguments, "smtp_password", ""); val != "" {
+		if val := common.ParseStringArg(request.GetArguments(), "smtp_password", ""); val != "" {
 			sendAs.SmtpMsa.Password = val
 		}
-		if val := common.ParseStringArg(request.Params.Arguments, "smtp_security_mode", ""); val != "" {
+		if val := common.ParseStringArg(request.GetArguments(), "smtp_security_mode", ""); val != "" {
 			sendAs.SmtpMsa.SecurityMode = val
 		}
 	}
@@ -121,23 +121,23 @@ func TestableGmailUpdateSendAs(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "send_as_email")
 	if errResult != nil {
 		return errResult, nil
 	}
 
 	sendAs := &gmail.SendAs{}
 
-	if val := common.ParseStringArg(request.Params.Arguments, "display_name", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "display_name", ""); val != "" {
 		sendAs.DisplayName = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "reply_to_address", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "reply_to_address", ""); val != "" {
 		sendAs.ReplyToAddress = val
 	}
-	if val := common.ParseStringArg(request.Params.Arguments, "signature", ""); val != "" {
+	if val := common.ParseStringArg(request.GetArguments(), "signature", ""); val != "" {
 		sendAs.Signature = val
 	}
-	if val, ok := request.Params.Arguments["is_default"].(bool); ok {
+	if val, ok := request.GetArguments()["is_default"].(bool); ok {
 		sendAs.IsDefault = val
 	}
 
@@ -159,7 +159,7 @@ func TestableGmailDeleteSendAs(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "send_as_email")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -183,7 +183,7 @@ func TestableGmailVerifySendAs(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "send_as_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "send_as_email")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -232,7 +232,7 @@ func TestableGmailCreateDelegate(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "delegate_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "delegate_email")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -259,7 +259,7 @@ func TestableGmailDeleteDelegate(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	email, errResult := common.RequireStringArg(request.Params.Arguments, "delegate_email")
+	email, errResult := common.RequireStringArg(request.GetArguments(), "delegate_email")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/gmail/testable_settings.go
+++ b/internal/gmail/testable_settings.go
@@ -71,28 +71,28 @@ func TestableGmailSetVacation(ctx context.Context, request mcp.CallToolRequest, 
 
 	settings := &gmail.VacationSettings{}
 
-	if val, ok := request.Params.Arguments["enabled"].(bool); ok {
+	if val, ok := request.GetArguments()["enabled"].(bool); ok {
 		settings.EnableAutoReply = val
 	}
-	if val, ok := request.Params.Arguments["subject"].(string); ok {
+	if val, ok := request.GetArguments()["subject"].(string); ok {
 		settings.ResponseSubject = val
 	}
-	if val, ok := request.Params.Arguments["body"].(string); ok {
+	if val, ok := request.GetArguments()["body"].(string); ok {
 		settings.ResponseBodyPlainText = val
 	}
-	if val, ok := request.Params.Arguments["body_html"].(string); ok {
+	if val, ok := request.GetArguments()["body_html"].(string); ok {
 		settings.ResponseBodyHtml = val
 	}
-	if val, ok := request.Params.Arguments["restrict_to_contacts"].(bool); ok {
+	if val, ok := request.GetArguments()["restrict_to_contacts"].(bool); ok {
 		settings.RestrictToContacts = val
 	}
-	if val, ok := request.Params.Arguments["restrict_to_domain"].(bool); ok {
+	if val, ok := request.GetArguments()["restrict_to_domain"].(bool); ok {
 		settings.RestrictToDomain = val
 	}
-	if val, ok := request.Params.Arguments["start_time"].(float64); ok {
+	if val, ok := request.GetArguments()["start_time"].(float64); ok {
 		settings.StartTime = int64(val)
 	}
-	if val, ok := request.Params.Arguments["end_time"].(float64); ok {
+	if val, ok := request.GetArguments()["end_time"].(float64); ok {
 		settings.EndTime = int64(val)
 	}
 

--- a/internal/gmail/testable_threads.go
+++ b/internal/gmail/testable_threads.go
@@ -11,7 +11,7 @@ import (
 
 // TestableGmailGetThread retrieves a thread using the provided service.
 func TestableGmailGetThread(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	threadID, errResult := common.RequireStringArg(request.GetArguments(), "thread_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -21,14 +21,14 @@ func TestableGmailGetThread(ctx context.Context, request mcp.CallToolRequest, de
 		return errResult, nil
 	}
 
-	format := common.ParseStringArg(request.Params.Arguments, "format", "full")
+	format := common.ParseStringArg(request.GetArguments(), "format", "full")
 
 	thread, err := svc.GetThread(ctx, threadID, format)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
 	}
 
-	opts := FormatMessageOptions{BodyFormat: parseBodyFormat(request.Params.Arguments)}
+	opts := FormatMessageOptions{BodyFormat: parseBodyFormat(request.GetArguments())}
 	messages := make([]map[string]any, 0, len(thread.Messages))
 	for _, msg := range thread.Messages {
 		messages = append(messages, FormatMessageWithOptions(msg, opts))
@@ -45,7 +45,7 @@ func TestableGmailGetThread(ctx context.Context, request mcp.CallToolRequest, de
 
 // TestableGmailThreadArchive archives all messages in a thread (removes INBOX label).
 func TestableGmailThreadArchive(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	threadID, errResult := common.RequireStringArg(request.GetArguments(), "thread_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -69,7 +69,7 @@ func TestableGmailThreadArchive(ctx context.Context, request mcp.CallToolRequest
 
 // TestableGmailThreadTrash moves an entire thread to trash.
 func TestableGmailThreadTrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	threadID, errResult := common.RequireStringArg(request.GetArguments(), "thread_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -89,7 +89,7 @@ func TestableGmailThreadTrash(ctx context.Context, request mcp.CallToolRequest, 
 
 // TestableGmailThreadUntrash restores an entire thread from trash.
 func TestableGmailThreadUntrash(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
-	threadID, errResult := common.RequireStringArg(request.Params.Arguments, "thread_id")
+	threadID, errResult := common.RequireStringArg(request.GetArguments(), "thread_id")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/meet/meet_testable.go
+++ b/internal/meet/meet_testable.go
@@ -27,8 +27,8 @@ func TestableListConferenceRecords(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	pageSize := common.ParseMaxResults(request.Params.Arguments, defaultPageSize, 100)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), defaultPageSize, 100)
 
 	records, nextPageToken, err := srv.ListConferenceRecords(ctx, pageToken, pageSize)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestableGetConferenceRecord(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -79,14 +79,14 @@ func TestableListParticipants(ctx context.Context, request mcp.CallToolRequest, 
 		return errResult, nil
 	}
 
-	parent, errResult := common.RequireStringArg(request.Params.Arguments, "conference_record")
+	parent, errResult := common.RequireStringArg(request.GetArguments(), "conference_record")
 	if errResult != nil {
 		return errResult, nil
 	}
 	parent = ensureConferenceRecordName(parent)
 
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	pageSize := common.ParseMaxResults(request.Params.Arguments, defaultPageSize, 100)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), defaultPageSize, 100)
 
 	participants, nextPageToken, totalSize, err := srv.ListParticipants(ctx, parent, pageToken, pageSize)
 	if err != nil {
@@ -120,13 +120,13 @@ func TestableListTranscripts(ctx context.Context, request mcp.CallToolRequest, d
 		return errResult, nil
 	}
 
-	parent, errResult := common.RequireStringArg(request.Params.Arguments, "conference_record")
+	parent, errResult := common.RequireStringArg(request.GetArguments(), "conference_record")
 	if errResult != nil {
 		return errResult, nil
 	}
 	parent = ensureConferenceRecordName(parent)
 
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	transcripts, nextPageToken, err := srv.ListTranscripts(ctx, parent, pageToken)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestableGetTranscript(ctx context.Context, request mcp.CallToolRequest, dep
 		return errResult, nil
 	}
 
-	name, errResult := common.RequireStringArg(request.Params.Arguments, "name")
+	name, errResult := common.RequireStringArg(request.GetArguments(), "name")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -177,13 +177,13 @@ func TestableListTranscriptEntries(ctx context.Context, request mcp.CallToolRequ
 		return errResult, nil
 	}
 
-	parent, errResult := common.RequireStringArg(request.Params.Arguments, "transcript")
+	parent, errResult := common.RequireStringArg(request.GetArguments(), "transcript")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	pageToken := common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	pageSize := common.ParseMaxResults(request.Params.Arguments, defaultPageSize, 250)
+	pageToken := common.ParseStringArg(request.GetArguments(), "page_token", "")
+	pageSize := common.ParseMaxResults(request.GetArguments(), defaultPageSize, 250)
 
 	entries, nextPageToken, err := srv.ListTranscriptEntries(ctx, parent, pageToken, pageSize)
 	if err != nil {

--- a/internal/sheets/sheets_charts_testable.go
+++ b/internal/sheets/sheets_charts_testable.go
@@ -27,7 +27,7 @@ func TestableSheetsCreateChart(ctx context.Context, request mcp.CallToolRequest,
 		return idErrResult, nil
 	}
 
-	chartType := common.ParseStringArg(request.Params.Arguments, "chart_type", "")
+	chartType := common.ParseStringArg(request.GetArguments(), "chart_type", "")
 	if chartType == "" {
 		return mcp.NewToolResultError("chart_type parameter is required (BAR, LINE, AREA, COLUMN, SCATTER, COMBO, STEPPED_AREA, PIE)"), nil
 	}
@@ -35,10 +35,10 @@ func TestableSheetsCreateChart(ctx context.Context, request mcp.CallToolRequest,
 		return mcp.NewToolResultError("chart_type must be one of: BAR, LINE, AREA, COLUMN, SCATTER, COMBO, STEPPED_AREA, PIE"), nil
 	}
 
-	title := common.ParseStringArg(request.Params.Arguments, "title", "")
+	title := common.ParseStringArg(request.GetArguments(), "title", "")
 
 	// Parse source data range
-	sourceRange, rangeErr := parseCellRange(request.Params.Arguments)
+	sourceRange, rangeErr := parseCellRange(request.GetArguments())
 	if rangeErr != nil {
 		return rangeErr, nil
 	}
@@ -56,7 +56,7 @@ func TestableSheetsCreateChart(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Optionally set legend position
-	if legendPos, ok := request.Params.Arguments["legend_position"].(string); ok && legendPos != "" {
+	if legendPos, ok := request.GetArguments()["legend_position"].(string); ok && legendPos != "" {
 		basicChart.LegendPosition = legendPos
 	}
 
@@ -68,10 +68,10 @@ func TestableSheetsCreateChart(ctx context.Context, request mcp.CallToolRequest,
 	// Overlay position (default to anchoring at row 0, col 0 of the same sheet)
 	anchorRow := int64(0)
 	anchorCol := int64(0)
-	if ar, ok := request.Params.Arguments["anchor_row"].(float64); ok {
+	if ar, ok := request.GetArguments()["anchor_row"].(float64); ok {
 		anchorRow = int64(ar)
 	}
-	if ac, ok := request.Params.Arguments["anchor_col"].(float64); ok {
+	if ac, ok := request.GetArguments()["anchor_col"].(float64); ok {
 		anchorCol = int64(ac)
 	}
 
@@ -127,7 +127,7 @@ func TestableSheetsUpdateChart(ctx context.Context, request mcp.CallToolRequest,
 		return idErrResult, nil
 	}
 
-	chartIDFloat, ok := request.Params.Arguments["chart_id"].(float64)
+	chartIDFloat, ok := request.GetArguments()["chart_id"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("chart_id parameter is required"), nil
 	}
@@ -136,12 +136,12 @@ func TestableSheetsUpdateChart(ctx context.Context, request mcp.CallToolRequest,
 	chartSpec := &sheets.ChartSpec{}
 	var fields []string
 
-	if title, ok := request.Params.Arguments["title"].(string); ok {
+	if title, ok := request.GetArguments()["title"].(string); ok {
 		chartSpec.Title = title
 		fields = append(fields, "title")
 	}
 
-	if chartType, ok := request.Params.Arguments["chart_type"].(string); ok && chartType != "" {
+	if chartType, ok := request.GetArguments()["chart_type"].(string); ok && chartType != "" {
 		if !validChartTypes[chartType] {
 			return mcp.NewToolResultError("chart_type must be one of: BAR, LINE, AREA, COLUMN, SCATTER, COMBO, STEPPED_AREA, PIE"), nil
 		}
@@ -191,7 +191,7 @@ func TestableSheetsDeleteChart(ctx context.Context, request mcp.CallToolRequest,
 		return idErrResult, nil
 	}
 
-	chartIDFloat, ok := request.Params.Arguments["chart_id"].(float64)
+	chartIDFloat, ok := request.GetArguments()["chart_id"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("chart_id parameter is required"), nil
 	}
@@ -232,13 +232,13 @@ func TestableSheetsCreatePivotTable(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Source data range (uses "source_sheet_id" instead of "sheet_id")
-	sourceRange, rangeErr := parseGridRange(request.Params.Arguments, "source_sheet_id")
+	sourceRange, rangeErr := parseGridRange(request.GetArguments(), "source_sheet_id")
 	if rangeErr != nil {
 		return rangeErr, nil
 	}
 
 	// Target location
-	targetSheetIDFloat, ok := request.Params.Arguments["target_sheet_id"].(float64)
+	targetSheetIDFloat, ok := request.GetArguments()["target_sheet_id"].(float64)
 	if !ok {
 		return mcp.NewToolResultError("target_sheet_id parameter is required (sheet ID where pivot table is placed)"), nil
 	}
@@ -246,10 +246,10 @@ func TestableSheetsCreatePivotTable(ctx context.Context, request mcp.CallToolReq
 
 	targetRow := int64(0)
 	targetCol := int64(0)
-	if tr, ok := request.Params.Arguments["target_row"].(float64); ok {
+	if tr, ok := request.GetArguments()["target_row"].(float64); ok {
 		targetRow = int64(tr)
 	}
-	if tc, ok := request.Params.Arguments["target_col"].(float64); ok {
+	if tc, ok := request.GetArguments()["target_col"].(float64); ok {
 		targetCol = int64(tc)
 	}
 
@@ -259,7 +259,7 @@ func TestableSheetsCreatePivotTable(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Row grouping columns (array of column indices)
-	if rowsRaw, ok := request.Params.Arguments["row_source_columns"].([]any); ok {
+	if rowsRaw, ok := request.GetArguments()["row_source_columns"].([]any); ok {
 		for _, r := range rowsRaw {
 			if colIdx, ok := r.(float64); ok {
 				pivotTable.Rows = append(pivotTable.Rows, &sheets.PivotGroup{
@@ -271,7 +271,7 @@ func TestableSheetsCreatePivotTable(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Column grouping columns
-	if colsRaw, ok := request.Params.Arguments["col_source_columns"].([]any); ok {
+	if colsRaw, ok := request.GetArguments()["col_source_columns"].([]any); ok {
 		for _, c := range colsRaw {
 			if colIdx, ok := c.(float64); ok {
 				pivotTable.Columns = append(pivotTable.Columns, &sheets.PivotGroup{
@@ -283,7 +283,7 @@ func TestableSheetsCreatePivotTable(ctx context.Context, request mcp.CallToolReq
 	}
 
 	// Values (aggregation)
-	if valuesRaw, ok := request.Params.Arguments["value_columns"].([]any); ok {
+	if valuesRaw, ok := request.GetArguments()["value_columns"].([]any); ok {
 		for _, v := range valuesRaw {
 			if valMap, ok := v.(map[string]any); ok {
 				colIdx, colOk := valMap["column"].(float64)

--- a/internal/sheets/sheets_formatting_testable.go
+++ b/internal/sheets/sheets_formatting_testable.go
@@ -126,7 +126,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 		return idErrResult, nil
 	}
 
-	gridRange, rangeErr := parseCellRange(request.Params.Arguments)
+	gridRange, rangeErr := parseCellRange(request.GetArguments())
 	if rangeErr != nil {
 		return rangeErr, nil
 	}
@@ -136,7 +136,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	var fields []string
 
 	// Background color
-	if bgColor, ok := request.Params.Arguments["background_color"].(string); ok && bgColor != "" {
+	if bgColor, ok := request.GetArguments()["background_color"].(string); ok && bgColor != "" {
 		color, err := parseHexColor(bgColor)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid background_color: %v", err)), nil
@@ -149,7 +149,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	textFormat := &sheets.TextFormat{}
 	hasTextFormat := false
 
-	if bold, ok := request.Params.Arguments["bold"].(bool); ok {
+	if bold, ok := request.GetArguments()["bold"].(bool); ok {
 		textFormat.Bold = bold
 		if !bold {
 			textFormat.ForceSendFields = append(textFormat.ForceSendFields, "Bold")
@@ -157,7 +157,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.bold")
 	}
-	if italic, ok := request.Params.Arguments["italic"].(bool); ok {
+	if italic, ok := request.GetArguments()["italic"].(bool); ok {
 		textFormat.Italic = italic
 		if !italic {
 			textFormat.ForceSendFields = append(textFormat.ForceSendFields, "Italic")
@@ -165,7 +165,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.italic")
 	}
-	if underline, ok := request.Params.Arguments["underline"].(bool); ok {
+	if underline, ok := request.GetArguments()["underline"].(bool); ok {
 		textFormat.Underline = underline
 		if !underline {
 			textFormat.ForceSendFields = append(textFormat.ForceSendFields, "Underline")
@@ -173,7 +173,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.underline")
 	}
-	if strikethrough, ok := request.Params.Arguments["strikethrough"].(bool); ok {
+	if strikethrough, ok := request.GetArguments()["strikethrough"].(bool); ok {
 		textFormat.Strikethrough = strikethrough
 		if !strikethrough {
 			textFormat.ForceSendFields = append(textFormat.ForceSendFields, "Strikethrough")
@@ -181,17 +181,17 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.strikethrough")
 	}
-	if fontFamily, ok := request.Params.Arguments["font_family"].(string); ok && fontFamily != "" {
+	if fontFamily, ok := request.GetArguments()["font_family"].(string); ok && fontFamily != "" {
 		textFormat.FontFamily = fontFamily
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.fontFamily")
 	}
-	if fontSize, ok := request.Params.Arguments["font_size"].(float64); ok && fontSize > 0 {
+	if fontSize, ok := request.GetArguments()["font_size"].(float64); ok && fontSize > 0 {
 		textFormat.FontSize = int64(fontSize)
 		hasTextFormat = true
 		fields = append(fields, "userEnteredFormat.textFormat.fontSize")
 	}
-	if fgColor, ok := request.Params.Arguments["foreground_color"].(string); ok && fgColor != "" {
+	if fgColor, ok := request.GetArguments()["foreground_color"].(string); ok && fgColor != "" {
 		color, err := parseHexColor(fgColor)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid foreground_color: %v", err)), nil
@@ -206,8 +206,8 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Number format
-	if numberFormat, ok := request.Params.Arguments["number_format"].(string); ok && numberFormat != "" {
-		numberFormatType := common.ParseStringArg(request.Params.Arguments, "number_format_type", "NUMBER")
+	if numberFormat, ok := request.GetArguments()["number_format"].(string); ok && numberFormat != "" {
+		numberFormatType := common.ParseStringArg(request.GetArguments(), "number_format_type", "NUMBER")
 		validTypes := map[string]bool{
 			"TEXT": true, "NUMBER": true, "PERCENT": true, "CURRENCY": true,
 			"DATE": true, "TIME": true, "DATE_TIME": true, "SCIENTIFIC": true,
@@ -223,7 +223,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Horizontal alignment
-	if hAlign, ok := request.Params.Arguments["horizontal_alignment"].(string); ok && hAlign != "" {
+	if hAlign, ok := request.GetArguments()["horizontal_alignment"].(string); ok && hAlign != "" {
 		validAlignments := map[string]bool{"LEFT": true, "CENTER": true, "RIGHT": true}
 		if !validAlignments[hAlign] {
 			return mcp.NewToolResultError("horizontal_alignment must be one of: LEFT, CENTER, RIGHT"), nil
@@ -233,7 +233,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Vertical alignment
-	if vAlign, ok := request.Params.Arguments["vertical_alignment"].(string); ok && vAlign != "" {
+	if vAlign, ok := request.GetArguments()["vertical_alignment"].(string); ok && vAlign != "" {
 		validAlignments := map[string]bool{"TOP": true, "MIDDLE": true, "BOTTOM": true}
 		if !validAlignments[vAlign] {
 			return mcp.NewToolResultError("vertical_alignment must be one of: TOP, MIDDLE, BOTTOM"), nil
@@ -243,7 +243,7 @@ func TestableSheetsFormatCells(ctx context.Context, request mcp.CallToolRequest,
 	}
 
 	// Wrap strategy
-	if wrapStrategy, ok := request.Params.Arguments["wrap_strategy"].(string); ok && wrapStrategy != "" {
+	if wrapStrategy, ok := request.GetArguments()["wrap_strategy"].(string); ok && wrapStrategy != "" {
 		validStrategies := map[string]bool{"OVERFLOW_CELL": true, "LEGACY_WRAP": true, "CLIP": true, "WRAP": true}
 		if !validStrategies[wrapStrategy] {
 			return mcp.NewToolResultError("wrap_strategy must be one of: OVERFLOW_CELL, LEGACY_WRAP, CLIP, WRAP"), nil
@@ -294,12 +294,12 @@ func TestableSheetsAddConditionalFormat(ctx context.Context, request mcp.CallToo
 		return idErrResult, nil
 	}
 
-	gridRange, rangeErr := parseCellRange(request.Params.Arguments)
+	gridRange, rangeErr := parseCellRange(request.GetArguments())
 	if rangeErr != nil {
 		return rangeErr, nil
 	}
 
-	ruleType := common.ParseStringArg(request.Params.Arguments, "rule_type", "")
+	ruleType := common.ParseStringArg(request.GetArguments(), "rule_type", "")
 	if ruleType == "" {
 		return mcp.NewToolResultError("rule_type parameter is required (BOOLEAN or GRADIENT)"), nil
 	}
@@ -308,14 +308,14 @@ func TestableSheetsAddConditionalFormat(ctx context.Context, request mcp.CallToo
 
 	switch ruleType {
 	case "BOOLEAN":
-		conditionType := common.ParseStringArg(request.Params.Arguments, "condition_type", "")
+		conditionType := common.ParseStringArg(request.GetArguments(), "condition_type", "")
 		if conditionType == "" {
 			return mcp.NewToolResultError("condition_type is required for BOOLEAN rules (e.g., NUMBER_GREATER, TEXT_CONTAINS, CUSTOM_FORMULA)"), nil
 		}
 
 		// Parse condition values
 		var conditionValues []*sheets.ConditionValue
-		if valuesRaw, ok := request.Params.Arguments["condition_values"].([]any); ok {
+		if valuesRaw, ok := request.GetArguments()["condition_values"].([]any); ok {
 			for _, v := range valuesRaw {
 				if s, ok := v.(string); ok {
 					conditionValues = append(conditionValues, &sheets.ConditionValue{UserEnteredValue: s})
@@ -332,27 +332,27 @@ func TestableSheetsAddConditionalFormat(ctx context.Context, request mcp.CallToo
 
 		// Parse format for matching cells
 		format := &sheets.CellFormat{}
-		if bgColor, ok := request.Params.Arguments["format_background_color"].(string); ok && bgColor != "" {
+		if bgColor, ok := request.GetArguments()["format_background_color"].(string); ok && bgColor != "" {
 			color, err := parseHexColor(bgColor)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Invalid format_background_color: %v", err)), nil
 			}
 			format.BackgroundColor = color
 		}
-		if fgColor, ok := request.Params.Arguments["format_text_color"].(string); ok && fgColor != "" {
+		if fgColor, ok := request.GetArguments()["format_text_color"].(string); ok && fgColor != "" {
 			color, err := parseHexColor(fgColor)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Invalid format_text_color: %v", err)), nil
 			}
 			format.TextFormat = &sheets.TextFormat{ForegroundColor: color}
 		}
-		if bold, ok := request.Params.Arguments["format_bold"].(bool); ok && bold {
+		if bold, ok := request.GetArguments()["format_bold"].(bool); ok && bold {
 			if format.TextFormat == nil {
 				format.TextFormat = &sheets.TextFormat{}
 			}
 			format.TextFormat.Bold = true
 		}
-		if italic, ok := request.Params.Arguments["format_italic"].(bool); ok && italic {
+		if italic, ok := request.GetArguments()["format_italic"].(bool); ok && italic {
 			if format.TextFormat == nil {
 				format.TextFormat = &sheets.TextFormat{}
 			}
@@ -368,47 +368,47 @@ func TestableSheetsAddConditionalFormat(ctx context.Context, request mcp.CallToo
 	case "GRADIENT":
 		gradientRule := &sheets.GradientRule{}
 
-		if minColor, ok := request.Params.Arguments["min_color"].(string); ok && minColor != "" {
+		if minColor, ok := request.GetArguments()["min_color"].(string); ok && minColor != "" {
 			color, err := parseHexColor(minColor)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Invalid min_color: %v", err)), nil
 			}
-			minType := common.ParseStringArg(request.Params.Arguments, "min_type", "MIN")
+			minType := common.ParseStringArg(request.GetArguments(), "min_type", "MIN")
 			gradientRule.Minpoint = &sheets.InterpolationPoint{
 				Color: color,
 				Type:  minType,
 			}
-			if minValue, ok := request.Params.Arguments["min_value"].(string); ok && minValue != "" {
+			if minValue, ok := request.GetArguments()["min_value"].(string); ok && minValue != "" {
 				gradientRule.Minpoint.Value = minValue
 			}
 		}
 
-		if midColor, ok := request.Params.Arguments["mid_color"].(string); ok && midColor != "" {
+		if midColor, ok := request.GetArguments()["mid_color"].(string); ok && midColor != "" {
 			color, err := parseHexColor(midColor)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Invalid mid_color: %v", err)), nil
 			}
-			midType := common.ParseStringArg(request.Params.Arguments, "mid_type", "PERCENTILE")
+			midType := common.ParseStringArg(request.GetArguments(), "mid_type", "PERCENTILE")
 			gradientRule.Midpoint = &sheets.InterpolationPoint{
 				Color: color,
 				Type:  midType,
 			}
-			if midValue, ok := request.Params.Arguments["mid_value"].(string); ok && midValue != "" {
+			if midValue, ok := request.GetArguments()["mid_value"].(string); ok && midValue != "" {
 				gradientRule.Midpoint.Value = midValue
 			}
 		}
 
-		if maxColor, ok := request.Params.Arguments["max_color"].(string); ok && maxColor != "" {
+		if maxColor, ok := request.GetArguments()["max_color"].(string); ok && maxColor != "" {
 			color, err := parseHexColor(maxColor)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Invalid max_color: %v", err)), nil
 			}
-			maxType := common.ParseStringArg(request.Params.Arguments, "max_type", "MAX")
+			maxType := common.ParseStringArg(request.GetArguments(), "max_type", "MAX")
 			gradientRule.Maxpoint = &sheets.InterpolationPoint{
 				Color: color,
 				Type:  maxType,
 			}
-			if maxValue, ok := request.Params.Arguments["max_value"].(string); ok && maxValue != "" {
+			if maxValue, ok := request.GetArguments()["max_value"].(string); ok && maxValue != "" {
 				gradientRule.Maxpoint.Value = maxValue
 			}
 		}
@@ -461,19 +461,19 @@ func TestableSheetsAddDataValidation(ctx context.Context, request mcp.CallToolRe
 		return idErrResult, nil
 	}
 
-	gridRange, rangeErr := parseCellRange(request.Params.Arguments)
+	gridRange, rangeErr := parseCellRange(request.GetArguments())
 	if rangeErr != nil {
 		return rangeErr, nil
 	}
 
-	validationType := common.ParseStringArg(request.Params.Arguments, "validation_type", "")
+	validationType := common.ParseStringArg(request.GetArguments(), "validation_type", "")
 	if validationType == "" {
 		return mcp.NewToolResultError("validation_type parameter is required (e.g., ONE_OF_LIST, NUMBER_BETWEEN, CUSTOM_FORMULA)"), nil
 	}
 
 	// Parse condition values
 	var conditionValues []*sheets.ConditionValue
-	if valuesRaw, ok := request.Params.Arguments["values"].([]any); ok {
+	if valuesRaw, ok := request.GetArguments()["values"].([]any); ok {
 		for _, v := range valuesRaw {
 			if s, ok := v.(string); ok {
 				conditionValues = append(conditionValues, &sheets.ConditionValue{UserEnteredValue: s})
@@ -481,9 +481,9 @@ func TestableSheetsAddDataValidation(ctx context.Context, request mcp.CallToolRe
 		}
 	}
 
-	strict := common.ParseBoolArg(request.Params.Arguments, "strict", true)
-	showDropdown := common.ParseBoolArg(request.Params.Arguments, "show_dropdown", true)
-	inputMessage := common.ParseStringArg(request.Params.Arguments, "input_message", "")
+	strict := common.ParseBoolArg(request.GetArguments(), "strict", true)
+	showDropdown := common.ParseBoolArg(request.GetArguments(), "show_dropdown", true)
+	inputMessage := common.ParseStringArg(request.GetArguments(), "input_message", "")
 
 	dataValidation := &sheets.DataValidationRule{
 		Condition: &sheets.BooleanCondition{
@@ -531,7 +531,7 @@ func TestableSheetsBatchUpdateSpreadsheet(ctx context.Context, request mcp.CallT
 		return idErrResult, nil
 	}
 
-	requestsJSON := common.ParseStringArg(request.Params.Arguments, "requests", "")
+	requestsJSON := common.ParseStringArg(request.GetArguments(), "requests", "")
 	if requestsJSON == "" {
 		return mcp.NewToolResultError("requests parameter is required (JSON array of batch update requests)"), nil
 	}

--- a/internal/sheets/sheets_tools_test.go
+++ b/internal/sheets/sheets_tools_test.go
@@ -13,13 +13,7 @@ import (
 // makeRequest creates a CallToolRequest with the given arguments.
 func makeRequest(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{
-		Params: struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Arguments: args,
 		},
 	}

--- a/internal/sheets/sheets_tools_testable.go
+++ b/internal/sheets/sheets_tools_testable.go
@@ -13,7 +13,7 @@ import (
 // extractRequiredSpreadsheetID extracts, validates, and normalizes the spreadsheet_id parameter.
 // Returns the cleaned ID or an error result if missing.
 func extractRequiredSpreadsheetID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	spreadsheetID := common.ParseStringArg(request.Params.Arguments, "spreadsheet_id", "")
+	spreadsheetID := common.ParseStringArg(request.GetArguments(), "spreadsheet_id", "")
 	if spreadsheetID == "" {
 		return "", mcp.NewToolResultError("spreadsheet_id parameter is required")
 	}
@@ -93,7 +93,7 @@ func TestableSheetsRead(ctx context.Context, request mcp.CallToolRequest, deps *
 		return idErrResult, nil
 	}
 
-	readRange := common.ParseStringArg(request.Params.Arguments, "range", "")
+	readRange := common.ParseStringArg(request.GetArguments(), "range", "")
 	if readRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C10')"), nil
 	}
@@ -135,12 +135,12 @@ func TestableSheetsWrite(ctx context.Context, request mcp.CallToolRequest, deps 
 		return idErrResult, nil
 	}
 
-	writeRange := common.ParseStringArg(request.Params.Arguments, "range", "")
+	writeRange := common.ParseStringArg(request.GetArguments(), "range", "")
 	if writeRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C3')"), nil
 	}
 
-	valuesRaw, ok := request.Params.Arguments["values"]
+	valuesRaw, ok := request.GetArguments()["values"]
 	if !ok {
 		return mcp.NewToolResultError("values parameter is required (2D array of values)"), nil
 	}
@@ -150,7 +150,7 @@ func TestableSheetsWrite(ctx context.Context, request mcp.CallToolRequest, deps 
 		return mcp.NewToolResultError(fmt.Sprintf("Invalid values format: %v", err)), nil
 	}
 
-	valueInputOption := parseValueInputOption(request.Params.Arguments)
+	valueInputOption := parseValueInputOption(request.GetArguments())
 
 	resp, err := srv.UpdateValues(ctx, spreadsheetID, writeRange, values, valueInputOption)
 	if err != nil {
@@ -182,12 +182,12 @@ func TestableSheetsAppend(ctx context.Context, request mcp.CallToolRequest, deps
 		return idErrResult, nil
 	}
 
-	appendRange := common.ParseStringArg(request.Params.Arguments, "range", "")
+	appendRange := common.ParseStringArg(request.GetArguments(), "range", "")
 	if appendRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation for table to append to, e.g., 'Sheet1!A:C')"), nil
 	}
 
-	valuesRaw, ok := request.Params.Arguments["values"]
+	valuesRaw, ok := request.GetArguments()["values"]
 	if !ok {
 		return mcp.NewToolResultError("values parameter is required (2D array of values)"), nil
 	}
@@ -197,7 +197,7 @@ func TestableSheetsAppend(ctx context.Context, request mcp.CallToolRequest, deps
 		return mcp.NewToolResultError(fmt.Sprintf("Invalid values format: %v", err)), nil
 	}
 
-	valueInputOption := parseValueInputOption(request.Params.Arguments)
+	valueInputOption := parseValueInputOption(request.GetArguments())
 
 	resp, err := srv.AppendValues(ctx, spreadsheetID, appendRange, values, valueInputOption)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestableSheetsCreate(ctx context.Context, request mcp.CallToolRequest, deps
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -261,7 +261,7 @@ func TestableSheetsBatchRead(ctx context.Context, request mcp.CallToolRequest, d
 		return idErrResult, nil
 	}
 
-	rangesRaw, ok := request.Params.Arguments["ranges"].([]any)
+	rangesRaw, ok := request.GetArguments()["ranges"].([]any)
 	if !ok || len(rangesRaw) == 0 {
 		return mcp.NewToolResultError("ranges parameter is required (array of A1 notation ranges)"), nil
 	}
@@ -312,12 +312,12 @@ func TestableSheetsBatchWrite(ctx context.Context, request mcp.CallToolRequest, 
 		return idErrResult, nil
 	}
 
-	dataRaw, ok := request.Params.Arguments["data"].([]any)
+	dataRaw, ok := request.GetArguments()["data"].([]any)
 	if !ok || len(dataRaw) == 0 {
 		return mcp.NewToolResultError("data parameter is required (array of {range, values} objects)"), nil
 	}
 
-	valueInputOption := parseValueInputOption(request.Params.Arguments)
+	valueInputOption := parseValueInputOption(request.GetArguments())
 
 	var data []*sheets.ValueRange
 	for i, entry := range dataRaw {
@@ -372,7 +372,7 @@ func TestableSheetsClear(ctx context.Context, request mcp.CallToolRequest, deps 
 		return idErrResult, nil
 	}
 
-	clearRange := common.ParseStringArg(request.Params.Arguments, "range", "")
+	clearRange := common.ParseStringArg(request.GetArguments(), "range", "")
 	if clearRange == "" {
 		return mcp.NewToolResultError("range parameter is required (A1 notation, e.g., 'Sheet1!A1:C10')"), nil
 	}

--- a/internal/slides/slides_testable.go
+++ b/internal/slides/slides_testable.go
@@ -13,7 +13,7 @@ const slidesEditURLFormat = "https://docs.google.com/presentation/d/%s/edit"
 
 // extractRequiredPresentationID extracts, validates, and normalizes the presentation_id parameter.
 func extractRequiredPresentationID(request mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	presID := common.ParseStringArg(request.Params.Arguments, "presentation_id", "")
+	presID := common.ParseStringArg(request.GetArguments(), "presentation_id", "")
 	if presID == "" {
 		return "", mcp.NewToolResultError("presentation_id parameter is required")
 	}
@@ -102,7 +102,7 @@ func TestableSlidesGetPage(ctx context.Context, request mcp.CallToolRequest, dep
 		return errResult, nil
 	}
 
-	pageID, errResult := common.RequireStringArg(request.Params.Arguments, "page_id")
+	pageID, errResult := common.RequireStringArg(request.GetArguments(), "page_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -130,7 +130,7 @@ func TestableSlidesGetThumbnail(ctx context.Context, request mcp.CallToolRequest
 		return errResult, nil
 	}
 
-	pageID, errResult := common.RequireStringArg(request.Params.Arguments, "page_id")
+	pageID, errResult := common.RequireStringArg(request.GetArguments(), "page_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -158,7 +158,7 @@ func TestableSlidesCreate(ctx context.Context, request mcp.CallToolRequest, deps
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -190,7 +190,7 @@ func TestableSlidesBatchUpdate(ctx context.Context, request mcp.CallToolRequest,
 		return errResult, nil
 	}
 
-	requestsJSON, errResult := common.RequireStringArg(request.Params.Arguments, "requests")
+	requestsJSON, errResult := common.RequireStringArg(request.GetArguments(), "requests")
 	if errResult != nil {
 		return errResult, nil
 	}

--- a/internal/tasks/tasks_tools_testable.go
+++ b/internal/tasks/tasks_tools_testable.go
@@ -17,8 +17,8 @@ func TestableTasksListTasklists(ctx context.Context, request mcp.CallToolRequest
 	}
 
 	opts := &ListTaskListsOptions{}
-	opts.MaxResults = common.ParseMaxResults(request.Params.Arguments, common.TasksDefaultMaxResults, common.TasksMaxResultsLimit)
-	opts.PageToken = common.ParseStringArg(request.Params.Arguments, "page_token", "")
+	opts.MaxResults = common.ParseMaxResults(request.GetArguments(), common.TasksDefaultMaxResults, common.TasksMaxResultsLimit)
+	opts.PageToken = common.ParseStringArg(request.GetArguments(), "page_token", "")
 
 	resp, err := srv.ListTaskLists(ctx, opts)
 	if err != nil {
@@ -50,17 +50,17 @@ func TestableTasksList(ctx context.Context, request mcp.CallToolRequest, deps *T
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	opts := &ListTasksOptions{}
-	opts.MaxResults = common.ParseMaxResults(request.Params.Arguments, common.TasksDefaultMaxResults, common.TasksMaxResultsLimit)
-	opts.PageToken = common.ParseStringArg(request.Params.Arguments, "page_token", "")
-	opts.ShowCompleted = common.ParseBoolArg(request.Params.Arguments, "show_completed", true)
-	if common.ParseBoolArg(request.Params.Arguments, "show_hidden", false) {
+	opts.MaxResults = common.ParseMaxResults(request.GetArguments(), common.TasksDefaultMaxResults, common.TasksMaxResultsLimit)
+	opts.PageToken = common.ParseStringArg(request.GetArguments(), "page_token", "")
+	opts.ShowCompleted = common.ParseBoolArg(request.GetArguments(), "show_completed", true)
+	if common.ParseBoolArg(request.GetArguments(), "show_hidden", false) {
 		opts.ShowHidden = true
 	}
-	opts.DueMin = common.ParseStringArg(request.Params.Arguments, "due_min", "")
-	opts.DueMax = common.ParseStringArg(request.Params.Arguments, "due_max", "")
+	opts.DueMin = common.ParseStringArg(request.GetArguments(), "due_min", "")
+	opts.DueMax = common.ParseStringArg(request.GetArguments(), "due_max", "")
 
 	resp, err := srv.ListTasks(ctx, taskListID, opts)
 	if err != nil {
@@ -88,12 +88,12 @@ func TestableTasksGet(ctx context.Context, request mcp.CallToolRequest, deps *Ta
 		return errResult, nil
 	}
 
-	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	taskID, errResult := common.RequireStringArg(request.GetArguments(), "task_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	task, err := srv.GetTask(ctx, taskListID, taskID)
 	if err != nil {
@@ -112,27 +112,27 @@ func TestableTasksCreate(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	task := &tasks.Task{
 		Title: title,
 	}
 
-	if notes := common.ParseStringArg(request.Params.Arguments, "notes", ""); notes != "" {
+	if notes := common.ParseStringArg(request.GetArguments(), "notes", ""); notes != "" {
 		task.Notes = notes
 	}
 
-	if due := common.ParseStringArg(request.Params.Arguments, "due", ""); due != "" {
+	if due := common.ParseStringArg(request.GetArguments(), "due", ""); due != "" {
 		task.Due = due
 	}
 
 	var createOpts *CreateTaskOptions
-	if parent := common.ParseStringArg(request.Params.Arguments, "parent", ""); parent != "" {
+	if parent := common.ParseStringArg(request.GetArguments(), "parent", ""); parent != "" {
 		createOpts = &CreateTaskOptions{Parent: parent}
 	}
 
@@ -153,12 +153,12 @@ func TestableTasksUpdate(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	taskID, errResult := common.RequireStringArg(request.GetArguments(), "task_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	// First, get the existing task
 	task, err := srv.GetTask(ctx, taskListID, taskID)
@@ -167,14 +167,14 @@ func TestableTasksUpdate(ctx context.Context, request mcp.CallToolRequest, deps 
 	}
 
 	// Update fields that are provided
-	if title := common.ParseStringArg(request.Params.Arguments, "title", ""); title != "" {
+	if title := common.ParseStringArg(request.GetArguments(), "title", ""); title != "" {
 		task.Title = title
 	}
 	// For notes and due, we need to handle empty string as "no change" if the key is missing,
 	// but common.ParseStringArg handles that by checking for existence.
 	// However, if the user explicitly passes empty string to clear it, we might want to allow it.
 	// But the current implementation logic was:
-	// if notes, ok := request.Params.Arguments["notes"].(string); ok { task.Notes = notes }
+	// if notes, ok := request.GetArguments()["notes"].(string); ok { task.Notes = notes }
 	// This means if "notes" is present (even empty), it updates.
 	// ParseStringArg returns default if missing OR empty. This might be a slight behavior change if empty string was allowed.
 	// But usually empty string means clear.
@@ -184,10 +184,10 @@ func TestableTasksUpdate(ctx context.Context, request mcp.CallToolRequest, deps 
 	// If I want to support clearing, I need to know if it was passed.
 	// Let's stick to the original logic for updates where empty string matters.
 
-	if val, ok := request.Params.Arguments["notes"].(string); ok {
+	if val, ok := request.GetArguments()["notes"].(string); ok {
 		task.Notes = val
 	}
-	if val, ok := request.Params.Arguments["due"].(string); ok {
+	if val, ok := request.GetArguments()["due"].(string); ok {
 		task.Due = val
 	}
 
@@ -208,12 +208,12 @@ func TestableTasksComplete(ctx context.Context, request mcp.CallToolRequest, dep
 		return errResult, nil
 	}
 
-	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	taskID, errResult := common.RequireStringArg(request.GetArguments(), "task_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	// Get the existing task
 	task, err := srv.GetTask(ctx, taskListID, taskID)
@@ -242,12 +242,12 @@ func TestableTasksDelete(ctx context.Context, request mcp.CallToolRequest, deps 
 		return errResult, nil
 	}
 
-	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	taskID, errResult := common.RequireStringArg(request.GetArguments(), "task_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	err := srv.DeleteTask(ctx, taskListID, taskID)
 	if err != nil {
@@ -273,7 +273,7 @@ func TestableTasksCreateTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -304,12 +304,12 @@ func TestableTasksUpdateTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	taskListID, errResult := common.RequireStringArg(request.Params.Arguments, "tasklist_id")
+	taskListID, errResult := common.RequireStringArg(request.GetArguments(), "tasklist_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	title, errResult := common.RequireStringArg(request.Params.Arguments, "title")
+	title, errResult := common.RequireStringArg(request.GetArguments(), "title")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -345,7 +345,7 @@ func TestableTasksDeleteTasklist(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	taskListID, errResult := common.RequireStringArg(request.Params.Arguments, "tasklist_id")
+	taskListID, errResult := common.RequireStringArg(request.GetArguments(), "tasklist_id")
 	if errResult != nil {
 		return errResult, nil
 	}
@@ -373,22 +373,22 @@ func TestableTasksMove(ctx context.Context, request mcp.CallToolRequest, deps *T
 		return errResult, nil
 	}
 
-	taskID, errResult := common.RequireStringArg(request.Params.Arguments, "task_id")
+	taskID, errResult := common.RequireStringArg(request.GetArguments(), "task_id")
 	if errResult != nil {
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	opts := &MoveTaskOptions{}
 
 	// Optional: set parent (for making subtasks)
-	if parent := common.ParseStringArg(request.Params.Arguments, "parent", ""); parent != "" {
+	if parent := common.ParseStringArg(request.GetArguments(), "parent", ""); parent != "" {
 		opts.Parent = parent
 	}
 
 	// Optional: set previous sibling (for ordering)
-	if previous := common.ParseStringArg(request.Params.Arguments, "previous", ""); previous != "" {
+	if previous := common.ParseStringArg(request.GetArguments(), "previous", ""); previous != "" {
 		opts.Previous = previous
 	}
 
@@ -410,7 +410,7 @@ func TestableTasksClearCompleted(ctx context.Context, request mcp.CallToolReques
 		return errResult, nil
 	}
 
-	taskListID := common.ParseStringArg(request.Params.Arguments, "tasklist_id", common.DefaultTaskListID)
+	taskListID := common.ParseStringArg(request.GetArguments(), "tasklist_id", common.DefaultTaskListID)
 
 	err := srv.ClearCompleted(ctx, taskListID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Bumps `github.com/mark3labs/mcp-go` from v0.23.1 to v0.52.0
- Closes #140 (deferred from #139)

## Breaking changes handled
- `CallToolParams.Arguments` is now `any` instead of `map[string]interface{}`. All ~438 read-time accesses migrated from `request.Params.Arguments` to `request.GetArguments()` (back-compat helper provided by upstream that returns `map[string]any`).
- The struct embedded inside `CallToolRequest.Params` is now the named type `mcp.CallToolParams`. Three test helpers (`internal/gmail`, `internal/sheets`, `internal/citation`) and `internal/common/types.go::CreateMCPRequest` had inline anonymous struct literals; switched to the named type.
- Assignments to `request.Params.Arguments = map[string]any{...}` in test files continue to work (`map[string]any` assigns cleanly to `any`); no changes needed.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (also with `-tags=e2e`)
- [x] `go test ./...` all 14 packages pass
- [x] `govulncheck ./...` — 0 vulnerabilities in our code

## Skipped / deferred
- None. All upstream API changes affecting this repo were addressed in this PR.