### PR TITLE
fix(install): install harness binary to libexec, keep bin CLI copy in sync (#175)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,15 +12,13 @@ Get from zero to working in under 10 minutes.
 ### From Source (Recommended)
 
 ```bash
-# Clone and build
+# Clone and install
 git clone https://github.com/aliwatters/gsuite-mcp.git
 cd gsuite-mcp
-go build -o gsuite-mcp ./cmd/gsuite-mcp/
-
-# Move to your PATH
-mv gsuite-mcp ~/.local/bin/
-# or: sudo mv gsuite-mcp /usr/local/bin/
+./install.sh
 ```
+
+This installs the MCP harness binary to `~/.local/libexec/gsuite-mcp` and a PATH/CLI copy to `~/.local/bin/gsuite-mcp`.
 
 ### Verify Installation
 
@@ -136,7 +134,7 @@ Add to `~/.claude/claude_desktop_config.json` (create if it doesn't exist):
 }
 ```
 
-Replace `/path/to/gsuite-mcp` with the actual path (e.g., `/Users/you/.local/bin/gsuite-mcp`).
+Replace `/path/to/gsuite-mcp` with the actual MCP harness path (e.g., `/Users/you/.local/libexec/gsuite-mcp`).
 
 ### Claude Desktop
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gsuite-mcp auth personal
 # Add to your MCP client config
 ```
 
-`install.sh` builds the binary to `~/.local/bin/gsuite-mcp` and skips a rebuild if the installed version already matches HEAD. Re-run with `--force` or `FORCE_REBUILD=1` to force a rebuild. Set `INSTALL_PREFIX` to change the install location.
+`install.sh` builds the MCP harness binary to `~/.local/libexec/gsuite-mcp` and also installs a PATH/CLI copy at `~/.local/bin/gsuite-mcp`. It skips a rebuild only when both installed binaries match HEAD. Re-run with `--force` or `FORCE_REBUILD=1` to force a rebuild. Set `INSTALL_PREFIX` to change the install location.
 
 ## Why gsuite-mcp?
 

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,9 @@
 #   INSTALL_PREFIX=/opt ./install.sh
 #
 # Environment:
-#   INSTALL_PREFIX   Install root (default: $HOME/.local). gsuite-mcp goes to
-#                    $INSTALL_PREFIX/bin/gsuite-mcp.
+#   INSTALL_PREFIX   Install root (default: $HOME/.local). The MCP harness
+#                    binary goes to $INSTALL_PREFIX/libexec/gsuite-mcp, and a
+#                    PATH/CLI copy goes to $INSTALL_PREFIX/bin/gsuite-mcp.
 #   XDG_DATA_HOME    Where the version stamp is recorded. Defaults to
 #                    $HOME/.local/share. The stamp file is at
 #                    $XDG_DATA_HOME/gsuite-mcp/version.
@@ -71,7 +72,9 @@ fi
 
 INSTALL_PREFIX="${INSTALL_PREFIX:-$HOME/.local}"
 BIN_DIR="$INSTALL_PREFIX/bin"
-BINARY="$BIN_DIR/gsuite-mcp"
+LIBEXEC_DIR="$INSTALL_PREFIX/libexec"
+CLI_BINARY="$BIN_DIR/gsuite-mcp"
+HARNESS_BINARY="$LIBEXEC_DIR/gsuite-mcp"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 STAMP_DIR="$XDG_DATA_HOME/gsuite-mcp"
@@ -119,31 +122,51 @@ if [[ -f "$STAMP_FILE" ]]; then
     INSTALLED_HEAD="$(cat "$STAMP_FILE" 2>/dev/null || true)"
 fi
 
+binary_matches_head() {
+    local binary="$1"
+    local version_output
+
+    if [[ ! -x "$binary" ]]; then
+        return 1
+    fi
+
+    version_output="$("$binary" version 2>/dev/null || true)"
+    [[ "$version_output" == *"($GIT_HEAD)"* ]]
+}
+
 # --- Idempotency check ------------------------------------------------------
 
 if [[ "$FORCE" -ne 1 ]] \
-   && [[ -x "$BINARY" ]] \
+   && binary_matches_head "$HARNESS_BINARY" \
+   && binary_matches_head "$CLI_BINARY" \
    && [[ -n "$INSTALLED_HEAD" ]] \
    && [[ "$INSTALLED_HEAD" == "$GIT_HEAD" ]]; then
     echo "gsuite-mcp already installed at $GIT_HEAD; nothing to do"
-    echo "  binary: $BINARY"
+    echo "  harness binary: $HARNESS_BINARY"
+    echo "  cli binary:     $CLI_BINARY"
     echo "(re-run with --force or FORCE_REBUILD=1 to rebuild)"
     exit 0
 fi
 
 # --- Build ------------------------------------------------------------------
 
-mkdir -p "$BIN_DIR" "$STAMP_DIR"
+mkdir -p "$LIBEXEC_DIR" "$BIN_DIR" "$STAMP_DIR"
 
 echo "Building gsuite-mcp (HEAD=$GIT_HEAD)"
+BUILD_BINARY="$HARNESS_BINARY.tmp.$$"
+rm -f "$BUILD_BINARY"
 if ! go build \
         -ldflags "-X main.GitCommit=$GIT_HEAD" \
-        -o "$BINARY" \
+        -o "$BUILD_BINARY" \
         ./cmd/gsuite-mcp/; then
+    rm -f "$BUILD_BINARY"
     echo "Error: gsuite-mcp build failed" >&2
     exit 1
 fi
-chmod +x "$BINARY"
+mv "$BUILD_BINARY" "$HARNESS_BINARY"
+chmod +x "$HARNESS_BINARY"
+cp "$HARNESS_BINARY" "$CLI_BINARY"
+chmod +x "$CLI_BINARY"
 
 # --- Record version stamp ---------------------------------------------------
 
@@ -153,8 +176,9 @@ printf '%s\n' "$GIT_HEAD" > "$STAMP_FILE"
 
 echo
 echo "Installed gsuite-mcp at $GIT_HEAD"
-echo "  binary: $BINARY"
-echo "  stamp:  $STAMP_FILE"
+echo "  harness binary: $HARNESS_BINARY"
+echo "  cli binary:     $CLI_BINARY"
+echo "  stamp:          $STAMP_FILE"
 
 # Hint about PATH
 case ":$PATH:" in

--- a/install_test.go
+++ b/install_test.go
@@ -1,0 +1,161 @@
+package gsuite_mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallWritesHarnessAndCLIBinaries(t *testing.T) {
+	fixture := newInstallFixture(t)
+
+	output := fixture.runInstall(t)
+	if !strings.Contains(output, "harness binary: "+fixture.harnessBinary) {
+		t.Fatalf("install output did not report harness binary %q:\n%s", fixture.harnessBinary, output)
+	}
+	if !strings.Contains(output, "cli binary:     "+fixture.cliBinary) {
+		t.Fatalf("install output did not report cli binary %q:\n%s", fixture.cliBinary, output)
+	}
+
+	assertBinaryReportsHead(t, fixture.harnessBinary, fixture.gitHead)
+	assertBinaryReportsHead(t, fixture.cliBinary, fixture.gitHead)
+
+	output = fixture.runInstall(t)
+	if !strings.Contains(output, "nothing to do") {
+		t.Fatalf("second install should no-op when both binaries match HEAD, got:\n%s", output)
+	}
+}
+
+func TestInstallRefreshesStaleHarnessBinaryDespiteMatchingStamp(t *testing.T) {
+	fixture := newInstallFixture(t)
+	fixture.runInstall(t)
+
+	staleScript := "#!/usr/bin/env bash\nprintf 'gsuite-mcp 0.0.0 (stale)\\n'\n"
+	if err := os.WriteFile(fixture.harnessBinary, []byte(staleScript), 0755); err != nil {
+		t.Fatalf("write stale harness binary: %v", err)
+	}
+
+	output := fixture.runInstall(t)
+	if !strings.Contains(output, "Building gsuite-mcp") {
+		t.Fatalf("expected stale harness binary to force rebuild, got:\n%s", output)
+	}
+
+	assertBinaryReportsHead(t, fixture.harnessBinary, fixture.gitHead)
+	assertBinaryReportsHead(t, fixture.cliBinary, fixture.gitHead)
+}
+
+type installFixture struct {
+	dir           string
+	installPrefix string
+	xdgDataHome   string
+	harnessBinary string
+	cliBinary     string
+	gitHead       string
+}
+
+func newInstallFixture(t *testing.T) installFixture {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	repoDir := filepath.Join(tempDir, "repo")
+	installPrefix := filepath.Join(tempDir, "prefix")
+	xdgDataHome := filepath.Join(tempDir, "data")
+
+	mkdirAll(t, filepath.Join(repoDir, "cmd", "gsuite-mcp"))
+
+	installScript, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	writeFile(t, filepath.Join(repoDir, "install.sh"), installScript, 0755)
+	writeFile(t, filepath.Join(repoDir, "go.mod"), []byte("module example.com/gsuite-install-fixture\n\ngo 1.23\n"), 0644)
+	writeFile(t, filepath.Join(repoDir, "cmd", "gsuite-mcp", "main.go"), []byte(`package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var GitCommit string
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		if GitCommit != "" {
+			fmt.Printf("gsuite-mcp 0.0.0 (%s)\n", GitCommit)
+			return
+		}
+		fmt.Println("gsuite-mcp 0.0.0")
+	}
+}
+`), 0644)
+
+	runInDir(t, repoDir, "git", "init")
+	runInDir(t, repoDir, "git", "config", "user.email", "test@example.com")
+	runInDir(t, repoDir, "git", "config", "user.name", "Install Test")
+	runInDir(t, repoDir, "git", "add", ".")
+	runInDir(t, repoDir, "git", "commit", "-m", "initial")
+	gitHead := strings.TrimSpace(runInDir(t, repoDir, "git", "rev-parse", "--short", "HEAD"))
+
+	return installFixture{
+		dir:           repoDir,
+		installPrefix: installPrefix,
+		xdgDataHome:   xdgDataHome,
+		harnessBinary: filepath.Join(installPrefix, "libexec", "gsuite-mcp"),
+		cliBinary:     filepath.Join(installPrefix, "bin", "gsuite-mcp"),
+		gitHead:       gitHead,
+	}
+}
+
+func (f installFixture) runInstall(t *testing.T) string {
+	t.Helper()
+
+	cmd := exec.Command("./install.sh")
+	cmd.Dir = f.dir
+	cmd.Env = append(os.Environ(),
+		"INSTALL_PREFIX="+f.installPrefix,
+		"XDG_DATA_HOME="+f.xdgDataHome,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run install.sh: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func assertBinaryReportsHead(t *testing.T, binary, gitHead string) {
+	t.Helper()
+
+	output := runInDir(t, ".", binary, "version")
+	want := "(" + gitHead + ")"
+	if !strings.Contains(output, want) {
+		t.Fatalf("%s version output = %q, want commit %s", binary, output, want)
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path string, contents []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, contents, mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runInDir(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}


### PR DESCRIPTION
Closes #175. install.sh now installs the canonical harness binary to `~/.local/libexec/gsuite-mcp` (what router-mcp launches) and keeps a `bin/` CLI copy in sync; idempotency check verifies both binaries' embedded GitCommit via `gsuite-mcp version`. Adds installer regression tests; updates README/INSTALLATION. Verified: real binary emits `gsuite-mcp <v> (<commit>)`; `go test ./...`, `go vet`, gofmt all pass.