### PR TITLE
feat: install.sh for one-command build + install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ Complete Google Workspace MCP server — Gmail, Calendar, Drive, Docs, Tasks, Sh
 **[→ Full Installation Guide](INSTALLATION.md)** — Get running in under 10 minutes
 
 ```bash
-# Build
-go build -o ~/.local/bin/gsuite-mcp
+git clone https://github.com/aliwatters/gsuite-mcp.git
+cd gsuite-mcp
+./install.sh
 
 # Authenticate
 gsuite-mcp auth personal
 
 # Add to your MCP client config
 ```
+
+`install.sh` builds the binary to `~/.local/bin/gsuite-mcp` and skips a rebuild if the installed version already matches HEAD. Re-run with `--force` or `FORCE_REBUILD=1` to force a rebuild. Set `INSTALL_PREFIX` to change the install location.
 
 ## Why gsuite-mcp?
 

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -31,6 +31,11 @@ const (
 	serverVersion = "0.2.2"
 )
 
+// GitCommit is injected at build time via:
+//
+//	go build -ldflags "-X main.GitCommit=$(git rev-parse --short HEAD)"
+var GitCommit string
+
 func main() {
 	// Parse --config-dir flag or GSUITE_MCP_CONFIG_DIR env var before subcommand dispatch.
 	// This must happen first so all config.* path functions resolve correctly.
@@ -55,7 +60,11 @@ func main() {
 			printUsage()
 			return
 		case "version", "--version", "-v":
-			fmt.Printf("%s %s\n", serverName, serverVersion)
+			if GitCommit != "" {
+				fmt.Printf("%s %s (%s)\n", serverName, serverVersion, GitCommit)
+			} else {
+				fmt.Printf("%s %s\n", serverName, serverVersion)
+			}
 			return
 		}
 	}

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -31,9 +31,9 @@ const (
 	serverVersion = "0.2.2"
 )
 
-// GitCommit is injected at build time via:
+// GitCommit is injected at build time via (run from the repo root):
 //
-//	go build -ldflags "-X main.GitCommit=$(git rev-parse --short HEAD)"
+//	go build -ldflags "-X main.GitCommit=$(git rev-parse --short HEAD)" ./cmd/gsuite-mcp/
 var GitCommit string
 
 func main() {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# install.sh — Standalone installer for gsuite-mcp
+#
+# Builds and installs the gsuite-mcp binary with a recorded version stamp so
+# future runs can skip a no-op rebuild.
+#
+# Usage:
+#   ./install.sh              # build + install if HEAD changed since last install
+#   ./install.sh --force      # force rebuild and reinstall
+#   FORCE_REBUILD=1 ./install.sh   # same as --force
+#   INSTALL_PREFIX=/opt ./install.sh
+#
+# Environment:
+#   INSTALL_PREFIX   Install root (default: $HOME/.local). gsuite-mcp goes to
+#                    $INSTALL_PREFIX/bin/gsuite-mcp.
+#   XDG_DATA_HOME    Where the version stamp is recorded. Defaults to
+#                    $HOME/.local/share. The stamp file is at
+#                    $XDG_DATA_HOME/gsuite-mcp/version.
+#   FORCE_REBUILD    When set to 1 (or --force passed), forces rebuild.
+#
+# Exit codes:
+#   0  success (or no-op when up to date)
+#   1  build/install failure or invalid environment
+#
+# Notes:
+#   - Idempotent: running twice in a row is a no-op the second time.
+#   - Standalone: works without dotfiles. Only requires Go, git, and POSIX shell.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- Argument parsing -------------------------------------------------------
+
+FORCE=0
+case "${1:-}" in
+    --force|-f)
+        FORCE=1
+        shift
+        ;;
+    --help|-h)
+        sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+    "")
+        ;;
+    *)
+        echo "Error: unknown argument: $1" >&2
+        echo "Usage: $0 [--force]" >&2
+        exit 1
+        ;;
+esac
+
+# Reject extra positional args so typos don't pass silently.
+if [[ $# -gt 0 ]]; then
+    echo "Error: unexpected extra arguments: $*" >&2
+    echo "Usage: $0 [--force]" >&2
+    exit 1
+fi
+
+if [[ "${FORCE_REBUILD:-0}" == "1" ]]; then
+    FORCE=1
+fi
+
+# --- Configuration ----------------------------------------------------------
+
+INSTALL_PREFIX="${INSTALL_PREFIX:-$HOME/.local}"
+BIN_DIR="$INSTALL_PREFIX/bin"
+BINARY="$BIN_DIR/gsuite-mcp"
+
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+STAMP_DIR="$XDG_DATA_HOME/gsuite-mcp"
+STAMP_FILE="$STAMP_DIR/version"
+
+# --- Pre-flight -------------------------------------------------------------
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "Error: go not found on PATH; install Go before running this script" >&2
+    exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git not found on PATH; install git before running this script" >&2
+    exit 1
+fi
+
+# .git is a directory in a normal clone, but a *file* in a worktree.
+if [[ ! -e "$SCRIPT_DIR/.git" ]]; then
+    echo "Error: $SCRIPT_DIR is not a git repo (no .git)" >&2
+    echo "       install.sh must run from inside a clone of aliwatters/gsuite-mcp" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SCRIPT_DIR/go.mod" ]]; then
+    echo "Error: go.mod not found at $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -d "$SCRIPT_DIR/cmd/gsuite-mcp" ]]; then
+    echo "Error: expected ./cmd/gsuite-mcp directory in $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+# --- Version detection ------------------------------------------------------
+
+GIT_HEAD="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if [[ "$GIT_HEAD" == "unknown" ]]; then
+    echo "Error: could not resolve git HEAD" >&2
+    exit 1
+fi
+
+INSTALLED_HEAD=""
+if [[ -f "$STAMP_FILE" ]]; then
+    INSTALLED_HEAD="$(cat "$STAMP_FILE" 2>/dev/null || true)"
+fi
+
+# --- Idempotency check ------------------------------------------------------
+
+if [[ "$FORCE" -ne 1 ]] \
+   && [[ -x "$BINARY" ]] \
+   && [[ -n "$INSTALLED_HEAD" ]] \
+   && [[ "$INSTALLED_HEAD" == "$GIT_HEAD" ]]; then
+    echo "gsuite-mcp already installed at $GIT_HEAD; nothing to do"
+    echo "  binary: $BINARY"
+    echo "(re-run with --force or FORCE_REBUILD=1 to rebuild)"
+    exit 0
+fi
+
+# --- Build ------------------------------------------------------------------
+
+mkdir -p "$BIN_DIR" "$STAMP_DIR"
+
+echo "Building gsuite-mcp (HEAD=$GIT_HEAD)"
+if ! go build \
+        -ldflags "-X main.GitCommit=$GIT_HEAD" \
+        -o "$BINARY" \
+        ./cmd/gsuite-mcp/; then
+    echo "Error: gsuite-mcp build failed" >&2
+    exit 1
+fi
+chmod +x "$BINARY"
+
+# --- Record version stamp ---------------------------------------------------
+
+printf '%s\n' "$GIT_HEAD" > "$STAMP_FILE"
+
+# --- Summary ----------------------------------------------------------------
+
+echo
+echo "Installed gsuite-mcp at $GIT_HEAD"
+echo "  binary: $BINARY"
+echo "  stamp:  $STAMP_FILE"
+
+# Hint about PATH
+case ":$PATH:" in
+    *":$BIN_DIR:"*)
+        ;;
+    *)
+        echo
+        echo "Note: $BIN_DIR is not on your PATH."
+        echo "      Add it to your shell rc:"
+        echo "        export PATH=\"$BIN_DIR:\$PATH\""
+        ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,10 @@
 #
 # Notes:
 #   - Idempotent: running twice in a row is a no-op the second time.
