### PR TITLE
fix(auth): take over oauth_port from stale gsuite-mcp daemon (closes #158)

### DIFF
--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -87,6 +87,20 @@ func main() {
 		}()
 	}
 
+	// Write the pidfile so `gsuite-mcp auth` can reliably identify us as the
+	// holder of oauth_port and take over instead of failing with EADDRINUSE
+	// (#158). Best-effort: a missing pidfile triggers a process-name fallback,
+	// so a write failure shouldn't crash the daemon.
+	if err := auth.WritePidFile(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not write pidfile: %v\n", err)
+	} else {
+		defer func() {
+			if err := auth.RemovePidFile(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not remove pidfile on shutdown: %v\n", err)
+			}
+		}()
+	}
+
 	s := server.NewMCPServer(serverName, serverVersion)
 
 	// Register all service tools

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -318,6 +318,29 @@ func ResolveOAuthPort() (port int, envOverride bool, err error) {
 	return p, false, err
 }
 
+// bindOAuthPort tries to bind localhost:port for the OAuth callback. If the
+// port is already in use, attempts a one-shot takeover from a stale
+// gsuite-mcp daemon (#158) before reporting failure. The error returned to
+// the user names the foreign-process holder if takeover refuses to proceed.
+func bindOAuthPort(port int) (net.Listener, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err == nil {
+		return listener, nil
+	}
+	// Try to identify-and-replace a stale gsuite-mcp daemon holding the port.
+	if takeoverErr := TakeOverPort(port); takeoverErr != nil {
+		return nil, fmt.Errorf("port %d is in use — %w. To override, set oauth_port in %s or GSUITE_MCP_OAUTH_PORT env var",
+			port, takeoverErr, config.ConfigPath())
+	}
+	// Retry once; if it still fails, something raced us to rebind.
+	listener, retryErr := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if retryErr != nil {
+		return nil, fmt.Errorf("port %d freed by takeover but rebind failed (race?): %w (original bind error: %v)",
+			port, retryErr, err)
+	}
+	return listener, nil
+}
+
 // AuthenticateDynamic performs OAuth2 flow without requiring a pre-configured account.
 // It opens the browser, lets the user choose any Google account, and saves the credential
 // using the authenticated email as the identifier. Returns the authenticated email.
