### PR TITLE
fix(auth): split portclaim by build tag — syscall.Kill is Unix-only (v0.3.2 release fix)

### DIFF
--- a/internal/auth/portclaim.go
+++ b/internal/auth/portclaim.go
@@ -3,9 +3,7 @@ package auth
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -18,13 +16,15 @@ type PortHolder struct {
 }
 
 // Process-discovery and signalling are wired through package-level function
-// variables so unit tests can override them. Production wiring uses lsof / ps
-// (both present on macOS and Linux out of the box).
+// variables so unit tests can override them. The default values are assigned
+// from the platform-specific init() in portclaim_unix.go or
+// portclaim_windows.go — `syscall.Kill` exists only on Unix, and `lsof`/`ps`
+// are not present on Windows, so production wiring lives there.
 var (
-	findPortHolder = findPortHolderViaLsof
-	commandForPID  = commandForPIDViaPS
-	signalProcess  = signalProcessReal
-	processExists  = processExistsReal
+	findPortHolder func(port int) (*PortHolder, error)
+	commandForPID  func(pid int) (string, error)
+	signalProcess  func(pid int, sig syscall.Signal) error
+	processExists  func(pid int) bool
 )
 
 // daemonExecName is the EXACT basename matched against a holder's command
@@ -44,63 +44,6 @@ const takeoverWaitForExit = 2 * time.Second
 // takeoverPollInterval is the polling interval used while waiting for a
 // signalled daemon to release the port.
 const takeoverPollInterval = 50 * time.Millisecond
