### PR TITLE
fix(docs): correct docs_batch_update endpoint URL construction

### DIFF
--- a/internal/docs/docs_service.go
+++ b/internal/docs/docs_service.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
 )
 
 // DocsService defines the interface for Google Docs API operations.
@@ -101,11 +102,14 @@ func (s *RealDocsService) BatchUpdateRaw(ctx context.Context, documentID string,
 		return nil, fmt.Errorf("marshal batch update body: %w", err)
 	}
 
-	url := fmt.Sprintf("%sdocuments/%s:batchUpdate", s.service.BasePath, documentID)
+	url := googleapi.ResolveRelative(s.service.BasePath, "v1/documents/{documentId}:batchUpdate")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
+	googleapi.Expand(req.URL, map[string]string{
+		"documentId": documentID,
+	})
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.httpClient.Do(req)

--- a/internal/docs/docs_service_test.go
+++ b/internal/docs/docs_service_test.go
@@ -1,0 +1,59 @@
+package docs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	googledocs "google.golang.org/api/docs/v1"
+)
+
+func TestRealDocsServiceBatchUpdateRawUsesDocsAPIEndpoint(t *testing.T) {
+	requestsJSON := json.RawMessage(`[{"insertText":{"text":"Hello","location":{"index":1}}}]`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != "/v1/documents/doc-123:batchUpdate" {
+			t.Errorf("path = %s, want /v1/documents/doc-123:batchUpdate", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+
+		var body struct {
+			Requests []json.RawMessage `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if len(body.Requests) != 1 {
+			t.Fatalf("request count = %d, want 1", len(body.Requests))
+		}
+		if string(body.Requests[0]) != string(requestsJSON[1:len(requestsJSON)-1]) {
+			t.Errorf("request body = %s, want %s", body.Requests[0], requestsJSON[1:len(requestsJSON)-1])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"documentId":"doc-123","replies":[{}]}`))
+	}))
+	defer server.Close()
+
+	srv := NewRealDocsServiceWithHTTP(&googledocs.Service{
+		BasePath: server.URL + "/",
+	}, nil, server.Client())
+
+	resp, err := srv.BatchUpdateRaw(context.Background(), "doc-123", requestsJSON)
+	if err != nil {
+		t.Fatalf("BatchUpdateRaw returned error: %v", err)
+	}
+	if resp.DocumentId != "doc-123" {
+		t.Errorf("DocumentId = %q, want doc-123", resp.DocumentId)
+	}
+	if len(resp.Replies) != 1 {
+		t.Errorf("reply count = %d, want 1", len(resp.Replies))
+	}
+}


### PR DESCRIPTION
Closes #180

## Problem

\`docs_batch_update\` returned HTTP 400 with Google's HTML "Page Not Found" page (not a JSON API error) for valid batchUpdate requests, while every other \`docs_*\` tool worked on the same document in the same session.

## Root cause

\`docs_batch_update\` routes through \`BatchUpdateRaw\`, which hand-built the request URL:

\`\`\`go
url := fmt.Sprintf("%sdocuments/%s:batchUpdate", s.service.BasePath, documentID)
\`\`\`

The docs Service \`BasePath\` is \`https://docs.googleapis.com/\`, so this produced \`https://docs.googleapis.com/documents/{id}:batchUpdate\` — **missing the required \`v1/\` path segment**. That URL hits Google's web frontend, which answers with an HTML "Page Not Found" page, matching the exact signature in the report. The other docs tools go through the typed Go client, which builds \`v1/documents/{documentId}:batchUpdate\` correctly.

## Fix

Build the URL the same way the generated Go client does:

\`\`\`go
url := googleapi.ResolveRelative(s.service.BasePath, "v1/documents/{documentId}:batchUpdate")
// ...
googleapi.Expand(req.URL, map[string]string{"documentId": documentID})
\`\`\`

This restores the correct \`https://docs.googleapis.com/v1/documents/{id}:batchUpdate\` endpoint and provides proper path-escaping of the document id.

## Test

Added \`TestRealDocsServiceBatchUpdateRawUsesDocsAPIEndpoint\` — spins up an httptest server and asserts the request path is \`/v1/documents/{id}:batchUpdate\`, the method/content-type are correct, the request body is the unwrapped requests array, and the response unmarshals.

\`go build ./...\` and \`go test ./...\` pass.