### PR TITLE
feat(auth): surface OAuth re-auth remediation on invalid_grant in tool error path

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -499,15 +499,10 @@ func (m *Manager) GetClientForEmail(ctx context.Context, email string) (*http.Cl
 		// Classify invalid_grant / token expired errors so callers can surface
 		// a clean re-auth instruction instead of a raw oauth2 error string.
 		if isAuthExpiredError(err) {
-			reAuthCmd := "gsuite-mcp auth"
-			if m.AuthServerURL != "" {
-				reAuthCmd = m.AuthServerURL + "?account=" + url.QueryEscape(email)
-			}
 			log.Printf("[oauth] refresh: account=%s result=failure(invalid_grant) — re-auth required", email)
 			// Evict the stale cached source so the next auth attempt starts fresh.
 			m.sources.Delete(email)
-			return nil, fmt.Errorf("%w: token for %s has expired or been revoked; re-authenticate with: %s: %w",
-				ErrAuthExpired, email, reAuthCmd, err)
+			return nil, m.authExpiredError(email, err)
 		}
 		log.Printf("[oauth] refresh: account=%s result=failure(%v)", email, err)
 		return nil, fmt.Errorf("refreshing token for %s: %w", email, err)
@@ -534,6 +529,24 @@ func isAuthExpiredError(err error) bool {
 	return strings.Contains(s, "invalid_grant") ||
 		strings.Contains(s, "Token has been expired or revoked") ||
 		strings.Contains(s, "token has been expired or revoked")
+}
+
+// authExpiredError builds a structured, actionable error for an expired or revoked OAuth token.
+// The returned error wraps ErrAuthExpired (detectable with errors.Is) and also wraps the
+// original oauth2 error (preserving the full chain via %w). The user-facing message includes:
+//   - the affected account email
+//   - the exact re-auth command or browser URL needed
+//   - a note that no MCP server restart is required after re-authentication
+func (m *Manager) authExpiredError(email string, cause error) error {
+	var reAuthInstr string
+	if m.AuthServerURL != "" {
+		// The persistent HTTP auth server is running; surface the browser URL directly.
+		reAuthInstr = fmt.Sprintf("open %s?account=%s in your browser", m.AuthServerURL, url.QueryEscape(email))
+	} else {
+		reAuthInstr = fmt.Sprintf("run: gsuite-mcp auth  (then sign in as %s)", email)
+	}
+	return fmt.Errorf("%w: OAuth token for %s has expired or been revoked — to re-authenticate: %s (no MCP server restart needed): %w",
+		ErrAuthExpired, email, reAuthInstr, cause)
 }
 
 // loadTokenForEmail loads the stored token for an email address.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -531,12 +531,28 @@ func isAuthExpiredError(err error) bool {
 		strings.Contains(s, "token has been expired or revoked")
 }
 
+// authExpiredErr is a custom error type for expired/revoked OAuth tokens.
+// Its Error() returns the clean, actionable user-facing message without the raw oauth2
+// error text. Unwrap returns both ErrAuthExpired and the underlying cause so that
+// errors.Is(err, ErrAuthExpired) and errors.Is(err, cause) both work correctly.
+type authExpiredErr struct {
+	msg   string
+	cause error
+}
+
+func (e *authExpiredErr) Error() string { return e.msg }
+
+// Unwrap returns both sentinel errors so errors.Is covers both ErrAuthExpired and the cause.
+func (e *authExpiredErr) Unwrap() []error { return []error{ErrAuthExpired, e.cause} }
+
 // authExpiredError builds a structured, actionable error for an expired or revoked OAuth token.
-// The returned error wraps ErrAuthExpired (detectable with errors.Is) and also wraps the
-// original oauth2 error (preserving the full chain via %w). The user-facing message includes:
+// The user-facing Error() string includes:
 //   - the affected account email
 //   - the exact re-auth command or browser URL needed
 //   - a note that no MCP server restart is required after re-authentication
