### PR TITLE
feat: patch-first release policy docs + vendor-neutral OAuth token hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses a patch-first versioning policy — see [RELEASING.md](RELEASING.md) for the full policy.
 
 ## [0.2.0] - 2026-03-20
 

--- a/README.md
+++ b/README.md
@@ -429,8 +429,8 @@ export GSUITE_OAUTH_TOKEN_CMD="my-secret-tool get-oauth-token"
 ```
 
 When `GSUITE_OAUTH_TOKEN_CMD` is **not set**, gsuite-mcp reads tokens from local JSON files
-in the credentials directory (default behaviour — unchanged). You can use local files for
-some accounts and the command hook for others by ensuring the env var is set only when needed.
+in the credentials directory (default behaviour — unchanged). The env var is process-wide:
+all accounts use the hook when it is set.
 
 The hook is secret-manager agnostic. It works with 1Password CLI, HashiCorp Vault,
 `pass`, environment injection, or any other tool that follows the contract above.

--- a/README.md
+++ b/README.md
@@ -410,6 +410,31 @@ The default OAuth callback port is **38917**. Override it in `config.json`:
 
 Or via environment variable: `GSUITE_MCP_OAUTH_PORT=9000`
 
+### Vendor-Neutral OAuth Token Command Hook
+
+Set `GSUITE_OAUTH_TOKEN_CMD` to supply OAuth refresh tokens from any external secret source
+(password manager, vault, environment injection — any tool that can print a token to stdout).
+
+**Contract**:
+- The command receives the account identifier (email address) as its first argument.
+- It must print the OAuth refresh token to stdout and exit 0.
+- Non-zero exit = failure; gsuite-mcp logs the exit code and stderr, then returns a clear error.
+
+```bash
+# Example: use any secret-retrieval tool that accepts an account id and prints a token
+export GSUITE_OAUTH_TOKEN_CMD="my-secret-tool get-oauth-token"
+
+# gsuite-mcp will call: my-secret-tool get-oauth-token user@example.com
+# and use the token printed to stdout as the OAuth refresh token for that account.
+```
+
+When `GSUITE_OAUTH_TOKEN_CMD` is **not set**, gsuite-mcp reads tokens from local JSON files
+in the credentials directory (default behaviour — unchanged). You can use local files for
+some accounts and the command hook for others by ensuring the env var is set only when needed.
+
+The hook is secret-manager agnostic. It works with 1Password CLI, HashiCorp Vault,
+`pass`, environment injection, or any other tool that follows the contract above.
+
 ### Drive Access Filtering
 
 Restrict which shared drives are accessible via MCP tools. Add `drive_access` to `config.json`:
@@ -467,6 +492,19 @@ go test -tags=e2e -v -count=1 ./e2e/...
 Tests create temporary artifacts (emails, labels, events, files, task lists) and clean up after themselves. The test account should be a dedicated account, not a production mailbox.
 
 See [docs/AGENTS.md](docs/AGENTS.md) for contribution guidelines.
+
+## Releases
+
+gsuite-mcp uses a **patch-first** versioning policy — an intentional deviation from strict SemVer:
+
+| Change type | Bump |
+|---|---|
+| Bug fix | patch |
+| Small / low-risk additive feature (e.g. a new optional parameter) | **patch** |
+| Larger feature set (multiple tools, new service area) | minor |
+| Breaking change (removed/renamed tool or param, behavior change) | major |
+
+See [RELEASING.md](RELEASING.md) for the full policy, rationale, and release process.
 
 ## Roadmap
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing gsuite-mcp
+
+This document describes the release process and versioning policy for gsuite-mcp.
+
+## Versioning Policy
+
+gsuite-mcp uses a **patch-first** versioning policy. This is an intentional, documented
+deviation from strict Semantic Versioning (which would treat any new feature as a minor bump).
+
+| Change type | Bump | Example |
+|---|---|---|
+| Bug fix | **patch** | Fix a nil-pointer panic in Gmail search → `v0.3.3 → v0.3.4` |
+| Small / low-risk additive feature (e.g. a new optional tool parameter, a new optional field in a response) | **patch** | Add optional `color_id` param to `calendar_create_event` → `v0.3.3 → v0.3.4` |
+| Larger or notable feature set (multiple new tools, new service area) | **minor** | Add Google Chat support (9 tools) → `v0.3.x → v0.4.0` |
+| Breaking change (removed or renamed tool/parameter, changed required parameter type, behavior change that breaks existing callers) | **major** | Rename `gmail_get` → `gmail_get_message` (breaking) → `v0.x.y → v1.0.0` |
+
+**Guiding principle**: patch is the default for bug fixes and small/low-risk additive changes.
+Reserve minor for releases that add meaningful new surface area (a new service, a batch of new
+tools, or a notable capability). Major is for breaking changes only.
+
+Strict SemVer would call any new feature a minor bump. For this project's cadence — where individual
+optional parameters and small quality-of-life additions ship frequently — that would produce a lot
+of minor bumps for changes that pose no compatibility risk. Patch-first keeps the version history
+aligned with how the project actually evolves.
+
+## Release Process
+
+1. **Update `CHANGELOG.md`** — add a new `## [X.Y.Z] - YYYY-MM-DD` section with changes grouped
+   under `### Added`, `### Changed`, `### Fixed`, `### Removed`.
+
+2. **Tag the release**:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+3. **GoReleaser** — the `.goreleaser.yml` and `.github/workflows/release.yml` build and publish
+   the release artifacts automatically when the tag is pushed.
+
+4. **Verify** — confirm the GitHub release page shows the correct binaries and the CHANGELOG
+   entry is accurate.
+
+## Changelog Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions:
+
+- **Added** — new features (tools, parameters, flags)
+- **Changed** — changes to existing behavior
+- **Fixed** — bug fixes
+- **Removed** — removed features or parameters
+- **Security** — security fixes
+
+Reference the GitHub issue or PR number in parentheses where applicable: `(#123)`.

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -206,8 +206,13 @@ Configuration:
   Client secret:  %s
 
 Environment variables:
