### PR TITLE
feat(calendar): include color_id in event output + field masks (#176)

### DIFF
--- a/internal/calendar/calendar_tools.go
+++ b/internal/calendar/calendar_tools.go
@@ -15,9 +15,9 @@ import (
 // These reduce response payload size by only requesting needed fields.
 const (
 	// CalendarEventListFields contains fields for event listings (compact format)
-	CalendarEventListFields = "nextPageToken,items(id,summary,status,start,end,location,htmlLink,hangoutLink,eventType)"
+	CalendarEventListFields = "nextPageToken,items(id,summary,status,start,end,location,colorId,htmlLink,hangoutLink,eventType)"
 	// CalendarEventGetFields contains fields for single event retrieval (full format)
-	CalendarEventGetFields = "id,summary,status,description,location,start,end,htmlLink,created,updated,creator,organizer,attendees,reminders,recurrence,recurringEventId,hangoutLink,conferenceData,eventType"
+	CalendarEventGetFields = "id,summary,status,description,location,colorId,start,end,htmlLink,created,updated,creator,organizer,attendees,reminders,recurrence,recurringEventId,hangoutLink,conferenceData,eventType"
 	// CalendarListFields contains fields for calendar list
 	CalendarListFields = "items(id,summary,description,primary,backgroundColor,accessRole,timeZone)"
 )

--- a/internal/calendar/calendar_tools_test.go
+++ b/internal/calendar/calendar_tools_test.go
@@ -159,6 +159,9 @@ func TestCalendarGetEvent(t *testing.T) {
 			args: map[string]any{
 				"event_id": "event001",
 			},
+			setupMock: func(m *MockCalendarService) {
+				m.Events["primary"]["event001"].ColorId = "4"
+			},
 			validate: func(t *testing.T, result string) {
 				var data map[string]any
 				if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -169,6 +172,9 @@ func TestCalendarGetEvent(t *testing.T) {
 				}
 				if data["summary"] != "Team Meeting" {
 					t.Errorf("expected summary 'Team Meeting', got %v", data["summary"])
+				}
+				if data["color_id"] != "4" {
+					t.Errorf("expected color_id '4', got %v", data["color_id"])
 				}
 			},
 		},
@@ -437,6 +443,9 @@ func TestCalendarCreateEventWithColorID(t *testing.T) {
 	if event.ColorId != "9" {
 		t.Errorf("expected color ID '9', got %q", event.ColorId)
 	}
+	if data["color_id"] != "9" {
+		t.Errorf("expected response color_id '9', got %v", data["color_id"])
+	}
 }
 
 // ============================================================================
@@ -572,6 +581,13 @@ func TestCalendarUpdateEventColorID(t *testing.T) {
 		}
 		if got := fixtures.MockService.Events["primary"]["event001"].ColorId; got != "9" {
 			t.Errorf("expected color ID '9', got %q", got)
+		}
+		var data map[string]any
+		if err := json.Unmarshal([]byte(getCalendarTextContent(result)), &data); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+		if data["color_id"] != "9" {
+			t.Errorf("expected response color_id '9', got %v", data["color_id"])
 		}
 	})
 
@@ -932,6 +948,19 @@ func TestFormatEvent(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "format event with color ID",
+			event: func() *calendar.Event {
+				e := createTestEvent("test4", "Colored Meeting", "", "2024-02-01T10:00:00-08:00", "2024-02-01T11:00:00-08:00", false)
+				e.ColorId = "9"
+				return e
+			},
+			validate: func(t *testing.T, result map[string]any) {
+				if result["color_id"] != "9" {
+					t.Errorf("expected color_id '9', got %v", result["color_id"])
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -981,6 +1010,19 @@ func TestFormatEventFull(t *testing.T) {
 				}
 				if len(attendees) != 2 {
 					t.Errorf("expected 2 attendees, got %d", len(attendees))
+				}
+			},
+		},
+		{
+			name: "full format includes color ID",
+			event: func() *calendar.Event {
+				e := createTestEvent("test3", "Colored Meeting", "Test Description", "2024-02-01T10:00:00-08:00", "2024-02-01T11:00:00-08:00", false)
+				e.ColorId = "7"
+				return e
+			},
+			validate: func(t *testing.T, result map[string]any) {
+				if result["color_id"] != "7" {
+					t.Errorf("expected color_id '7', got %v", result["color_id"])
 				}
 			},
 		},

--- a/internal/calendar/helpers.go
+++ b/internal/calendar/helpers.go
@@ -35,6 +35,10 @@ func formatEvent(event *calendar.Event) map[string]any {
 		result["location"] = event.Location
 	}
 
+	if event.ColorId != "" {
+		result["color_id"] = event.ColorId
+	}
+
 	if event.EventType != "" && event.EventType != "default" {
 		result["event_type"] = event.EventType
 	}


### PR DESCRIPTION
Closes #176. `formatEvent`/`formatEventFull` emit `color_id` when set, and list/get field masks request `colorId` so it's populated. Makes event color a verifiable round-trip. Tests/vet/gofmt pass.