### PR TITLE
fix(security): prevent path traversal in account resolution (#182)

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -391,6 +391,9 @@ func (m *Manager) AuthenticateDynamic(ctx context.Context) (string, error) {
 // initial grant). If oauth2Token.RefreshToken is empty we preserve the existing
 // on-disk value so the token file never loses its refresh token.
 func (m *Manager) saveTokenForEmail(email string, oauth2Token *oauth2.Token) error {
+	if err := config.ValidateAccount(email); err != nil {
+		return fmt.Errorf("invalid account %q: %w", email, err)
+	}
 	if err := config.EnsureConfigDir(); err != nil {
 		return fmt.Errorf("ensuring config dir: %w", err)
 	}

--- a/internal/common/deps.go
+++ b/internal/common/deps.go
@@ -63,6 +63,9 @@ func ResolveAccountFromRequestWithDeps(request mcp.CallToolRequest, d *Deps) (st
 	}
 
 	// Account param specified - check if credentials exist
+	if err := config.ValidateAccount(accountParam); err != nil {
+		return "", fmt.Errorf("invalid account %q: %w", accountParam, err)
+	}
 	if config.HasCredentialsForEmail(accountParam) {
 		return accountParam, nil
 	}

--- a/internal/common/deps_test.go
+++ b/internal/common/deps_test.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestResolveAccountFromRequestWithDepsRejectsInvalidAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+	}{
+		{name: "traversal", account: "../user@example.com"},
+		{name: "absolute path", account: filepath.Join(string(filepath.Separator), "tmp", "user@example.com")},
+		{name: "null byte", account: "user\x00@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Arguments: map[string]any{"account": tt.account},
+				},
+			}
+
+			email, err := ResolveAccountFromRequestWithDeps(request, nil)
+			if err == nil {
+				t.Fatal("expected invalid account error")
+			}
+			if email != "" {
+				t.Errorf("expected empty email on error, got %q", email)
+			}
+			if !strings.Contains(err.Error(), "invalid account") {
+				t.Errorf("expected invalid account error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strings"
 )
 
 // DefaultOAuthPort is the default port used for the OAuth callback server.
@@ -17,6 +19,8 @@ const DefaultOAuthPort = 38917
 // configFileMode restricts config.json to owner-only access (matches credential files).
 // Config may contain organizational metadata (drive access rules, sheet IDs, feature flags).
 const configFileMode = 0600
+
+var accountEmailPattern = regexp.MustCompile(`^[A-Za-z0-9._%+\-]+@[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?)+$`)
 
 // DriveAccess configures which shared drives are accessible via MCP tools.
 // Set either Allowed (allowlist) or Blocked (blocklist), not both.
@@ -167,7 +171,59 @@ func ClientSecretPath() string {
 
 // CredentialPathForEmail returns the credential file path for an email address.
 func CredentialPathForEmail(email string) string {
-	return filepath.Join(CredentialsDir(), email+".json")
+	path, err := credentialPathForEmail(email)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+// ValidateAccount checks that an account identifier is a plausible email address,
+// not a filesystem path.
+func ValidateAccount(email string) error {
+	if email == "" {
+		return fmt.Errorf("account is required")
+	}
+	if strings.ContainsRune(email, 0) {
+		return fmt.Errorf("account must not contain NUL bytes")
+	}
+	if filepath.IsAbs(email) {
+		return fmt.Errorf("account must be an email address, not an absolute path")
+	}
+	if filepath.Base(email) != email || strings.Contains(email, `\`) {
+		return fmt.Errorf("account must not contain path separators")
+	}
+	if !accountEmailPattern.MatchString(email) {
+		return fmt.Errorf("account must be a valid email address")
+	}
+	if _, err := credentialPathForEmail(email); err != nil {
+		return err
+	}
+	return nil
+}
+
+func credentialPathForEmail(email string) (string, error) {
+	base := filepath.Base(email)
+	if base == "." || base == string(filepath.Separator) || strings.ContainsRune(base, 0) {
+		return "", fmt.Errorf("invalid account credential path")
+	}
+
+	credentialsDir, err := filepath.Abs(filepath.Clean(CredentialsDir()))
+	if err != nil {
+		return "", fmt.Errorf("resolving credentials dir: %w", err)
+	}
+	path, err := filepath.Abs(filepath.Clean(filepath.Join(credentialsDir, base+".json")))
+	if err != nil {
+		return "", fmt.Errorf("resolving credential path: %w", err)
+	}
+	rel, err := filepath.Rel(credentialsDir, path)
+	if err != nil {
+		return "", fmt.Errorf("checking credential path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("credential path escapes credentials dir")
+	}
+	return path, nil
 }
 
 // EnsureConfigDir creates the configuration directory if it doesn't exist.
@@ -211,6 +267,9 @@ func GetAuthenticatedEmails() ([]string, error) {
 // HasCredentialsForEmail checks if credentials exist for an email.
 func HasCredentialsForEmail(email string) bool {
 	path := CredentialPathForEmail(email)
+	if path == "" {
+		return false
+	}
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,102 @@ func TestCredentialPathForEmail(t *testing.T) {
 			}
 			if filepath.Base(path) != tt.wantSuffix {
 				t.Errorf("CredentialPathForEmail() = %s, want suffix %s", filepath.Base(path), tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestValidateAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+		wantErr bool
+	}{
+		{name: "traversal", account: "../user@example.com", wantErr: true},
+		{name: "absolute path", account: filepath.Join(string(filepath.Separator), "tmp", "user@example.com"), wantErr: true},
+		{name: "null byte", account: "user\x00@example.com", wantErr: true},
+		{name: "empty", account: "", wantErr: true},
+		{name: "valid email", account: "user.name+tag@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAccount(tt.account)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAccount(%q) error = %v, wantErr %v", tt.account, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCredentialPathForEmailFailsClosed(t *testing.T) {
+	origOverride := configDirOverride
+	SetConfigDir(t.TempDir())
+	t.Cleanup(func() { configDirOverride = origOverride })
+
+	tests := []struct {
+		name     string
+		account  string
+		wantBase string
+		wantPath bool
+	}{
+		{
+			name:     "traversal collapses to basename",
+			account:  "../user@example.com",
+			wantBase: "user@example.com.json",
+			wantPath: true,
+		},
+		{
+			name:     "absolute path collapses to basename",
+			account:  filepath.Join(string(filepath.Separator), "tmp", "user@example.com"),
+			wantBase: "user@example.com.json",
+			wantPath: true,
+		},
+		{
+			name:    "null byte rejected",
+			account: "user\x00@example.com",
+		},
+		{
+			name:    "empty rejected",
+			account: "",
+		},
+		{
+			name:     "valid email unchanged",
+			account:  "user.name+tag@example.com",
+			wantBase: "user.name+tag@example.com.json",
+			wantPath: true,
+		},
+	}
+
+	credentialsDir, err := filepath.Abs(filepath.Clean(CredentialsDir()))
+	if err != nil {
+		t.Fatalf("failed to resolve credentials dir: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := CredentialPathForEmail(tt.account)
+			if !tt.wantPath {
+				if path != "" {
+					t.Fatalf("CredentialPathForEmail(%q) = %q, want empty", tt.account, path)
+				}
+				return
+			}
+			if path == "" {
+				t.Fatalf("CredentialPathForEmail(%q) returned empty path", tt.account)
+			}
+			if filepath.Base(path) != tt.wantBase {
+				t.Errorf("CredentialPathForEmail(%q) base = %q, want %q", tt.account, filepath.Base(path), tt.wantBase)
+			}
+			if !filepath.IsAbs(path) {
+				t.Errorf("CredentialPathForEmail(%q) returned non-absolute path: %s", tt.account, path)
+			}
+			rel, err := filepath.Rel(credentialsDir, path)
+			if err != nil {
+				t.Fatalf("failed to compare credential path: %v", err)
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+				t.Errorf("CredentialPathForEmail(%q) escaped credentials dir: %s", tt.account, path)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #182

## Summary

The MCP `account` parameter flowed unsanitized into credential path construction (`config.CredentialPathForEmail` → `filepath.Join(CredentialsDir(), email+".json")`), allowing crafted values like `../../../etc/foo`, absolute paths, or null-byte payloads to escape `CredentialsDir()` for arbitrary `.json` file read / account impersonation.

## Changes

- **`config.ValidateAccount(email) error`** (new): rejects empty input, embedded NUL bytes, absolute paths, path separators, non-email identifiers, and any path that escapes `CredentialsDir()`. Called at the resolver (`internal/common/deps.go`) **before** credential lookup, and on the auth write path (`internal/auth/auth.go` `saveTokenForEmail`) before persisting tokens.
- **`CredentialPathForEmail`** is now fail-closed: applies `filepath.Base` and a `filepath.Rel` containment check against `CredentialsDir()`, returning empty on any escape. `HasCredentialsForEmail` treats an empty path as no match (never `os.Stat("")`).
- Email regex is conservative-but-permissive for real Google addresses (allows `+`-tags and dots).

## Tests

Table-driven coverage for `../` traversal, absolute path, null-byte, and empty (all rejected) plus a valid-email happy path; fail-closed basename-collapse + containment assertions using `SetConfigDir(t.TempDir())` with `configDirOverride` restored in `t.Cleanup`; and resolver-level rejection in `internal/common/deps_test.go`.

`go build ./...` and `go test ./...` pass.
