### PR TITLE
fix(auth): No-Silent-Failures + TokenSource cache + functional pre-refresh + test hardening (P67 Slot 2)

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -359,7 +359,17 @@ func (m *Manager) saveTokenForEmail(email string, oauth2Token *oauth2.Token) err
 	// empty RefreshToken would permanently destroy the user's offline access.
 	refreshToken := oauth2Token.RefreshToken
 	if refreshToken == "" {
-		if existing, err := loadTokenForEmail(email); err == nil && existing.RefreshToken != "" {
+		existing, loadErr := loadTokenForEmail(email)
+		if loadErr != nil {
+			// Loading the existing credential failed (corrupt JSON, permission issue, etc.).
+			// We MUST NOT silently overwrite the file with an empty refresh_token — that is
+			// exactly the failure mode we were trying to fix. Log the error and bail out so
+			// the caller knows re-authentication is required rather than silently breaking
+			// offline access.
+			log.Printf("[oauth] save: load existing creds for %s failed: %v — refusing to overwrite with empty refresh_token", email, loadErr)
+			return fmt.Errorf("loading existing credentials for %s before save: %w", email, loadErr)
+		}
+		if existing.RefreshToken != "" {
 			refreshToken = existing.RefreshToken
 			log.Printf("[oauth] refresh token preserved for %s (response did not include a new one)", email)
 		}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -193,11 +193,32 @@ type Token struct {
 	Expiry       time.Time `json:"expiry"`
 }
 
+// cachedTokenSource wraps an oauth2.TokenSource with a per-email mutex so that
+// concurrent callers for the same email serialise through a single refresh rather
+// than issuing redundant token-refresh requests to Google.
+type cachedTokenSource struct {
+	mu     sync.Mutex
+	source oauth2.TokenSource
+}
+
+// Token acquires the per-email lock, delegates to the underlying source, and
+// returns the (potentially refreshed) token. Only one goroutine per email can
+// be in a refresh at a time.
+func (c *cachedTokenSource) Token() (*oauth2.Token, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.source.Token()
+}
+
 // Manager handles OAuth2 authentication and token management.
 type Manager struct {
 	oauthConfig *oauth2.Config
 	// authMu prevents concurrent authentication attempts
 	authMu sync.Mutex
+	// sources caches one cachedTokenSource per email so that concurrent callers
+	// for the same account share a single underlying TokenSource and its refresh
+	// state instead of each constructing a new one.
+	sources sync.Map // key: email (string) → value: *cachedTokenSource
 	// AuthServerURL is set when the HTTP auth server is running (e.g. "http://localhost:38917/auth").
 	AuthServerURL string
 }
@@ -402,6 +423,10 @@ func (m *Manager) saveTokenForEmail(email string, oauth2Token *oauth2.Token) err
 // It logs every refresh attempt and preserves the refresh token across silent refreshes.
 // When the token is within tokenPreRefreshWindow of expiry (or already expired), a
 // proactive refresh is forced so callers never receive a stale access token.
+//
+// A per-email TokenSource is cached in m.sources. Concurrent callers for the same
+// email serialise through a single underlying refresh (via cachedTokenSource.mu) so
+// only one token-rotation request reaches Google at a time per account.
 func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Client, error) {
 	token, err := loadTokenForEmail(email)
 	if err != nil {
@@ -425,9 +450,12 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 		TokenType:    "Bearer",
 	}
 
-	tokenSource := m.oauthConfig.TokenSource(ctx, oauth2Token)
-
+	// Force-refresh by backdating the expiry when within the pre-refresh window.
+	// oauth2.TokenSource only refreshes tokens with ≤10s of life (defaultExpiryDelta).
+	// Backdating makes the library treat the token as already expired and issue a
+	// refresh, realising the intended 30-min proactive window.
 	if needsRefresh {
+		oauth2Token.Expiry = time.Now().Add(-time.Second)
 		if expiresIn <= 0 {
 			log.Printf("[oauth] refresh: account=%s token_age=%s expires_in=expired — forcing refresh", email, tokenAge.Round(time.Second))
 		} else {
@@ -435,7 +463,16 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 		}
 	}
 
-	newToken, err := tokenSource.Token()
+	// Retrieve (or create) the per-email cached token source.
+	// LoadOrStore is used to avoid a TOCTOU race: two goroutines that both miss
+	// the cache simultaneously will both attempt to store; only one wins and the
+	// loser discards its newly-constructed source.
+	rawSrc := m.oauthConfig.TokenSource(ctx, oauth2Token)
+	newCached := &cachedTokenSource{source: rawSrc}
+	actual, _ := m.sources.LoadOrStore(email, newCached)
+	cached := actual.(*cachedTokenSource)
+
+	newToken, err := cached.Token()
 	if err != nil {
 		// Classify invalid_grant / token expired errors so callers can surface
 		// a clean re-auth instruction instead of a raw oauth2 error string.
@@ -445,6 +482,8 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 				reAuthCmd = m.AuthServerURL + "?account=" + url.QueryEscape(email)
 			}
 			log.Printf("[oauth] refresh: account=%s result=failure(invalid_grant) — re-auth required", email)
+			// Evict the stale cached source so the next auth attempt starts fresh.
+			m.sources.Delete(email)
 			return nil, fmt.Errorf("%w: token for %s has expired or been revoked; re-authenticate with: %s: %w",
 				ErrAuthExpired, email, reAuthCmd, err)
 		}
@@ -452,7 +491,7 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 		return nil, fmt.Errorf("refreshing token for %s: %w", email, err)
 	}
 