+//
+// The original oauth2 cause is accessible via errors.Is/errors.As but is NOT included in
+// the user-facing string — callers (MCP clients) see only the actionable instruction.
 func (m *Manager) authExpiredError(email string, cause error) error {
 	var reAuthInstr string
 	if m.AuthServerURL != "" {
@@ -545,8 +561,9 @@ func (m *Manager) authExpiredError(email string, cause error) error {
 	} else {
 		reAuthInstr = fmt.Sprintf("run: gsuite-mcp auth  (then sign in as %s)", email)
 	}
-	return fmt.Errorf("%w: OAuth token for %s has expired or been revoked — to re-authenticate: %s (no MCP server restart needed): %w",
-		ErrAuthExpired, email, reAuthInstr, cause)
+	msg := fmt.Sprintf("OAuth token for %s has expired or been revoked — to re-authenticate: %s (no MCP server restart needed)",
+		email, reAuthInstr)
+	return &authExpiredErr{msg: msg, cause: cause}
 }
 
 // loadTokenForEmail loads the stored token for an email address.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -371,7 +371,8 @@ func TestErrAuthExpired_IsDetectable(t *testing.T) {
 func TestAuthExpiredError_CLIFallback(t *testing.T) {
 	// When no AuthServerURL is set, the remediation message must include the
 	// gsuite-mcp auth CLI command, the affected account, and a note that no
-	// MCP server restart is required.
+	// MCP server restart is required. The raw oauth2 error must NOT appear in
+	// the user-facing string (it stays in the error chain for errors.Is only).
 	m := &Manager{}
 	cause := fmt.Errorf("oauth2: %q %q", "invalid_grant", "Token has been expired or revoked.")
 	email := "user@example.com"
@@ -391,15 +392,19 @@ func TestAuthExpiredError_CLIFallback(t *testing.T) {
 	if !strings.Contains(msg, "no MCP server restart") {
 		t.Errorf("expected 'no MCP server restart' in error message, got: %s", msg)
 	}
-	// Original error must be preserved in the chain.
+	// Original error must be preserved in the chain (not in Error() string, but via errors.Is).
 	if !errors.Is(err, cause) {
 		t.Error("expected original cause error to be preserved in the error chain")
+	}
+	// Raw oauth2 error text must NOT appear in the user-facing message.
+	if strings.Contains(msg, "oauth2:") {
+		t.Errorf("raw oauth2 error text should not appear in user-facing message, got: %s", msg)
 	}
 }
 
 func TestAuthExpiredError_AuthServerURL(t *testing.T) {
 	// When AuthServerURL is set, the remediation message must surface the browser
-	// URL (with the account query param) instead of the CLI command.
+	// URL with the account query param (?account=<email>) instead of the CLI command.
 	m := &Manager{AuthServerURL: "http://localhost:38917/auth"}
 	cause := fmt.Errorf("oauth2: invalid_grant")
 	email := "work@company.com"
@@ -413,15 +418,23 @@ func TestAuthExpiredError_AuthServerURL(t *testing.T) {
 	if !strings.Contains(msg, "http://localhost:38917/auth") {
 		t.Errorf("expected auth server URL in error message, got: %s", msg)
 	}
+	// The ?account= query parameter must be present so the user gets a one-click URL.
+	if !strings.Contains(msg, "?account=") {
+		t.Errorf("expected '?account=' query param in error message, got: %s", msg)
+	}
 	if !strings.Contains(msg, email) {
 		t.Errorf("expected account email %q in error message, got: %s", email, msg)
 	}
 	if !strings.Contains(msg, "no MCP server restart") {
 		t.Errorf("expected 'no MCP server restart' in error message, got: %s", msg)
 	}
-	// Original error must be preserved in the chain.
+	// Original error must be preserved in the chain (not in Error() string, but via errors.Is).
 	if !errors.Is(err, cause) {
 		t.Error("expected original cause error to be preserved in the error chain")
+	}
+	// Raw oauth2 error text must NOT appear in the user-facing message.
+	if strings.Contains(msg, "oauth2:") {
+		t.Errorf("raw oauth2 error text should not appear in user-facing message, got: %s", msg)
 	}
 }
 
@@ -477,6 +490,10 @@ func TestGetClientForEmail_InvalidGrantSurfacesRemediation(t *testing.T) {
 	}
 	if !strings.Contains(msg, "no MCP server restart") {
 		t.Errorf("expected 'no MCP server restart' note in error message, got: %s", msg)
+	}
+	// Raw oauth2 error text must NOT appear in the user-facing message.
+	if strings.Contains(msg, "invalid_grant") {
+		t.Errorf("raw 'invalid_grant' text should not appear in user-facing message, got: %s", msg)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -368,6 +368,118 @@ func TestErrAuthExpired_IsDetectable(t *testing.T) {
 	}
 }
 
+func TestAuthExpiredError_CLIFallback(t *testing.T) {
+	// When no AuthServerURL is set, the remediation message must include the
+	// gsuite-mcp auth CLI command, the affected account, and a note that no
+	// MCP server restart is required.
+	m := &Manager{}
+	cause := fmt.Errorf("oauth2: %q %q", "invalid_grant", "Token has been expired or revoked.")
+	email := "user@example.com"
+
+	err := m.authExpiredError(email, cause)
+
+	if !errors.Is(err, ErrAuthExpired) {
+		t.Error("expected errors.Is(err, ErrAuthExpired) to be true")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, email) {
+		t.Errorf("expected account email %q in error message, got: %s", email, msg)
+	}
+	if !strings.Contains(msg, "gsuite-mcp auth") {
+		t.Errorf("expected 'gsuite-mcp auth' in error message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "no MCP server restart") {
+		t.Errorf("expected 'no MCP server restart' in error message, got: %s", msg)
+	}
+	// Original error must be preserved in the chain.
+	if !errors.Is(err, cause) {
+		t.Error("expected original cause error to be preserved in the error chain")
+	}
+}
+
+func TestAuthExpiredError_AuthServerURL(t *testing.T) {
+	// When AuthServerURL is set, the remediation message must surface the browser
+	// URL (with the account query param) instead of the CLI command.
+	m := &Manager{AuthServerURL: "http://localhost:38917/auth"}
+	cause := fmt.Errorf("oauth2: invalid_grant")
+	email := "work@company.com"
+
+	err := m.authExpiredError(email, cause)
+
+	if !errors.Is(err, ErrAuthExpired) {
+		t.Error("expected errors.Is(err, ErrAuthExpired) to be true")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "http://localhost:38917/auth") {
+		t.Errorf("expected auth server URL in error message, got: %s", msg)
+	}
+	if !strings.Contains(msg, email) {
+		t.Errorf("expected account email %q in error message, got: %s", email, msg)
+	}
+	if !strings.Contains(msg, "no MCP server restart") {
+		t.Errorf("expected 'no MCP server restart' in error message, got: %s", msg)
+	}
+	// Original error must be preserved in the chain.
+	if !errors.Is(err, cause) {
+		t.Error("expected original cause error to be preserved in the error chain")
+	}
+}
+
+func TestGetClientForEmail_InvalidGrantSurfacesRemediation(t *testing.T) {
+	// When the token endpoint returns invalid_grant, GetClientForEmail must return
+	// an error that wraps ErrAuthExpired and contains the remediation instruction.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`)
+	}))
+	defer tokenServer.Close()
+
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() { config.SetConfigDir("") })
+
+	m := &Manager{
+		oauthConfig: &oauth2.Config{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			Endpoint: oauth2.Endpoint{
+				TokenURL:  tokenServer.URL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+			Scopes: []string{"openid"},
+		},
+	}
+
+	email := "expired@example.com"
+	expired := &oauth2.Token{
+		AccessToken:  "old",
+		RefreshToken: "stale-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}
+	if err := m.saveTokenForEmail(email, expired); err != nil {
+		t.Fatalf("saving token: %v", err)
+	}
+
+	_, err := m.GetClientForEmail(t.Context(), email)
+	if err == nil {
+		t.Fatal("expected error from invalid_grant response, got nil")
+	}
+	if !errors.Is(err, ErrAuthExpired) {
+		t.Errorf("expected ErrAuthExpired in error chain, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, email) {
+		t.Errorf("expected account email in error message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "gsuite-mcp auth") {
+		t.Errorf("expected 'gsuite-mcp auth' remediation in error message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "no MCP server restart") {
+		t.Errorf("expected 'no MCP server restart' note in error message, got: %s", msg)
+	}
+}
+
 func TestGetClientForEmail_PreRefreshWindowForcesRefresh(t *testing.T) {
 	// A token that expires 20 minutes from now is within the 30-min tokenPreRefreshWindow.
 	// GetClientForEmail must proactively refresh it — the returned client should carry


### PR DESCRIPTION
Closes aliwatters/gsuite-mcp#170

## Summary

When a tool call fails because the OAuth refresh token has expired or been revoked, the raw `oauth2: "invalid_grant"` error is now replaced with an actionable remediation message that tells the user exactly how to re-authenticate without restarting the MCP server.

- **AuthServerURL path**: error surfaces the browser URL (`http://localhost:<port>/auth?account=<email>`) so the user can click to re-auth
- **CLI fallback**: when no HTTP auth server is running, the error includes the exact `gsuite-mcp auth` command with the affected account name
- **No restart needed**: both paths include the note that re-running the tool after re-authenticating is sufficient — no MCP server restart required
- **Error chain preserved**: original oauth2 error is wrapped via `%w` so `errors.Is(err, ErrAuthExpired)` and the underlying cause remain inspectable by callers

## Design note: surfacing vs auto-opening the browser

The issue mentions "auto-open the OAuth page" as the primary remediation. Auto-opening a browser from a daemon/server tool call path is not implemented here — the daemon runs as a background process attached to the MCP stdio pipe, and spawning `open`/`xdg-open` from that context is unexpected behavior that may not work in all deployment environments (e.g., headless servers, remote MCP). Surfacing the URL + "no restart needed" in the error message is the safe, non-interactive equivalent: the user sees exactly what to do without the server taking autonomous browser actions on their behalf.

## Changes

- `internal/auth/auth.go`: extract `authExpiredError(email, cause)` method on `*Manager`; builds the actionable message using `AuthServerURL` (if set) or the CLI command; preserves both `ErrAuthExpired` and the original `cause` in the chain
- `internal/auth/auth_test.go`: three new tests — `TestAuthExpiredError_CLIFallback`, `TestAuthExpiredError_AuthServerURL`, and `TestGetClientForEmail_InvalidGrantSurfacesRemediation` (end-to-end against mock invalid_grant endpoint)

## Test plan

- [ ] All 17 packages pass: `go test ./... -short`
- [ ] New tests verify remediation string contains account email, auth command/URL, and "no MCP server restart" note
- [ ] `errors.Is(err, ErrAuthExpired)` still works after the refactor
- [ ] Original oauth2 cause is preserved in error chain