### PR TITLE
fix(gmail): resolve_web_id validates FMfcg IDs and fails explicitly when unfetchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ Google Chat management: list/get/create spaces, list/get/send messages, thread r
 #### Gmail URL / Web-ID Resolution
 | Tool | Description |
 |------|-------------|
-| `gmail_resolve_web_id` | Resolve a Gmail web-UI ID (from a browser URL) to API message/thread IDs. Accepts a full Gmail URL (`https://mail.google.com/mail/u/0/#inbox/FMfcg…`) or bare ID in any form: `FMfcg…` (current), `thread-f:<decimal>` (legacy), `msg-f:<decimal>` (legacy), or an already-API hex ID. Returns `message_id` and/or `thread_id` for use with `gmail_get_message` / `gmail_get_thread`. |
+| `gmail_resolve_web_id` | Resolve a Gmail web-UI ID (from a browser URL) to API message/thread IDs. Accepts a full Gmail URL (`https://mail.google.com/mail/u/0/#inbox/FMfcg…`) or bare ID in any form: `FMfcg…` (current), `thread-f:<decimal>` (legacy), `msg-f:<decimal>` (legacy), or an already-API hex ID. `FMfcg…` candidates are validated against the selected account before IDs are returned; if validation fails, use `gmail_search` with subject, sender, or date terms. |
 
 **Example:**
 ```
 gmail_resolve_web_id(id="https://mail.google.com/mail/u/0/#inbox/FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj")
 # → { thread_id: "552634d52b0bc546", message_id: "6dd2cf16cc577e3", id_kind: "FMfcg" }
+# If those decoded IDs are not fetchable for the selected account, the tool returns
+# an explicit error recommending gmail_search instead of returning unusable IDs.
 
 gmail_resolve_web_id(id="thread-f:1821570065795440641")
 # → { thread_id: "19478452e138e001", id_kind: "thread-f" }

--- a/internal/gmail/gmail_web_id_test.go
+++ b/internal/gmail/gmail_web_id_test.go
@@ -2,8 +2,11 @@ package gmail
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/gmail/v1"
 )
 
 // === ParseGmailWebID unit tests ===
@@ -280,11 +283,30 @@ func TestParseGmailWebID_ThreadFFromURL(t *testing.T) {
 
 // === TestableGmailResolveWebID handler tests ===
 
+const (
+	testFMfcgID        = "FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj"
+	testFMfcgThreadID  = "552634d52b0bc546"
+	testFMfcgMessageID = "6dd2cf16cc577e3"
+)
+
+func seedFMfcgMessage(fixtures *GmailTestFixtures) {
+	msg := &gmail.Message{
+		Id:       testFMfcgMessageID,
+		ThreadId: testFMfcgThreadID,
+	}
+	fixtures.MockService.Messages[testFMfcgMessageID] = msg
+	fixtures.MockService.Threads[testFMfcgThreadID] = &gmail.Thread{
+		Id:       testFMfcgThreadID,
+		Messages: []*gmail.Message{msg},
+	}
+}
+
 func TestGmailResolveWebID_FMfcgSuccess(t *testing.T) {
 	fixtures := NewGmailTestFixtures()
+	seedFMfcgMessage(fixtures)
 
 	request := makeRequest(map[string]any{
-		"id": "FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj",
+		"id": testFMfcgID,
 	})
 
 	result, err := TestableGmailResolveWebID(context.Background(), request, fixtures.Deps)
@@ -299,17 +321,36 @@ func TestGmailResolveWebID_FMfcgSuccess(t *testing.T) {
 	if response["id_kind"] != "FMfcg" {
 		t.Errorf("id_kind: got %v, want FMfcg", response["id_kind"])
 	}
-	if response["thread_id"] == nil || response["thread_id"] == "" {
-		t.Error("expected thread_id in response")
+	if response["thread_id"] != testFMfcgThreadID {
+		t.Errorf("thread_id: got %v, want %s", response["thread_id"], testFMfcgThreadID)
 	}
-	if response["message_id"] == nil || response["message_id"] == "" {
-		t.Error("expected message_id in response")
+	if response["message_id"] != testFMfcgMessageID {
+		t.Errorf("message_id: got %v, want %s", response["message_id"], testFMfcgMessageID)
 	}
-	if response["source_id"] != "FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj" {
+	if response["source_id"] != testFMfcgID {
 		t.Errorf("source_id: got %v", response["source_id"])
 	}
 	if response["hint"] == nil {
 		t.Error("expected hint in response")
+	}
+}
+
+func TestGmailResolveWebID_FMfcgNotFetchable(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+
+	request := makeRequest(map[string]any{
+		"id": testFMfcgID,
+	})
+
+	result, err := TestableGmailResolveWebID(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error for FMfcg ID that is not fetchable, got success: %v", result.Content)
+	}
+	if !strings.Contains(fmt.Sprint(result.Content), "gmail_search") {
+		t.Fatalf("expected error to recommend gmail_search fallback, got: %v", result.Content)
 	}
 }
 
@@ -396,9 +437,10 @@ func TestGmailResolveWebID_APIIDPassthrough(t *testing.T) {
 
 func TestGmailResolveWebID_FullURL(t *testing.T) {
 	fixtures := NewGmailTestFixtures()
+	seedFMfcgMessage(fixtures)
 
 	request := makeRequest(map[string]any{
-		"id": "https://mail.google.com/mail/u/0/#inbox/FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj",
+		"id": "https://mail.google.com/mail/u/0/#inbox/" + testFMfcgID,
 	})
 
 	result, err := TestableGmailResolveWebID(context.Background(), request, fixtures.Deps)
@@ -413,8 +455,8 @@ func TestGmailResolveWebID_FullURL(t *testing.T) {
 	if response["id_kind"] != "FMfcg" {
 		t.Errorf("id_kind: got %v, want FMfcg", response["id_kind"])
 	}
-	if response["thread_id"] == nil || response["thread_id"] == "" {
-		t.Error("expected thread_id in response")
+	if response["thread_id"] != testFMfcgThreadID {
+		t.Errorf("thread_id: got %v, want %s", response["thread_id"], testFMfcgThreadID)
 	}
 }
 

--- a/internal/gmail/register.go
+++ b/internal/gmail/register.go
@@ -401,7 +401,8 @@ func registerExtendedTools(s *server.MCPServer) {
 		mcp.WithDescription("Resolve a Gmail web-UI message/thread ID (from a browser URL) to Gmail API IDs. "+
 			"Accepts a full Gmail URL (https://mail.google.com/mail/u/0/#inbox/FMfcg…) or a bare ID in any form: "+
 			"FMfcg… (current), thread-f:<decimal> (legacy), msg-f:<decimal> (legacy), or an already-API hex ID. "+
-			"Returns message_id and/or thread_id for use with gmail_get_message / gmail_get_thread."),
+			"FMfcg candidates are validated against the selected account before returning message_id and thread_id; "+
+			"if validation fails, use gmail_search with subject, sender, or date terms."),
 		mcp.WithString("id", mcp.Required(), mcp.Description(
 			"Gmail web-UI ID or full Gmail URL. Examples: "+
 				"\"FMfcgzQgLrxVJjTVKwvFRgbdLPFsxXfj\", "+

--- a/internal/gmail/testable_web_id_resolve.go
+++ b/internal/gmail/testable_web_id_resolve.go
@@ -71,13 +71,13 @@ func TestableGmailResolveWebID(ctx context.Context, request mcp.CallToolRequest,
 func validateFMfcgResolution(ctx context.Context, svc GmailService, resolved *ResolvedWebID) error {
 	if resolved.MessageID != "" {
 		if _, err := svc.GetMessage(ctx, resolved.MessageID, "metadata"); err != nil {
-			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded message_id is not fetchable; use gmail_search with subject, sender, or date terms to find the message")
+			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded message_id %q is not fetchable (%w); use gmail_search with subject, sender, or date terms to find the message", resolved.MessageID, err)
 		}
 	}
 
 	if resolved.ThreadID != "" {
 		if _, err := svc.GetThread(ctx, resolved.ThreadID, "metadata"); err != nil {
-			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded thread_id is not fetchable; use gmail_search with subject, sender, or date terms to find the message")
+			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded thread_id %q is not fetchable (%w); use gmail_search with subject, sender, or date terms to find the message", resolved.ThreadID, err)
 		}
 	}
 

--- a/internal/gmail/testable_web_id_resolve.go
+++ b/internal/gmail/testable_web_id_resolve.go
@@ -20,7 +20,7 @@ import (
 //
 // On success it returns message_id, thread_id, id_kind, and source_id.
 // On failure it returns a clear error — never a silent wrong-ID fallback.
-func TestableGmailResolveWebID(_ context.Context, request mcp.CallToolRequest, _ *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+func TestableGmailResolveWebID(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
 	input, errResult := common.RequireStringArg(request.GetArguments(), "id")
 	if errResult != nil {
 		return errResult, nil
@@ -29,6 +29,16 @@ func TestableGmailResolveWebID(_ context.Context, request mcp.CallToolRequest, _
 	resolved, err := ParseGmailWebID(strings.TrimSpace(input))
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("cannot resolve Gmail web ID: %v", err)), nil
+	}
+
+	if resolved.Kind == WebIDKindFMfcg {
+		svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+		if !ok {
+			return errResult, nil
+		}
+		if err := validateFMfcgResolution(ctx, svc, resolved); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 	}
 
 	result := map[string]any{
@@ -56,4 +66,20 @@ func TestableGmailResolveWebID(_ context.Context, request mcp.CallToolRequest, _
 	}
 
 	return common.MarshalToolResult(result)
+}
+
+func validateFMfcgResolution(ctx context.Context, svc GmailService, resolved *ResolvedWebID) error {
+	if resolved.MessageID != "" {
+		if _, err := svc.GetMessage(ctx, resolved.MessageID, "metadata"); err != nil {
+			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded message_id is not fetchable; use gmail_search with subject, sender, or date terms to find the message")
+		}
+	}
+
+	if resolved.ThreadID != "" {
+		if _, err := svc.GetThread(ctx, resolved.ThreadID, "metadata"); err != nil {
+			return fmt.Errorf("cannot resolve Gmail FMfcg web ID for this account: decoded thread_id is not fetchable; use gmail_search with subject, sender, or date terms to find the message")
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Closes aliwatters/gsuite-mcp#166

## Problem

`gmail_resolve_web_id(id=<FMfcg URL>)` returned `message_id`/`thread_id` that were not fetchable: `gmail_get_thread` -> 400 "Invalid id value", `gmail_get_message` -> 404. The FMfcg->API-ID transform in `decodeFMfcg` assumes a "community-documented" 24-byte big-endian layout (bytes 8-15 = thread, 16-23 = message) that no longer holds for current FMfcg web URLs, so it produced hex IDs that looked authoritative but pointed at nothing.

## Fix (explicit-failure contract)

FMfcg web IDs cannot be deterministically converted to API IDs, so the resolver now **validates** before returning:

- For FMfcg inputs, the decoded candidate `message_id`/`thread_id` are checked against the selected account with a lightweight `metadata` fetch.
- If they fetch, they are returned as before.
- If they do not, the tool returns an **explicit error** recommending a `gmail_search` fallback (by subject/sender/date) instead of returning unusable IDs that look authoritative.
- Legacy `thread-f:`/`msg-f:` and already-API hex inputs keep their deterministic pass-through behavior (out of scope for this bug).

## Tests

- New `TestGmailResolveWebID_FMfcgNotFetchable`: fixture-based regression asserting that an FMfcg ID whose decoded IDs are not seeded in the account returns an error recommending `gmail_search`.
- Updated `TestGmailResolveWebID_FMfcgSuccess` / `_FullURL` to seed matching mock messages so the validated happy path is exercised.
- Full `go test ./...` and `go vet ./...` pass.

## Docs

README example and the tool description now state that FMfcg candidates are validated against the selected account and may fail explicitly with a `gmail_search` recommendation.

## Acceptance criteria

- [x] Resolvable current Gmail web URLs return IDs that `gmail_get_message`/`gmail_get_thread` can fetch (validated before return).
- [x] Non-resolvable web IDs fail explicitly with a structured fallback recommendation instead of returning unusable authoritative-looking IDs.
- [x] README examples and tool descriptions match real behavior.