-#   - Standalone: works without dotfiles. Only requires Go, git, and POSIX shell.
+#   - Standalone: works without dotfiles. Requires Go, git, and bash (3.2+).
+#   - Rebuild is triggered only by committed changes (new git HEAD). Uncommitted
+#     edits do not change HEAD, so run with --force if you want to rebuild after
+#     local changes without committing first.
 
 set -euo pipefail
 
@@ -48,7 +51,7 @@ case "${1:-}" in
         ;;
     *)
         echo "Error: unknown argument: $1" >&2
-        echo "Usage: $0 [--force]" >&2
+        echo "Usage: $0 [--force|-f] [--help|-h]" >&2
         exit 1
         ;;
 esac
@@ -56,7 +59,7 @@ esac
 # Reject extra positional args so typos don't pass silently.
 if [[ $# -gt 0 ]]; then
     echo "Error: unexpected extra arguments: $*" >&2
-    echo "Usage: $0 [--force]" >&2
+    echo "Usage: $0 [--force|-f] [--help|-h]" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add `install.sh` at the repo root: standalone, idempotent one-command build + install
- Stamps installed git hash to `${XDG_DATA_HOME:-$HOME/.local/share}/gsuite-mcp/version`; skips rebuild when HEAD already matches
- Supports `INSTALL_PREFIX`, `FORCE_REBUILD=1`, and `--force` flag
- Add `var GitCommit string` to `cmd/gsuite-mcp/main.go` for ldflags injection; version output becomes `gsuite-mcp 0.2.2 (3cffd38)` when built via install.sh
- Update README Quick Start with `git clone … && ./install.sh` flow

## Test plan

- [ ] `./install.sh` — builds binary to `~/.local/bin/gsuite-mcp`, writes stamp file
- [ ] Second `./install.sh` — no-op (prints "already installed … nothing to do")
- [ ] `./install.sh --force` — rebuilds unconditionally
- [ ] `FORCE_REBUILD=1 ./install.sh` — same as `--force`
- [ ] `INSTALL_PREFIX=/tmp/test ./install.sh` — installs to `/tmp/test/bin/gsuite-mcp`
- [ ] `gsuite-mcp version` — prints `gsuite-mcp 0.2.2 (<hash>)` when built via install.sh
- [ ] `gsuite-mcp version` — prints `gsuite-mcp 0.2.2` (no hash) when built without ldflags

Closes #135