-	if newToken.AccessToken != oauth2Token.AccessToken {
+	if newToken.AccessToken != token.Token {
 		newExpiresIn := newToken.Expiry.Sub(now)
 		log.Printf("[oauth] refresh: account=%s result=success new_expires_in=%s", email, newExpiresIn.Round(time.Second))
 		if err := m.saveTokenForEmail(email, newToken); err != nil {
@@ -460,7 +499,7 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 		}
 	}
 
-	return oauth2.NewClient(ctx, tokenSource), nil
+	return oauth2.NewClient(ctx, cached), nil
 }
 
 // isAuthExpiredError reports whether err represents an expired or revoked OAuth token.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -368,6 +368,62 @@ func TestErrAuthExpired_IsDetectable(t *testing.T) {
 	}
 }
 
+func TestGetClientForEmail_PreRefreshWindowForcesRefresh(t *testing.T) {
+	// A token that expires 20 minutes from now is within the 30-min tokenPreRefreshWindow.
+	// GetClientForEmail must proactively refresh it — the returned client should carry
+	// the new access token, and the mock token endpoint must have been called exactly once.
+
+	var refreshCount int32
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&refreshCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer tokenServer.Close()
+
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() { config.SetConfigDir("") })
+
+	m := &Manager{
+		oauthConfig: &oauth2.Config{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  tokenServer.URL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+			Scopes: []string{"openid"},
+		},
+	}
+
+	email := "prerefresh@example.com"
+
+	// Write a token that expires in 20 minutes — within the 30-min window.
+	nearExpiry := &oauth2.Token{
+		AccessToken:  "soon-expiring-access",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(20 * time.Minute),
+	}
+	if err := m.saveTokenForEmail(email, nearExpiry); err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+
+	client, err := m.GetClientForEmail(t.Context(), email)
+	if err != nil {
+		t.Fatalf("GetClientForEmail error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+
+	// Must have triggered exactly one proactive refresh.
+	got := atomic.LoadInt32(&refreshCount)
+	if got != 1 {
+		t.Errorf("expected 1 proactive refresh for token expiring in 20min (within %s window), got %d", tokenPreRefreshWindow, got)
+	}
+}
+
 func TestGetClientForEmail_ConcurrentCallsOnlyRefreshOnce(t *testing.T) {
 	// N goroutines calling GetClientForEmail for the same email with an expired token
 	// should result in exactly 1 refresh request reaching the token endpoint.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -366,6 +366,49 @@ func TestErrAuthExpired_IsDetectable(t *testing.T) {
 	}
 }
 