-  GSUITE_MCP_CONFIG_DIR   Override config directory (same as --config-dir)
-  GSUITE_MCP_OAUTH_PORT   Override OAuth callback port (default: %d)
+  GSUITE_MCP_CONFIG_DIR    Override config directory (same as --config-dir)
+  GSUITE_MCP_OAUTH_PORT    Override OAuth callback port (default: %d)
+  GSUITE_OAUTH_TOKEN_CMD   Command to retrieve an OAuth refresh token from an external
+                            secret source. The command receives the account email as its
+                            first argument and must print the token to stdout; non-zero
+                            exit is treated as an error. When unset, tokens are read from
+                            local JSON files (default behaviour).
 
 For more information, see README.md
 `, serverName, serverName, serverName, serverName, serverName, serverName,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -402,7 +402,9 @@ func (m *Manager) saveTokenForEmail(email string, oauth2Token *oauth2.Token) err
 	// empty RefreshToken would permanently destroy the user's offline access.
 	refreshToken := oauth2Token.RefreshToken
 	if refreshToken == "" {
-		existing, loadErr := loadTokenForEmail(email)
+		// Always read from the local file for refresh-token preservation — the
+		// token-command hook is for loading, not for persisting OAuth state.
+		existing, loadErr := loadTokenFromFile(email)
 		if loadErr != nil {
 			// Loading the existing credential failed (corrupt JSON, permission issue, etc.).
 			// We MUST NOT silently overwrite the file with an empty refresh_token — that is
@@ -566,8 +568,72 @@ func (m *Manager) authExpiredError(email string, cause error) error {
 	return &authExpiredErr{msg: msg, cause: cause}
 }
 
-// loadTokenForEmail loads the stored token for an email address.
-func loadTokenForEmail(email string) (*Token, error) {
+// oauthTokenCmdEnv is the environment variable that, when set, enables the
+// vendor-neutral OAuth token command hook. The named command is executed with
+// the account identifier (email) as its first argument; it must print the
+// OAuth refresh token to stdout and exit 0 on success, or exit non-zero on
+// failure.
+const oauthTokenCmdEnv = "GSUITE_OAUTH_TOKEN_CMD"
+
+// loadTokenViaCmd executes the command specified by oauthTokenCmdEnv with
+// email as the first argument and returns a Token whose RefreshToken field is
+// populated from the command's stdout. The rest of the token fields (client
+// credentials, scopes, token_uri) are read from the local credential file so
+// that the token can be exchanged normally — only the refresh_token is
+// supplied by the external command.
+//
+// If the local credential file does not exist the token fields are left at
+// their zero values; callers that need client credentials should handle this.
+//
+// Returns an explicit, logged error when:
+//   - the command exits non-zero (non-zero exit = handled error, not swallowed)
+//   - the command produces no output
+func loadTokenViaCmd(email, cmd string) (*Token, error) {
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("GSUITE_OAUTH_TOKEN_CMD is set but empty")
+	}
+
+	// Append the account identifier as the first positional argument.
+	args := append(parts[1:], email)
+	c := exec.Command(parts[0], args...)
+	out, err := c.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			log.Printf("[oauth] token-cmd: account=%s cmd=%q exit_code=%d stderr=%q",
+				email, cmd, exitErr.ExitCode(), strings.TrimSpace(string(exitErr.Stderr)))
+			return nil, fmt.Errorf("GSUITE_OAUTH_TOKEN_CMD exited %d for account %s: %w",
+				exitErr.ExitCode(), email, err)
+		}
+		log.Printf("[oauth] token-cmd: account=%s cmd=%q error=%v", email, cmd, err)
+		return nil, fmt.Errorf("running GSUITE_OAUTH_TOKEN_CMD for account %s: %w", email, err)
+	}
+
+	refreshToken := strings.TrimSpace(string(out))
+	if refreshToken == "" {
+		log.Printf("[oauth] token-cmd: account=%s cmd=%q result=empty-output", email, cmd)
+		return nil, fmt.Errorf("GSUITE_OAUTH_TOKEN_CMD produced no output for account %s", email)
+	}
+
+	log.Printf("[oauth] token-cmd: account=%s result=ok", email)
+
+	// Seed the token struct with client credentials from the local file when
+	// it exists, so that the token source can exchange correctly.
+	token := &Token{RefreshToken: refreshToken}
+	if existing, loadErr := loadTokenFromFile(email); loadErr == nil {
+		token.TokenURI = existing.TokenURI
+		token.ClientID = existing.ClientID
+		token.ClientSecret = existing.ClientSecret
+		token.Scopes = existing.Scopes
+	}
+
+	return token, nil
+}
+
+// loadTokenFromFile loads the stored token for an email address directly from
+// the local credential file, bypassing any token-command hook.
+func loadTokenFromFile(email string) (*Token, error) {
 	path := config.CredentialPathForEmail(email)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -583,6 +649,22 @@ func loadTokenForEmail(email string) (*Token, error) {
 	}
 
 	return &token, nil
+}
+
+// loadTokenForEmail loads the stored OAuth token for an email address.
+//
+// Resolution order:
+//  1. If GSUITE_OAUTH_TOKEN_CMD is set, execute it with email as the argument
+//     and use the refresh token it prints to stdout. The local credential file
+//     is used only to seed the client-credential fields (ClientID, ClientSecret,
+//     TokenURI, Scopes) if it exists.
+//  2. Otherwise, read the token directly from the local JSON credential file
+//     (default and offline-fallback behaviour — unchanged from before).
+func loadTokenForEmail(email string) (*Token, error) {
+	if cmd := os.Getenv(oauthTokenCmdEnv); cmd != "" {
+		return loadTokenViaCmd(email, cmd)
+	}
+	return loadTokenFromFile(email)
 }
 
 // GetClientOrAuthenticate returns an authenticated HTTP client for the given email.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -577,13 +577,13 @@ const oauthTokenCmdEnv = "GSUITE_OAUTH_TOKEN_CMD"
 
 // loadTokenViaCmd executes the command specified by oauthTokenCmdEnv with
 // email as the first argument and returns a Token whose RefreshToken field is
-// populated from the command's stdout. The rest of the token fields (client
-// credentials, scopes, token_uri) are read from the local credential file so
-// that the token can be exchanged normally — only the refresh_token is
-// supplied by the external command.
+// populated from the command's stdout.
 //
-// If the local credential file does not exist the token fields are left at
-// their zero values; callers that need client credentials should handle this.
+// The Manager's oauthConfig (loaded from client_secret.json) is the authoritative
+// source for client credentials during token exchange — the Token.ClientID,
+// ClientSecret, TokenURI, and Scopes fields are best-effort seeds from the local
+// credential file (if it exists) and are used only if the file is written back to
+// disk. They do not affect how GetClientForEmail exchanges the refresh token.
 //
 // Returns an explicit, logged error when:
 //   - the command exits non-zero (non-zero exit = handled error, not swallowed)
@@ -618,8 +618,9 @@ func loadTokenViaCmd(email, cmd string) (*Token, error) {
 
 	log.Printf("[oauth] token-cmd: account=%s result=ok", email)
 
-	// Seed the token struct with client credentials from the local file when
-	// it exists, so that the token source can exchange correctly.
+	// Best-effort: seed ClientID/ClientSecret/TokenURI/Scopes from the local file
+	// so they are preserved if saveTokenForEmail writes the credential to disk later.
+	// These fields are NOT used for token exchange — the Manager's oauthConfig is.
 	token := &Token{RefreshToken: refreshToken}
 	if existing, loadErr := loadTokenFromFile(email); loadErr == nil {
 		token.TokenURI = existing.TokenURI

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -714,9 +714,17 @@ func TestLoadTokenViaCmd_SuppliesRefreshToken(t *testing.T) {
 	email := "cmd@example.com"
 	wantToken := "refresh-from-command"
 
-	// Write a small shell script that ignores its argument and prints a fixed token.
+	// Write a shell script that verifies it received the email as $1 and prints the token.
+	// This validates both that stdout is used as the refresh token AND that the account
+	// email is correctly passed as the first argument (per the GSUITE_OAUTH_TOKEN_CMD contract).
 	scriptPath := filepath.Join(dir, "get-token.sh")
-	script := "#!/bin/sh\necho " + wantToken + "\n"
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"" + email + "\" ]; then\n" +
+		"  echo " + wantToken + "\n" +
+		"else\n" +
+		"  echo \"unexpected account: $1\" >&2\n" +
+		"  exit 2\n" +
+		"fi\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0700); err != nil {
 		t.Fatalf("writing test script: %v", err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -678,7 +678,7 @@ func TestSaveTokenForEmail_CredentialFilePermissions(t *testing.T) {
 
 	email := "perm@example.com"
 	token := &oauth2.Token{
-		AccessToken:  "access",
+		AccessToken:  "refresh",
 		RefreshToken: "refresh",
 		Expiry:       time.Now().Add(time.Hour),
 	}
@@ -696,5 +696,111 @@ func TestSaveTokenForEmail_CredentialFilePermissions(t *testing.T) {
 	// the constant itself would make this test vacuously pass (both sides move together).
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Errorf("expected file mode 0600, got %04o", perm)
+	}
+}
+
+// === GSUITE_OAUTH_TOKEN_CMD hook tests ===
+
+func TestLoadTokenViaCmd_SuppliesRefreshToken(t *testing.T) {
+	// When GSUITE_OAUTH_TOKEN_CMD is set, loadTokenForEmail must execute the command
+	// with the account email as the argument and use its stdout as the refresh token.
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() {
+		config.SetConfigDir("")
+		os.Unsetenv(oauthTokenCmdEnv)
+	})
+
+	email := "cmd@example.com"
+	wantToken := "refresh-from-command"
+
+	// Write a small shell script that ignores its argument and prints a fixed token.
+	scriptPath := filepath.Join(dir, "get-token.sh")
+	script := "#!/bin/sh\necho " + wantToken + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0700); err != nil {
+		t.Fatalf("writing test script: %v", err)
+	}
+
+	t.Setenv(oauthTokenCmdEnv, scriptPath)
+
+	token, err := loadTokenForEmail(email)
+	if err != nil {
+		t.Fatalf("loadTokenForEmail with cmd hook failed: %v", err)
+	}
+	if token.RefreshToken != wantToken {
+		t.Errorf("expected refresh token %q from command, got %q", wantToken, token.RefreshToken)
+	}
+}
+
+func TestLoadTokenViaCmd_NonZeroExitReturnsError(t *testing.T) {
+	// A non-zero exit from GSUITE_OAUTH_TOKEN_CMD must return a clear error
+	// (not a silent failure / swallowed error).
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() {
+		config.SetConfigDir("")
+		os.Unsetenv(oauthTokenCmdEnv)
+	})
+
+	email := "fail@example.com"
+	t.Setenv(oauthTokenCmdEnv, "false") // 'false' always exits 1
+
+	_, err := loadTokenForEmail(email)
+	if err == nil {
+		t.Fatal("expected error from non-zero exit command, got nil")
+	}
+	if !strings.Contains(err.Error(), "GSUITE_OAUTH_TOKEN_CMD") {
+		t.Errorf("expected GSUITE_OAUTH_TOKEN_CMD in error message, got: %v", err)
+	}
+}
+
+func TestLoadTokenViaCmd_EmptyOutputReturnsError(t *testing.T) {
+	// A command that exits 0 but prints nothing must return a clear error.
+	dir := t.TempDir()
+	config.SetConfigDir(dir)
+	t.Cleanup(func() {
+		config.SetConfigDir("")
+		os.Unsetenv(oauthTokenCmdEnv)
+	})
+
+	email := "empty@example.com"
+	t.Setenv(oauthTokenCmdEnv, "true") // 'true' exits 0 and prints nothing
+
+	_, err := loadTokenForEmail(email)
+	if err == nil {
+		t.Fatal("expected error from empty-output command, got nil")
+	}
+	if !strings.Contains(err.Error(), "no output") {
+		t.Errorf("expected 'no output' in error message, got: %v", err)
+	}
+}
+
+func TestLoadTokenForEmail_UnsetCmd_ReadsLocalFile(t *testing.T) {
+	// When GSUITE_OAUTH_TOKEN_CMD is not set, loadTokenForEmail must read from
+	// the local JSON credential file (unchanged default behaviour).
+	dir := t.TempDir()
+	m := newTestManager(t, dir)
+
+	email := "local@example.com"
+	wantRefresh := "local-refresh-token"
+
+	initial := &oauth2.Token{
+		AccessToken:  "access",
+		RefreshToken: wantRefresh,
+		Expiry:       time.Now().Add(time.Hour),
+	}
+	if err := m.saveTokenForEmail(email, initial); err != nil {
+		t.Fatalf("saving token: %v", err)
+	}
+
+	// Ensure env var is not set.
+	os.Unsetenv(oauthTokenCmdEnv)
+
+	token, err := loadTokenForEmail(email)
+	if err != nil {
+		t.Fatalf("loadTokenForEmail without cmd: %v", err)
+	}
+	if token.RefreshToken != wantRefresh {
+		t.Errorf("expected refresh token %q from local file, got %q", wantRefresh, token.RefreshToken)
 	}
 }


### PR DESCRIPTION
Closes #174
Closes #168

## Summary

- **#174 — Release policy docs**: Adds `RELEASING.md` with the patch-first versioning policy table (bug fixes and small additive features → patch; larger feature sets → minor; breaking changes → major). Documents this as an intentional, stated deviation from strict SemVer. README gains a compact `Releases` section with the same table and a link to RELEASING.md.

- **#168 — Vendor-neutral OAuth token hook**: Implements `GSUITE_OAUTH_TOKEN_CMD`. When set, gsuite-mcp executes the command with the account email as its first argument and uses stdout as the OAuth refresh token. Non-zero exit or empty output returns a clear, logged error (never swallowed). When unset, behaviour is unchanged — tokens are read from local JSON files. The hook is secret-manager agnostic (works with 1Password, Vault, `pass`, env injection, or any tool that follows the contract). README and `--help` output document only the generic contract; no private tools are named.

  > Note: issue #168's title ("via creds-mcp") is stale — the implementation is vendor-neutral per the rescoped issue body.

## Changes

| File | Change |
|---|---|
| `RELEASING.md` | New — full release policy, bump table, and release process |
| `README.md` | Added `Releases` section + `GSUITE_OAUTH_TOKEN_CMD` docs |
| `cmd/gsuite-mcp/main.go` | Added `GSUITE_OAUTH_TOKEN_CMD` to `--help` env-var list |
| `internal/auth/auth.go` | `loadTokenForEmail` dispatches to `loadTokenViaCmd` when env set; `loadTokenFromFile` is the file-only path used by `saveTokenForEmail` for preservation |
| `internal/auth/auth_test.go` | 4 new tests: cmd supplies token, non-zero exit errors, empty output errors, unset reads local file |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -short` — all pass (19 packages)
- [x] New token-cmd tests cover: hook set → token from command, non-zero exit → clear error, empty stdout → clear error, unset → local file