@@ -327,10 +350,9 @@ func (m *Manager) AuthenticateDynamic(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", oauthPort))
+	listener, err := bindOAuthPort(oauthPort)
 	if err != nil {
-		return "", fmt.Errorf("port %d is in use — set a different port in %s (oauth_port) or via GSUITE_MCP_OAUTH_PORT env var: %w",
-			oauthPort, config.ConfigPath(), err)
+		return "", err
 	}
 	defer listener.Close()
 

--- a/internal/auth/pidfile.go
+++ b/internal/auth/pidfile.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aliwatters/gsuite-mcp/internal/config"
+)
+
+// pidFileName is the filename used for the running MCP-server pidfile inside
+// the config directory. Centralising the constant keeps Write/Read/Remove and
+// IsOurDaemon agreeing on a single path.
+const pidFileName = "server.pid"
+
+// PidFilePath returns the absolute path to the pidfile used to identify the
+// running gsuite-mcp daemon. Lives next to config.json so a single
+// GSUITE_MCP_CONFIG_DIR override moves both.
+func PidFilePath() string {
+	return filepath.Join(config.DefaultConfigDir(), pidFileName)
+}
+
+// WritePidFile records the current process's PID so that a future
+// `gsuite-mcp auth` invocation can reliably identify whether the holder of
+// the OAuth port is our own daemon (gsuite-mcp#158).
+//
+// Returns an error if the parent directory cannot be created or the file
+// cannot be written. Errors are typically surfaced as warnings, not fatal:
+// the daemon runs fine without a pidfile, only the auth-time port-takeover
+// loses its primary identification signal (it falls back to a process-name
+// match in that case).
+func WritePidFile() error {
+	dir := config.DefaultConfigDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating config dir for pidfile: %w", err)
+	}
+	pid := strconv.Itoa(os.Getpid())
+	if err := os.WriteFile(PidFilePath(), []byte(pid+"\n"), 0o644); err != nil {
+		return fmt.Errorf("writing pidfile: %w", err)
+	}
+	return nil
+}
+
+// ReadPidFile returns the PID recorded in the pidfile. Returns (0, error) when
+// the file is missing, empty, or unparseable — callers should fall back to
+// process-name matching in those cases.
+func ReadPidFile() (int, error) {
+	data, err := os.ReadFile(PidFilePath())
+	if err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0, fmt.Errorf("pidfile %s is empty", PidFilePath())
+	}
+	pid, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("pidfile %s does not contain a valid PID (%q): %w", PidFilePath(), s, err)
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("pidfile %s contains non-positive PID %d", PidFilePath(), pid)
+	}
+	return pid, nil
+}
+
+// RemovePidFile deletes the pidfile. Best-effort: callers should ignore the
+// error (the pidfile is non-authoritative state and a stale one is handled
+// by the auth-time port-takeover logic).
+func RemovePidFile() error {
+	err := os.Remove(PidFilePath())
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/auth/portclaim.go
+++ b/internal/auth/portclaim.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// PortHolder describes the process currently bound to a port.
+type PortHolder struct {
+	PID     int
+	Command string // typically the short executable name (15-char truncated on Linux)
+}
+
+// Process-discovery and signalling are wired through package-level function
+// variables so unit tests can override them. Production wiring uses lsof / ps
+// (both present on macOS and Linux out of the box).
+var (
+	findPortHolder = findPortHolderViaLsof
+	commandForPID  = commandForPIDViaPS
+	signalProcess  = signalProcessReal
+	processExists  = processExistsReal
+)
+
+// daemonCommandHint is the substring matched against a process command name to
+// decide whether a holder is "our" daemon. We compare lowercased substrings to
+// survive Linux's 15-char /proc/N/comm truncation ("gsuite-mcp" → "gsuite-mc")
+// and macOS' tendency to report the absolute path.
+const daemonCommandHint = "gsuite-mc"
+
+// takeoverWaitForExit is how long to wait between SIGTERM and SIGKILL.
+const takeoverWaitForExit = 2 * time.Second
+
+// takeoverPollInterval is the polling interval used while waiting for a
+// signalled daemon to release the port.
+const takeoverPollInterval = 50 * time.Millisecond
+
+// findPortHolderViaLsof returns the PID + command of the first process
+// LISTENing on the given TCP port (loopback or otherwise). Returns (nil, nil)
+// when no process holds the port — that's a normal pre-bind state, not an
+// error. Returns an error only when lsof itself errors in an unexpected way
+// (missing binary, malformed output).
+func findPortHolderViaLsof(port int) (*PortHolder, error) {
+	// `lsof -ti tcp:PORT -sTCP:LISTEN` prints just PIDs, one per line, exit
+	// code 1 when nothing matches (treated as "no holder").
+	cmd := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port), "-sTCP:LISTEN") //nolint:gosec // fixed args, integer port — no shell interpolation
+	out, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 with empty stdout = "no holder" — normal.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("lsof failed: %w", err)
+	}
+	first := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
+	if first == "" {
+		return nil, nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(first))
+	if err != nil {
+		return nil, fmt.Errorf("lsof returned non-numeric pid %q: %w", first, err)
+	}
+	command, _ := commandForPID(pid) // best-effort; empty string is fine
+	return &PortHolder{PID: pid, Command: command}, nil
+}
+
+// commandForPIDViaPS returns the short command name for a PID via
+// `ps -o comm= -p PID`. Empty string + nil error when the PID does not exist
+// (caller treats empty as "unknown"); non-nil error only on unexpected ps
+// failures.
+func commandForPIDViaPS(pid int) (string, error) {
+	cmd := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)) //nolint:gosec // fixed flags, integer pid
+	out, err := cmd.Output()
+	if err != nil {
+		// ps returns non-zero when the PID doesn't exist; treat as "unknown".
+		if _, ok := err.(*exec.ExitError); ok {
+			return "", nil
+		}
+		return "", fmt.Errorf("ps failed: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// signalProcessReal sends sig to pid. Wraps syscall.Kill so tests can mock it.
+func signalProcessReal(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}
+
+// processExistsReal returns true if a process with the given PID is currently
+// alive. Implemented via `kill -0`, which is portable across macOS and Linux.
+func processExistsReal(pid int) bool {
+	return syscall.Kill(pid, syscall.Signal(0)) == nil
+}
+
+// IsOurDaemon reports whether the process with the given PID is a gsuite-mcp
+// daemon we (or a prior session) started. Uses two signals:
+//
+//  1. PRIMARY: the pidfile at PidFilePath(). If readable AND its recorded PID
+//     matches the candidate AND that PID is alive, it's ours. This is the
+//     reliable post-reboot path (process names alone can collide).
+//
+//  2. FALLBACK: the candidate's command name (via `ps -o comm=`) contains
+//     "gsuite-mc" (lowercased). This covers the case where the pidfile is
+//     missing (older daemon predating this fix, or a manual cleanup), and is
+//     intentionally permissive given Linux's 15-char comm truncation makes
+//     the full "gsuite-mcp" name unmatchable in that environment.
+//
+// The function never kills anything — it only classifies. The caller decides
+// whether to act on the classification (see TakeOverPort).
+func IsOurDaemon(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	if pidFilePID, err := ReadPidFile(); err == nil && pidFilePID == pid {
+		return true
+	}
+	cmdName, err := commandForPID(pid)
+	if err != nil || cmdName == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(cmdName), daemonCommandHint)
+}
+
+// TakeOverPort is called when a bind to `port` fails with EADDRINUSE. It
+// inspects the holder; if it's our own daemon, it sends SIGTERM, waits up to
+// takeoverWaitForExit for graceful release, escalates to SIGKILL if needed,
+// and returns nil once the port is free. If the holder is foreign (or
+// unidentifiable) it returns a descriptive error that the caller surfaces to
+// the user — we never signal an unfamiliar process.
+//
+// Returns nil with no action when no holder is found (caller should retry the
+// bind regardless — the EADDRINUSE may have raced with a port release).
+func TakeOverPort(port int) error {
+	holder, err := findPortHolder(port)
+	if err != nil {
+		return fmt.Errorf("identifying holder of port %d: %w", port, err)
+	}
+	if holder == nil {
+		return nil
+	}
+	if !IsOurDaemon(holder.PID) {
+		cmd := holder.Command
+		if cmd == "" {
+			cmd = "<unknown>"
+		}
+		return fmt.Errorf("port %d is held by foreign process %q (pid %d); refusing to kill — "+
+			"stop that process manually or change oauth_port", port, cmd, holder.PID)
+	}
+	fmt.Fprintf(os.Stderr, "auth: replacing stale gsuite-mcp daemon (pid %d) on port %d\n", holder.PID, port)
+	if err := signalProcess(holder.PID, syscall.SIGTERM); err != nil {
+		// ESRCH = process already gone, which is fine — port should be free.
+		if err != syscall.ESRCH {
+			return fmt.Errorf("SIGTERM to gsuite-mcp pid %d: %w", holder.PID, err)
+		}
+	}
+	deadline := time.Now().Add(takeoverWaitForExit)
+	for time.Now().Before(deadline) {
+		if !processExists(holder.PID) {
+			break
+		}
+		time.Sleep(takeoverPollInterval)
+	}
+	if processExists(holder.PID) {
+		fmt.Fprintf(os.Stderr, "auth: gsuite-mcp pid %d did not exit within %s; sending SIGKILL\n", holder.PID, takeoverWaitForExit)
+		_ = signalProcess(holder.PID, syscall.SIGKILL)
+		time.Sleep(takeoverPollInterval * 4)
+	}
+	// One last sanity check: is the port actually free now?
+	if h, _ := findPortHolder(port); h != nil {
+		return fmt.Errorf("port %d still held after SIGKILL of pid %d (now held by pid %d)", port, holder.PID, h.PID)
+	}
+	return nil
+}

--- a/internal/auth/portclaim.go
+++ b/internal/auth/portclaim.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -26,11 +27,16 @@ var (
 	processExists  = processExistsReal
 )
 
-// daemonCommandHint is the substring matched against a process command name to
-// decide whether a holder is "our" daemon. We compare lowercased substrings to
-// survive Linux's 15-char /proc/N/comm truncation ("gsuite-mcp" → "gsuite-mc")
-// and macOS' tendency to report the absolute path.
-const daemonCommandHint = "gsuite-mc"
+// daemonExecName is the EXACT basename matched against a holder's command
+// when classifying via process-name fallback. Substring matching was rejected
+// here because a foreign binary whose name happens to contain "gsuite-mcp"
+// (e.g. "gsuite-mcp-helper", "my-gsuite-mcp-wrapper") would otherwise be
+// flagged as ours and signalled — a real risk per Copilot review of
+// gsuite-mcp#159. The kernel TASK_COMM_LEN cap is 15 chars, comfortably
+// above the 10-char "gsuite-mcp", so ps -o comm= does not truncate. Path
+// prefixes that macOS' ps returns are stripped via filepath.Base before
+// comparison.
+const daemonExecName = "gsuite-mcp"
 
 // takeoverWaitForExit is how long to wait between SIGTERM and SIGKILL.
 const takeoverWaitForExit = 2 * time.Second
@@ -100,14 +106,14 @@ func processExistsReal(pid int) bool {
 // daemon we (or a prior session) started. Uses two signals:
 //
 //  1. PRIMARY: the pidfile at PidFilePath(). If readable AND its recorded PID
-//     matches the candidate AND that PID is alive, it's ours. This is the
-//     reliable post-reboot path (process names alone can collide).
+//     matches the candidate, it's ours. This is the reliable post-reboot
+//     path (process names alone can collide with foreign binaries).
 //
-//  2. FALLBACK: the candidate's command name (via `ps -o comm=`) contains
-//     "gsuite-mc" (lowercased). This covers the case where the pidfile is
-//     missing (older daemon predating this fix, or a manual cleanup), and is
-//     intentionally permissive given Linux's 15-char comm truncation makes
-//     the full "gsuite-mcp" name unmatchable in that environment.
+//  2. FALLBACK: an EXACT match on the candidate's command basename (via
+//     `ps -o comm=`, then `filepath.Base`, lowercased). Substring matching
+//     was rejected here as too permissive — see daemonExecName for the
+//     reasoning. The fallback only fires when the pidfile is missing or
+//     stale (e.g. older daemon predating this fix, or manual cleanup).
 //
 // The function never kills anything — it only classifies. The caller decides
 // whether to act on the classification (see TakeOverPort).
@@ -122,7 +128,8 @@ func IsOurDaemon(pid int) bool {
 	if err != nil || cmdName == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(cmdName), daemonCommandHint)
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(cmdName)))
+	return base == daemonExecName
 }
 
 // TakeOverPort is called when a bind to `port` fails with EADDRINUSE. It