+func TestSaveTokenForEmail_CorruptExistingFileReturnsError(t *testing.T) {
+	// When the existing credential file is corrupt (malformed JSON) and the caller
+	// supplies an empty refresh_token, saveTokenForEmail must return an error and
+	// leave the original file unchanged. Silently overwriting would zero the
+	// refresh_token — the exact failure mode fixed in #149/#150.
+	dir := t.TempDir()
+	m := newTestManager(t, dir)
+
+	email := "corrupt@example.com"
+
+	// Write a credential file with malformed JSON directly.
+	credDir := config.CredentialsDir()
+	if err := os.MkdirAll(credDir, 0700); err != nil {
+		t.Fatalf("creating credentials dir: %v", err)
+	}
+	credPath := filepath.Join(credDir, email+".json")
+	originalContent := []byte("{ this is NOT valid json }")
+	if err := os.WriteFile(credPath, originalContent, 0600); err != nil {
+		t.Fatalf("writing corrupt credential file: %v", err)
+	}
+
+	// Attempt to save a token with an empty refresh_token.
+	token := &oauth2.Token{
+		AccessToken:  "new-access",
+		RefreshToken: "", // empty — triggers load of existing
+		Expiry:       time.Now().Add(time.Hour),
+	}
+
+	err := m.saveTokenForEmail(email, token)
+	if err == nil {
+		t.Fatal("expected saveTokenForEmail to return an error for corrupt credential file, got nil")
+	}
+
+	// Original file must be unchanged.
+	content, readErr := os.ReadFile(credPath)
+	if readErr != nil {
+		t.Fatalf("reading credential file after failed save: %v", readErr)
+	}
+	if string(content) != string(originalContent) {
+		t.Errorf("credential file was modified despite load error: got %q, want %q", string(content), string(originalContent))
+	}
+}
+
 func TestSaveTokenForEmail_CredentialFilePermissions(t *testing.T) {
 	// Credential files must be 0600 — no group/world read.
 	dir := t.TempDir()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -562,7 +562,10 @@ func TestSaveTokenForEmail_CredentialFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != credentialFileMode {
-		t.Errorf("expected file mode %04o, got %04o", credentialFileMode, perm)
+	// Hardcode the expected mode rather than referencing credentialFileMode: if the
+	// constant were changed from 0o600 to a less restrictive value, comparing against
+	// the constant itself would make this test vacuously pass (both sides move together).
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected file mode 0600, got %04o", perm)
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -363,6 +365,81 @@ func TestErrAuthExpired_IsDetectable(t *testing.T) {
 		ErrAuthExpired, fmt.Errorf("oauth2: invalid_grant"))
 	if !errors.Is(wrapped, ErrAuthExpired) {
 		t.Error("expected errors.Is(err, ErrAuthExpired) to be true")
+	}
+}
+
+func TestGetClientForEmail_ConcurrentCallsOnlyRefreshOnce(t *testing.T) {
+	// N goroutines calling GetClientForEmail for the same email with an expired token
+	// should result in exactly 1 refresh request reaching the token endpoint.
+	// The per-email cachedTokenSource mutex serialises concurrent refresh calls.
+
+	const goroutines = 10
+
+	// refreshCount tracks how many times the mock token endpoint is called.
+	var refreshCount int32
+	// Serve a token endpoint that counts invocations.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&refreshCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Return a fresh token valid for 1 hour.
+		fmt.Fprintf(w, `{"access_token":"fresh-access","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer tokenServer.Close()
+
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() { config.SetConfigDir("") })
+
+	m := &Manager{
+		oauthConfig: &oauth2.Config{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  tokenServer.URL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+			Scopes: []string{"openid"},
+		},
+	}
+
+	email := "concurrent@example.com"
+
+	// Write a credential with an expired token so GetClientForEmail will refresh.
+	expired := &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(-time.Hour), // already expired
+	}
+	if err := m.saveTokenForEmail(email, expired); err != nil {
+		t.Fatalf("initial save failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			ctx := t.Context()
+			_, err := m.GetClientForEmail(ctx, email)
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: GetClientForEmail error: %v", i, err)
+		}
+	}
+
+	// The per-email mutex means only the first goroutine issues a refresh; the rest
+	// receive the already-refreshed token from the cached source. The count MUST be
+	// exactly 1 — if it is > 1 the cache is not serialising correctly.
+	got := atomic.LoadInt32(&refreshCount)
+	if got != 1 {
+		t.Errorf("expected exactly 1 refresh request to token endpoint, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #153, Closes #152, Closes #151, Closes #154

Follow-up fixes to PR #150 (OAuth refresh root-cause fix), addressing issues surfaced by Opus deep-review.

### #153 — No-Silent-Failures: `saveTokenForEmail` logs and returns error on load failure

Previously, when `loadTokenForEmail` failed (corrupt JSON, permission error), the code silently fell through and wrote a credential file with `refresh_token=""` — exactly the failure mode fixed in #149. Now the error is logged with full context and returned, refusing to overwrite. Callers receive an error and must re-authenticate explicitly.

New test: `TestSaveTokenForEmail_CorruptExistingFileReturnsError` — malformed JSON credential → assert error returned and file unchanged.

### #152 — Per-email TokenSource cache prevents redundant refresh storms

`GetClientForEmail` previously constructed a fresh `oauth2.TokenSource` on every call. Concurrent callers (parallel Gmail/Calendar invocations) would each race to refresh, burning API quota unnecessarily.

Added `cachedTokenSource` (wraps `oauth2.TokenSource` with `sync.Mutex`) and `Manager.sources` (`sync.Map`). One source per email; concurrent callers for the same account serialise through a single in-flight refresh. Stale entries are evicted on `invalid_grant` so re-authentication starts fresh.

New test: `TestGetClientForEmail_ConcurrentCallsOnlyRefreshOnce` — 10 goroutines on an expired token → mock endpoint called exactly once.

### #151 — Functional 30-min proactive pre-refresh window

`oauth2.TokenSource` only refreshes tokens with ≤10 seconds of life (`defaultExpiryDelta`). The `needsRefresh` flag from #150 was computed correctly but only used for logging — no actual refresh was forced.

Fix: when within `tokenPreRefreshWindow`, backdate `oauth2Token.Expiry` to `time.Now()-1s` before constructing the source. The library then treats the token as expired and issues a real refresh.

New test: `TestGetClientForEmail_PreRefreshWindowForcesRefresh` — token expiring in 20min (within 30min window) → mock endpoint called exactly once, confirming proactive refresh.

### #154 — Hardcode `0o600` in credential file permission assertion

`TestSaveTokenForEmail_CredentialFilePermissions` compared `info.Mode().Perm() != credentialFileMode`. If `credentialFileMode` were changed from `0o600` to a less restrictive value, the test would still pass (both sides move together — tautological). Hardcoded the literal `0o600` so the test catches regressions.

## Test plan

- [x] `go test -race ./...` — all 17 packages pass
- [x] `go vet ./...` — clean
- [x] `TestSaveTokenForEmail_CorruptExistingFileReturnsError` — new, passes
- [x] `TestGetClientForEmail_ConcurrentCallsOnlyRefreshOnce` — new, passes (race-clean)
- [x] `TestGetClientForEmail_PreRefreshWindowForcesRefresh` — new, passes
- [x] All existing auth tests pass