-
-// findPortHolderViaLsof returns the PID + command of the first process
-// LISTENing on the given TCP port (loopback or otherwise). Returns (nil, nil)
-// when no process holds the port — that's a normal pre-bind state, not an
-// error. Returns an error only when lsof itself errors in an unexpected way
-// (missing binary, malformed output).
-func findPortHolderViaLsof(port int) (*PortHolder, error) {
-	// `lsof -ti tcp:PORT -sTCP:LISTEN` prints just PIDs, one per line, exit
-	// code 1 when nothing matches (treated as "no holder").
-	cmd := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port), "-sTCP:LISTEN") //nolint:gosec // fixed args, integer port — no shell interpolation
-	out, err := cmd.Output()
-	if err != nil {
-		// Exit code 1 with empty stdout = "no holder" — normal.
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("lsof failed: %w", err)
-	}
-	first := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
-	if first == "" {
-		return nil, nil
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(first))
-	if err != nil {
-		return nil, fmt.Errorf("lsof returned non-numeric pid %q: %w", first, err)
-	}
-	command, _ := commandForPID(pid) // best-effort; empty string is fine
-	return &PortHolder{PID: pid, Command: command}, nil
-}
-
-// commandForPIDViaPS returns the short command name for a PID via
-// `ps -o comm= -p PID`. Empty string + nil error when the PID does not exist
-// (caller treats empty as "unknown"); non-nil error only on unexpected ps
-// failures.
-func commandForPIDViaPS(pid int) (string, error) {
-	cmd := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)) //nolint:gosec // fixed flags, integer pid
-	out, err := cmd.Output()
-	if err != nil {
-		// ps returns non-zero when the PID doesn't exist; treat as "unknown".
-		if _, ok := err.(*exec.ExitError); ok {
-			return "", nil
-		}
-		return "", fmt.Errorf("ps failed: %w", err)
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-// signalProcessReal sends sig to pid. Wraps syscall.Kill so tests can mock it.
-func signalProcessReal(pid int, sig syscall.Signal) error {
-	return syscall.Kill(pid, sig)
-}
-
-// processExistsReal returns true if a process with the given PID is currently
-// alive. Implemented via `kill -0`, which is portable across macOS and Linux.
-func processExistsReal(pid int) bool {
-	return syscall.Kill(pid, syscall.Signal(0)) == nil
-}
 
 // IsOurDaemon reports whether the process with the given PID is a gsuite-mcp
 // daemon we (or a prior session) started. Uses two signals:

--- a/internal/auth/portclaim_unix.go
+++ b/internal/auth/portclaim_unix.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package auth
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Unix wiring for the cross-platform function-variables in portclaim.go.
+// macOS and Linux both ship `lsof` and `ps` in the base install, and both
+// support POSIX signals through syscall.Kill — so the same implementation
+// covers both platforms.
+//
+// The Windows counterpart in portclaim_windows.go is a no-op set; callers
+// should treat takeover as unsupported there.
+func init() {
+	findPortHolder = findPortHolderViaLsof
+	commandForPID = commandForPIDViaPS
+	signalProcess = signalProcessReal
+	processExists = processExistsReal
+}
+
+// findPortHolderViaLsof returns the PID + command of the first process
+// LISTENing on the given TCP port (loopback or otherwise). Returns (nil, nil)
+// when no process holds the port — that's a normal pre-bind state, not an
+// error. Returns an error only when lsof itself errors in an unexpected way
+// (missing binary, malformed output).
+func findPortHolderViaLsof(port int) (*PortHolder, error) {
+	// `lsof -ti tcp:PORT -sTCP:LISTEN` prints just PIDs, one per line, exit
+	// code 1 when nothing matches (treated as "no holder").
+	cmd := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port), "-sTCP:LISTEN") //nolint:gosec // fixed args, integer port — no shell interpolation
+	out, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 with empty stdout = "no holder" — normal.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("lsof failed: %w", err)
+	}
+	first := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
+	if first == "" {
+		return nil, nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(first))
+	if err != nil {
+		return nil, fmt.Errorf("lsof returned non-numeric pid %q: %w", first, err)
+	}
+	command, _ := commandForPID(pid) // best-effort; empty string is fine
+	return &PortHolder{PID: pid, Command: command}, nil
+}
+
+// commandForPIDViaPS returns the short command name for a PID via
+// `ps -o comm= -p PID`. Empty string + nil error when the PID does not exist
+// (caller treats empty as "unknown"); non-nil error only on unexpected ps
+// failures.
+func commandForPIDViaPS(pid int) (string, error) {
+	cmd := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)) //nolint:gosec // fixed flags, integer pid
+	out, err := cmd.Output()
+	if err != nil {
+		// ps returns non-zero when the PID doesn't exist; treat as "unknown".
+		if _, ok := err.(*exec.ExitError); ok {
+			return "", nil
+		}
+		return "", fmt.Errorf("ps failed: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// signalProcessReal sends sig to pid. Wraps syscall.Kill so tests can mock it.
+func signalProcessReal(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}
+
+// processExistsReal returns true if a process with the given PID is currently
+// alive. Implemented via `kill -0`, which is portable across macOS and Linux.
+func processExistsReal(pid int) bool {
+	return syscall.Kill(pid, syscall.Signal(0)) == nil
+}

--- a/internal/auth/portclaim_windows.go
+++ b/internal/auth/portclaim_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package auth
+
+import "syscall"
+
+// Windows wiring for the cross-platform function-variables in portclaim.go.
+// The takeover feature relies on lsof, ps, and POSIX signals — none of which
+// exist on Windows in the same form. Rather than blocking the Windows build
+// (which gsuite-mcp ships for windows_amd64 and windows_arm64), we wire stub
+// implementations that report "no holder" + reject any kill request. The
+// effective behaviour is: `gsuite-mcp auth` on Windows falls back to the
+// original EADDRINUSE failure, which is no worse than before this fix.
+//
+// If Windows takeover is ever wanted, the place to add it is here — likely
+// via golang.org/x/sys/windows.GetExtendedTcpTable to enumerate listeners and
+// OpenProcess/TerminateProcess to manage them.
+func init() {
+	findPortHolder = func(port int) (*PortHolder, error) { return nil, nil }
+	commandForPID = func(pid int) (string, error) { return "", nil }
+	signalProcess = func(pid int, sig syscall.Signal) error {
+		return syscall.EWINDOWS // "not supported by windows"
+	}
+	processExists = func(pid int) bool { return false }
+}


### PR DESCRIPTION
## Summary

The v0.3.2 release workflow failed because goreleaser builds windows_amd64 + windows_arm64 targets and `syscall.Kill` (used by my #159 work) doesn't exist on Windows. The v0.3.2 tag was pushed but no artifacts published.

Splits `internal/auth/portclaim.go` into three files via build tags:
- platform-agnostic logic stays in `portclaim.go`
- `portclaim_unix.go` (build tag `!windows`) wires `lsof`/`ps` + `syscall.Kill` — the real macOS/Linux path
- `portclaim_windows.go` (build tag `windows`) wires no-op stubs so Windows builds cleanly. Effect on Windows users: `gsuite-mcp auth` falls back to the pre-#158 EADDRINUSE error — no regression from prior releases.

If Windows takeover is ever wanted, the door is open: `x/sys/windows.GetExtendedTcpTable` + `OpenProcess/TerminateProcess` would slot into the same function-variable hooks.

## Verified

- `go build ./...` (darwin host) ✓
- `GOOS=windows GOARCH=amd64 go build` ✓
- `GOOS=windows GOARCH=arm64 go build` ✓
- `GOOS=linux GOARCH=amd64 go build` ✓
- `go test ./internal/auth/` (15 tests, all pass) ✓

## Next step (after merge)

The v0.3.2 tag points at the broken commit and produced no artifacts. After this PR merges, will:
1. Delete the v0.3.2 tag locally + on origin
2. Re-tag v0.3.2 on the new HEAD (this commit + #159's commit)
3. Push — goreleaser re-runs and publishes the v0.3.2 artifacts

This preserves the v0.3.2 version number (no skip to v0.3.3), since the failed tag never produced a release artifact.

## Test plan

- [x] Cross-compile to all 4 release targets passes
- [x] Full `go test ./...` clean
- [ ] Post-merge: re-tag v0.3.2 and confirm goreleaser succeeds