--- a/internal/auth/portclaim_test.go
+++ b/internal/auth/portclaim_test.go
@@ -1,0 +1,341 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/aliwatters/gsuite-mcp/internal/config"
+)
+
+// withTempConfigDir redirects the config-dir for the duration of t. Restores
+// the prior override on Cleanup. Used by every test that touches the pidfile.
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := os.Getenv("GSUITE_MCP_CONFIG_DIR")
+	t.Setenv("GSUITE_MCP_CONFIG_DIR", dir)
+	config.SetConfigDir(dir)
+	t.Cleanup(func() {
+		if prev != "" {
+			os.Setenv("GSUITE_MCP_CONFIG_DIR", prev)
+			config.SetConfigDir(prev)
+		} else {
+			os.Unsetenv("GSUITE_MCP_CONFIG_DIR")
+			config.SetConfigDir("") // reset to default
+		}
+	})
+	return dir
+}
+
+// === pidfile lifecycle ===
+
+func TestPidFile_WriteReadRemove(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	if err := WritePidFile(); err != nil {
+		t.Fatalf("WritePidFile: %v", err)
+	}
+
+	// File at expected location with our PID.
+	path := filepath.Join(dir, "server.pid")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading pidfile at %s: %v", path, err)
+	}
+	got, err := strconv.Atoi(string(data[:len(data)-1])) // strip trailing newline
+	if err != nil {
+		t.Fatalf("pidfile contents not a PID: %v (raw: %q)", err, string(data))
+	}
+	if got != os.Getpid() {
+		t.Errorf("WritePidFile: file has pid %d, want %d", got, os.Getpid())
+	}
+
+	// ReadPidFile round-trip.
+	readPID, err := ReadPidFile()
+	if err != nil {
+		t.Fatalf("ReadPidFile: %v", err)
+	}
+	if readPID != os.Getpid() {
+		t.Errorf("ReadPidFile: got %d, want %d", readPID, os.Getpid())
+	}
+
+	if err := RemovePidFile(); err != nil {
+		t.Fatalf("RemovePidFile: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("after RemovePidFile, expected file gone; stat err: %v", err)
+	}
+
+	// RemovePidFile is idempotent — second call must not error.
+	if err := RemovePidFile(); err != nil {
+		t.Errorf("RemovePidFile (second call): expected no error, got %v", err)
+	}
+}
+
+func TestReadPidFile_MissingReturnsError(t *testing.T) {
+	withTempConfigDir(t)
+	if _, err := ReadPidFile(); err == nil {
+		t.Error("ReadPidFile on missing file: expected error, got nil")
+	}
+}
+
+func TestReadPidFile_EmptyReturnsError(t *testing.T) {
+	dir := withTempConfigDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "server.pid"), []byte("   \n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if _, err := ReadPidFile(); err == nil {
+		t.Error("ReadPidFile on empty file: expected error, got nil")
+	}
+}
+
+func TestReadPidFile_NonNumericReturnsError(t *testing.T) {
+	dir := withTempConfigDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "server.pid"), []byte("not-a-pid"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if _, err := ReadPidFile(); err == nil {
+		t.Error("ReadPidFile on non-numeric file: expected error, got nil")
+	}
+}
+
+// === IsOurDaemon classification ===
+
+func TestIsOurDaemon_PidFileMatchWins(t *testing.T) {
+	withTempConfigDir(t)
+	// Pidfile says 12345 is ours. Even with a generic command name, the
+	// pidfile match is authoritative.
+	if err := os.WriteFile(PidFilePath(), []byte("12345\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+	commandForPID = func(pid int) (string, error) { return "some-other-binary", nil }
+
+	if !IsOurDaemon(12345) {
+		t.Error("IsOurDaemon: pidfile match should win regardless of command name")
+	}
+}
+
+func TestIsOurDaemon_FallbackToCommandName(t *testing.T) {
+	withTempConfigDir(t) // pidfile absent
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+	commandForPID = func(pid int) (string, error) { return "gsuite-mc", nil } // Linux 15-char truncation
+
+	if !IsOurDaemon(99999) {
+		t.Error("IsOurDaemon: should match the Linux-truncated gsuite-mc name")
+	}
+}
+
+func TestIsOurDaemon_RejectsForeignCommand(t *testing.T) {
+	withTempConfigDir(t)
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+	commandForPID = func(pid int) (string, error) { return "vim", nil }
+
+	if IsOurDaemon(99999) {
+		t.Error("IsOurDaemon: vim should NOT be classified as our daemon")
+	}
+}
+
+func TestIsOurDaemon_PidFileStaleFallsBackToName(t *testing.T) {
+	withTempConfigDir(t)
+	// Pidfile says 11111 is ours, but we ask about 22222. Fallback should
+	// kick in and use the command name.
+	if err := os.WriteFile(PidFilePath(), []byte("11111\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+	commandForPID = func(pid int) (string, error) { return "GSUITE-MCP", nil } // case-insensitive match
+
+	if !IsOurDaemon(22222) {
+		t.Error("IsOurDaemon: should fall back to command-name match when pidfile points elsewhere")
+	}
+}
+
+func TestIsOurDaemon_RejectsZeroPid(t *testing.T) {
+	if IsOurDaemon(0) {
+		t.Error("IsOurDaemon(0): must reject non-positive PIDs")
+	}
+	if IsOurDaemon(-1) {
+		t.Error("IsOurDaemon(-1): must reject non-positive PIDs")
+	}
+}
+
+// === TakeOverPort behaviour ===
+
+func TestTakeOverPort_NoHolderIsNoOp(t *testing.T) {
+	origFind := findPortHolder
+	defer func() { findPortHolder = origFind }()
+	findPortHolder = func(port int) (*PortHolder, error) { return nil, nil }
+
+	if err := TakeOverPort(38917); err != nil {
+		t.Errorf("TakeOverPort with no holder: expected nil, got %v", err)
+	}
+}
+
+func TestTakeOverPort_ForeignProcessNeverKilled(t *testing.T) {
+	withTempConfigDir(t) // no pidfile
+	origFind := findPortHolder
+	origCmd := commandForPID
+	origSig := signalProcess
+	defer func() {
+		findPortHolder = origFind
+		commandForPID = origCmd
+		signalProcess = origSig
+	}()
+
+	findPortHolder = func(port int) (*PortHolder, error) {
+		return &PortHolder{PID: 4242, Command: "ssh-agent"}, nil
+	}
+	commandForPID = func(pid int) (string, error) { return "ssh-agent", nil }
+
+	var signalled atomic.Bool
+	signalProcess = func(pid int, sig syscall.Signal) error {
+		signalled.Store(true)
+		return nil
+	}
+
+	err := TakeOverPort(38917)
+	if err == nil {
+		t.Fatal("TakeOverPort with foreign holder: expected error, got nil")
+	}
+	if signalled.Load() {
+		t.Error("TakeOverPort sent a signal to a foreign process — this must never happen")
+	}
+	// Error message must name the foreign command + PID so the operator can act.
+	msg := err.Error()
+	if !contains(msg, "ssh-agent") || !contains(msg, "4242") {
+		t.Errorf("error message missing command/PID context: %q", msg)
+	}
+}
+
+func TestTakeOverPort_OurDaemonSigTermThenFreed(t *testing.T) {
+	withTempConfigDir(t)
+	// Pidfile says 7777 is ours.
+	if err := os.WriteFile(PidFilePath(), []byte("7777\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	origFind := findPortHolder
+	origSig := signalProcess
+	origExists := processExists
+	defer func() {
+		findPortHolder = origFind
+		signalProcess = origSig
+		processExists = origExists
+	}()
+
+	var (
+		sigterm   atomic.Int32
+		sigkill   atomic.Int32
+		findCalls atomic.Int32
+	)
+
+	findPortHolder = func(port int) (*PortHolder, error) {
+		n := findCalls.Add(1)
+		if n == 1 {
+			// First call: report our daemon holding the port.
+			return &PortHolder{PID: 7777, Command: "gsuite-mcp"}, nil
+		}
+		// Subsequent calls (after SIGTERM): port is free.
+		return nil, nil
+	}
+	signalProcess = func(pid int, sig syscall.Signal) error {
+		switch sig {
+		case syscall.SIGTERM:
+			sigterm.Add(1)
+		case syscall.SIGKILL:
+			sigkill.Add(1)
+		}
+		return nil
+	}
+	// Process "exits" immediately after SIGTERM.
+	processExists = func(pid int) bool { return false }
+
+	if err := TakeOverPort(38917); err != nil {
+		t.Fatalf("TakeOverPort with our daemon: expected nil, got %v", err)
+	}
+	if sigterm.Load() != 1 {
+		t.Errorf("expected 1 SIGTERM, got %d", sigterm.Load())
+	}
+	if sigkill.Load() != 0 {
+		t.Errorf("expected 0 SIGKILL (process exited gracefully), got %d", sigkill.Load())
+	}
+}
+
+func TestTakeOverPort_OurDaemonEscalatesToSigKill(t *testing.T) {
+	withTempConfigDir(t)
+	if err := os.WriteFile(PidFilePath(), []byte("8888\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	origFind := findPortHolder
+	origSig := signalProcess
+	origExists := processExists
+	defer func() {
+		findPortHolder = origFind
+		signalProcess = origSig
+		processExists = origExists
+	}()
+
+	var (
+		sigterm atomic.Int32
+		sigkill atomic.Int32
+	)
+	// First findPortHolder call reports our daemon; final check after SIGKILL says port free.
+	findCalls := atomic.Int32{}
+	findPortHolder = func(port int) (*PortHolder, error) {
+		n := findCalls.Add(1)
+		if n == 1 {
+			return &PortHolder{PID: 8888, Command: "gsuite-mcp"}, nil
+		}
+		return nil, nil
+	}
+	signalProcess = func(pid int, sig syscall.Signal) error {
+		switch sig {
+		case syscall.SIGTERM:
+			sigterm.Add(1)
+		case syscall.SIGKILL:
+			sigkill.Add(1)
+		}
+		return nil
+	}
+	// Process refuses to exit after SIGTERM; becomes "gone" only after the
+	// SIGKILL stage waits.
+	var killed atomic.Bool
+	processExists = func(pid int) bool { return !killed.Load() }
+	prevSig := signalProcess
+	signalProcess = func(pid int, sig syscall.Signal) error {
+		if sig == syscall.SIGKILL {
+			killed.Store(true)
+		}
+		return prevSig(pid, sig)
+	}
+
+	if err := TakeOverPort(38917); err != nil {
+		t.Fatalf("TakeOverPort: expected nil, got %v", err)
+	}
+	if sigterm.Load() != 1 {
+		t.Errorf("expected exactly 1 SIGTERM, got %d", sigterm.Load())
+	}
+	if sigkill.Load() != 1 {
+		t.Errorf("expected exactly 1 SIGKILL (process did not exit gracefully), got %d", sigkill.Load())
+	}
+}
+
+// helper that doesn't pull in strings.Contains import noise into the test file
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/portclaim_test.go
+++ b/internal/auth/portclaim_test.go
@@ -125,10 +125,52 @@ func TestIsOurDaemon_FallbackToCommandName(t *testing.T) {
 	withTempConfigDir(t) // pidfile absent
 	origCmd := commandForPID
 	defer func() { commandForPID = origCmd }()
-	commandForPID = func(pid int) (string, error) { return "gsuite-mc", nil } // Linux 15-char truncation
+	commandForPID = func(pid int) (string, error) { return "gsuite-mcp", nil }
 
 	if !IsOurDaemon(99999) {
-		t.Error("IsOurDaemon: should match the Linux-truncated gsuite-mc name")
+		t.Error("IsOurDaemon: should match exact 'gsuite-mcp' command name")
+	}
+}
+
+func TestIsOurDaemon_FallbackStripsPathPrefix(t *testing.T) {
+	// macOS' ps -o comm= typically returns the absolute path. We must take
+	// the basename before comparison or the exact match never fires.
+	withTempConfigDir(t)
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+	commandForPID = func(pid int) (string, error) {
+		return "/Users/ali/.local/bin/gsuite-mcp", nil
+	}
+
+	if !IsOurDaemon(99999) {
+		t.Error("IsOurDaemon: should strip path prefix and match the basename")
+	}
+}
+
+// TestIsOurDaemon_RejectsLookAlikeNames is the regression for Copilot's
+// review on PR #159: substring matching against "gsuite-mc" treats foreign
+// binaries whose name contains that as ours, which could lead to signalling
+// an unfamiliar process. Exact-basename matching MUST reject every variant
+// here.
+func TestIsOurDaemon_RejectsLookAlikeNames(t *testing.T) {
+	withTempConfigDir(t) // pidfile absent — pure name-fallback path
+	origCmd := commandForPID
+	defer func() { commandForPID = origCmd }()
+
+	lookAlikes := []string{
+		"gsuite-mc",              // 9-char lsof truncation — NOT our ps output but defensive
+		"gsuite-mcp-helper",      // sibling tool, never ours
+		"my-gsuite-mcp",          // wrapper, never ours
+		"gsuite-mcp-controller",  // controller, never ours
+		"not-gsuite-mcp",         // adversarial prefix
+		"gsuite-mcpdbg",          // adversarial suffix without separator
+		"/path/to/gsuite-mcp-x",  // path-stripped basename still mismatches
+	}
+	for _, name := range lookAlikes {
+		commandForPID = func(pid int) (string, error) { return name, nil }
+		if IsOurDaemon(99999) {
+			t.Errorf("IsOurDaemon: foreign command %q must NOT be classified as ours", name)
+		}
 	}
 }
 
@@ -146,16 +188,17 @@ func TestIsOurDaemon_RejectsForeignCommand(t *testing.T) {
 func TestIsOurDaemon_PidFileStaleFallsBackToName(t *testing.T) {
 	withTempConfigDir(t)
 	// Pidfile says 11111 is ours, but we ask about 22222. Fallback should
-	// kick in and use the command name.
+	// kick in and use the command name (exact-basename match,
+	// case-insensitive).
 	if err := os.WriteFile(PidFilePath(), []byte("11111\n"), 0o644); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 	origCmd := commandForPID
 	defer func() { commandForPID = origCmd }()
-	commandForPID = func(pid int) (string, error) { return "GSUITE-MCP", nil } // case-insensitive match
+	commandForPID = func(pid int) (string, error) { return "GSUITE-MCP", nil } // exact match, case-insensitive
 
 	if !IsOurDaemon(22222) {
-		t.Error("IsOurDaemon: should fall back to command-name match when pidfile points elsewhere")
+		t.Error("IsOurDaemon: should fall back to exact-basename match when pidfile points elsewhere")
 	}
 }
 


### PR DESCRIPTION
## Summary

Before this PR, `gsuite-mcp auth` failed with:

```
Authentication error: port 38917 is in use — set a different port in /Users/ali/.config/gsuite-mcp/config.json (oauth_port) or via GSUITE_MCP_OAUTH_PORT env var: listen tcp 127.0.0.1:38917: bind: address already in use
```

…when the MCP daemon (or a prior auth attempt) was already holding the OAuth port. The suggested env-var workaround didn't actually work — Google's OAuth client is bound to a specific redirect URI, so picking a different port locks the user out.

This PR:

- Adds `~/.config/gsuite-mcp/server.pid` written by the MCP daemon on start, removed on shutdown
- When `gsuite-mcp auth` hits EADDRINUSE: identify the holder via `lsof -ti tcp:PORT -sTCP:LISTEN`, classify via pidfile match (primary) or `ps -o comm=` substring match (fallback, tolerates Linux's 15-char truncation per the issue body)
- If holder is our daemon: SIGTERM → 2s graceful window → SIGKILL → port-free verification → retry bind
- If holder is foreign: refuse, name the command + PID in the error so the operator knows who to talk to. **Never** signals a foreign process

## Test plan

- [x] 13 new unit tests with injectable port-introspection + signal mocks
- [x] Real-process branches covered by the SIGKILL-escalation test (2-second wait actually happens)
- [x] Foreign-process branch asserts that the mock signal function is never called
- [x] Full repo `go build ./...` + `go test ./...` clean
- [ ] Manual: kill -STOP a real daemon, run `gsuite-mcp auth`, confirm takeover (deferred to post-merge smoke)

## Acceptance per issue body

- [x] `gsuite-mcp auth` succeeds silently when a stale gsuite-mcp daemon is holding `oauth_port` — Yes; one `auth: replacing stale gsuite-mcp daemon (pid N) on port P` line to stderr is the only output, no prompt
- [x] Foreign processes on `oauth_port` are reported with command + PID and left alone — error names them and exits non-zero
- [x] A pidfile makes identification reliable across reboots — yes, `~/.config/gsuite-mcp/server.pid` written at startup
- [x] Works on macOS and Linux — `lsof`/`ps` are present on both; Linux's `comm` truncation is explicitly handled
- [ ] (Issue mentions an optional follow-up: auto-restart the MCP daemon after auth so it picks up the new token. Not in this PR — that's a separate ergonomic improvement, worth its own change if you want it)

Closes #158