### PR TITLE
feat: support gmail attachments (Closes #190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Google Chat management: list/get/create spaces, list/get/send messages, thread r
 | `gmail_get_message` | Alias for `gmail_get` |
 | `gmail_get_messages` | Batch get messages (max 25) |
 | `gmail_get_thread` | Get full conversation thread |
-| `gmail_send` | Send new email |
-| `gmail_reply` | Reply to existing thread |
-| `gmail_draft` | Create draft |
+| `gmail_send` | Send new email, optionally with local attachments |
+| `gmail_reply` | Reply to existing thread, optionally with local attachments |
+| `gmail_draft` | Create draft, optionally with local attachments |
 | `gmail_list_labels` | List all labels with counts |
 
 #### Gmail Management
@@ -335,7 +335,7 @@ All tools accept an optional `account` parameter:
 ```
 1. gmail_search({"query": "is:unread", "account": "support"})
 2. gmail_get({"message_id": "...", "account": "support"})
-3. gmail_reply({"message_id": "...", "body": "Thanks for reaching out..."})
+3. gmail_reply({"message_id": "...", "body": "Thanks for reaching out...", "attachments": ["/abs/path/to/form.pdf"]})
 4. gmail_batch_archive({"message_ids": [...]})
 ```
 

--- a/internal/gmail/gmail_helpers.go
+++ b/internal/gmail/gmail_helpers.go
@@ -1,9 +1,16 @@
 package gmail
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -13,6 +20,11 @@ import (
 
 // emailContentType is the default Content-Type header for plain text emails.
 const emailContentType = "Content-Type: text/plain; charset=\"UTF-8\""
+
+const (
+	gmailDefaultAttachmentMIMEType = "application/octet-stream"
+	gmailMaxOutgoingRawBytes       = 25 * 1024 * 1024
+)
 
 // parseBodyFormat parses the "body_format" argument from a request and returns the
 // corresponding BodyFormat. Defaults to BodyFormatText if not specified.
@@ -49,6 +61,28 @@ func buildMessageFromArgs(args map[string]any) *gmail.Message {
 	return &gmail.Message{Raw: raw}
 }
 
+// buildMessageFromArgsWithAttachments builds a gmail.Message from common email
+// arguments and optional local attachment file paths.
+func buildMessageFromArgsWithAttachments(args map[string]any) (*gmail.Message, error) {
+	attachments, err := loadEmailAttachments(args["attachments"])
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := buildEmailMessageWithAttachments(EmailMessage{
+		To:      common.ParseStringArg(args, "to", ""),
+		Cc:      common.ParseStringArg(args, "cc", ""),
+		Bcc:     common.ParseStringArg(args, "bcc", ""),
+		Subject: common.ParseStringArg(args, "subject", ""),
+		Body:    common.ParseStringArg(args, "body", ""),
+	}, attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gmail.Message{Raw: raw}, nil
+}
+
 // EmailMessage holds the components for building an RFC 2822 email message.
 type EmailMessage struct {
 	To           string
@@ -59,32 +93,208 @@ type EmailMessage struct {
 	ExtraHeaders map[string]string // Additional headers (e.g., In-Reply-To, References)
 }
 
+type emailAttachment struct {
+	Path     string
+	Filename string
+	MIMEType string
+	Data     []byte
+}
+
 // buildEmailMessage constructs an RFC 2822 email message and returns it
 // as a base64 URL-encoded string suitable for the Gmail API Raw field.
 // Fields that are empty strings are omitted from the headers.
 func buildEmailMessage(msg EmailMessage) string {
 	var b strings.Builder
 
-	if msg.To != "" {
-		fmt.Fprintf(&b, "To: %s\r\n", msg.To)
-	}
-	if msg.Cc != "" {
-		fmt.Fprintf(&b, "Cc: %s\r\n", msg.Cc)
-	}
-	if msg.Bcc != "" {
-		fmt.Fprintf(&b, "Bcc: %s\r\n", msg.Bcc)
-	}
-	if msg.Subject != "" {
-		fmt.Fprintf(&b, "Subject: %s\r\n", msg.Subject)
-	}
-	for key, value := range msg.ExtraHeaders {
-		fmt.Fprintf(&b, "%s: %s\r\n", key, value)
-	}
+	writeEmailHeaders(&b, msg)
 	b.WriteString(emailContentType + "\r\n")
 	b.WriteString("\r\n")
 	b.WriteString(msg.Body)
 
 	return base64.URLEncoding.EncodeToString([]byte(b.String()))
+}
+
+func buildEmailMessageWithAttachments(msg EmailMessage, attachments []emailAttachment) (string, error) {
+	if len(attachments) == 0 {
+		return buildEmailMessage(msg), nil
+	}
+
+	raw, err := buildMultipartEmailBytes(msg, attachments)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) > gmailMaxOutgoingRawBytes {
+		return "", fmt.Errorf("email with attachments is %d bytes, exceeding the 25 MiB Gmail send limit", len(raw))
+	}
+
+	return base64.URLEncoding.EncodeToString(raw), nil
+}
+
+func buildMultipartEmailBytes(msg EmailMessage, attachments []emailAttachment) ([]byte, error) {
+	var b bytes.Buffer
+	writeEmailHeaders(&b, msg)
+	b.WriteString("MIME-Version: 1.0\r\n")
+
+	writer := multipart.NewWriter(&b)
+	contentType := mime.FormatMediaType("multipart/mixed", map[string]string{"boundary": writer.Boundary()})
+	fmt.Fprintf(&b, "Content-Type: %s\r\n", contentType)
+	b.WriteString("\r\n")
+
+	bodyHeader := textproto.MIMEHeader{}
+	bodyHeader.Set("Content-Type", "text/plain; charset=\"UTF-8\"")
+	bodyHeader.Set("Content-Transfer-Encoding", "8bit")
+	bodyPart, err := writer.CreatePart(bodyHeader)
+	if err != nil {
+		return nil, fmt.Errorf("create email body part: %w", err)
+	}
+	if _, err := io.WriteString(bodyPart, msg.Body); err != nil {
+		return nil, fmt.Errorf("write email body part: %w", err)
+	}
+
+	for _, attachment := range attachments {
+		attachmentHeader := textproto.MIMEHeader{}
+		attachmentHeader.Set("Content-Type", formatAttachmentContentType(attachment.MIMEType, attachment.Filename))
+		attachmentHeader.Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": attachment.Filename}))
+		attachmentHeader.Set("Content-Transfer-Encoding", "base64")
+
+		attachmentPart, err := writer.CreatePart(attachmentHeader)
+		if err != nil {
+			return nil, fmt.Errorf("create attachment part for %q: %w", attachment.Path, err)
+		}
+		if err := writeWrappedBase64(attachmentPart, attachment.Data); err != nil {
+			return nil, fmt.Errorf("write attachment %q: %w", attachment.Path, err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close email multipart body: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+func writeEmailHeaders(w io.Writer, msg EmailMessage) {
+	if msg.To != "" {
+		fmt.Fprintf(w, "To: %s\r\n", msg.To)
+	}
+	if msg.Cc != "" {
+		fmt.Fprintf(w, "Cc: %s\r\n", msg.Cc)
+	}
+	if msg.Bcc != "" {
+		fmt.Fprintf(w, "Bcc: %s\r\n", msg.Bcc)
+	}
+	if msg.Subject != "" {
+		fmt.Fprintf(w, "Subject: %s\r\n", msg.Subject)
+	}
+	for key, value := range msg.ExtraHeaders {
+		fmt.Fprintf(w, "%s: %s\r\n", key, value)
+	}
+}
+
+func loadEmailAttachments(value any) ([]emailAttachment, error) {
+	paths, err := parseAttachmentPaths(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	attachments := make([]emailAttachment, 0, len(paths))
+	var totalSize int64
+	for index, path := range paths {
+		if path == "" {
+			return nil, fmt.Errorf("attachments[%d] must be a non-empty file path", index)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot access attachment %q: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("attachment %q is a directory, not a file", path)
+		}
+
+		totalSize += info.Size()
+		if totalSize > gmailMaxOutgoingRawBytes {
+			return nil, fmt.Errorf("attachments exceed the 25 MiB Gmail send limit after adding %q", path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read attachment %q: %w", path, err)
+		}
+
+		attachments = append(attachments, emailAttachment{
+			Path:     path,
+			Filename: filepath.Base(path),
+			MIMEType: detectAttachmentMIMEType(path),
+			Data:     data,
+		})
+	}
+
+	return attachments, nil
+}
+
+func parseAttachmentPaths(value any) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	switch typed := value.(type) {
+	case []any:
+		paths := make([]string, 0, len(typed))
+		for index, item := range typed {
+			path, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("attachments[%d] must be a file path string", index)
+			}
+			paths = append(paths, path)
+		}
+		return paths, nil
+	case []string:
+		return typed, nil
+	default:
+		return nil, fmt.Errorf("attachments must be an array of file path strings")
+	}
+}
+
+func detectAttachmentMIMEType(path string) string {
+	mimeType := mime.TypeByExtension(filepath.Ext(path))
+	if mimeType == "" {
+		return gmailDefaultAttachmentMIMEType
+	}
+	return mimeType
+}
+
+func formatAttachmentContentType(mimeType, filename string) string {
+	mediaType, params, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		mediaType = gmailDefaultAttachmentMIMEType
+		params = map[string]string{}
+	}
+	if params == nil {
+		params = map[string]string{}
+	}
+	params["name"] = filename
+
+	contentType := mime.FormatMediaType(mediaType, params)
+	if contentType == "" {
+		return mime.FormatMediaType(gmailDefaultAttachmentMIMEType, map[string]string{"name": filename})
+	}
+	return contentType
+}
+
+func writeWrappedBase64(w io.Writer, data []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(data)
+	for len(encoded) > 76 {
+		if _, err := io.WriteString(w, encoded[:76]+"\r\n"); err != nil {
+			return err
+		}
+		encoded = encoded[76:]
+	}
+	_, err := io.WriteString(w, encoded+"\r\n")
+	return err
 }
 
 // modifyMessageLabels is a generic helper for single-message label modification

--- a/internal/gmail/gmail_tools_test.go
+++ b/internal/gmail/gmail_tools_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -109,6 +112,41 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func decodeRawEmail(t *testing.T, raw string) string {
+	t.Helper()
+	decoded, err := base64.URLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("failed to decode raw email: %v", err)
+	}
+	return string(decoded)
+}
+
+func lastGmailMessageArg(t *testing.T, fixtures *GmailTestFixtures, method string) *gmail.Message {
+	t.Helper()
+	lastCall := fixtures.MockService.GetLastCall()
+	if lastCall == nil || lastCall.Method != method {
+		t.Fatalf("expected %s call, got %#v", method, lastCall)
+	}
+	message, ok := lastCall.Args[0].(*gmail.Message)
+	if !ok {
+		t.Fatalf("expected gmail.Message arg, got %T", lastCall.Args[0])
+	}
+	return message
+}
+
+func lastGmailDraftArg(t *testing.T, fixtures *GmailTestFixtures, method string) *gmail.Draft {
+	t.Helper()
+	lastCall := fixtures.MockService.GetLastCall()
+	if lastCall == nil || lastCall.Method != method {
+		t.Fatalf("expected %s call, got %#v", method, lastCall)
+	}
+	draft, ok := lastCall.Args[0].(*gmail.Draft)
+	if !ok {
+		t.Fatalf("expected gmail.Draft arg, got %T", lastCall.Args[0])
+	}
+	return draft
 }
 
 // === gmail_search tests ===
@@ -643,6 +681,106 @@ func TestGmailSend_NoSubjectAllowed(t *testing.T) {
 	}
 }
 
+func TestGmailSend_WithAttachment(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	attachmentPath := filepath.Join(t.TempDir(), "notes.txt")
+	attachmentData := []byte("attachment contents")
+	if err := os.WriteFile(attachmentPath, attachmentData, 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	request := makeRequest(map[string]any{
+		"to":          "recipient@example.com",
+		"subject":     "Test Email",
+		"body":        "This is a test email.",
+		"attachments": []any{attachmentPath},
+	})
+
+	result, err := TestableGmailSend(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	raw := decodeRawEmail(t, lastGmailMessageArg(t, fixtures, "SendMessage").Raw)
+	for _, want := range []string{
+		"Content-Type: multipart/mixed;",
+		"Content-Type: text/plain; charset=\"UTF-8\"",
+		"Content-Disposition: attachment; filename=notes.txt",
+		"name=notes.txt",
+		"Content-Transfer-Encoding: base64",
+		base64.StdEncoding.EncodeToString(attachmentData),
+	} {
+		if !strings.Contains(raw, want) {
+			t.Errorf("raw message missing %q:\n%s", want, raw)
+		}
+	}
+}
+
+func TestGmailSend_MissingAttachmentPath(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	missingPath := filepath.Join(t.TempDir(), "missing.pdf")
+
+	request := makeRequest(map[string]any{
+		"to":          "recipient@example.com",
+		"subject":     "Test Email",
+		"body":        "This is a test email.",
+		"attachments": []any{missingPath},
+	})
+
+	result, err := TestableGmailSend(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error for missing attachment path")
+	}
+	if !strings.Contains(getTextResult(result), missingPath) {
+		t.Fatalf("expected error to name missing path %q, got %q", missingPath, getTextResult(result))
+	}
+	if fixtures.MockService.WasMethodCalled("SendMessage") {
+		t.Fatal("SendMessage should not be called when attachment validation fails")
+	}
+}
+
+func TestGmailSend_AttachmentSizeLimit(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	largePath := filepath.Join(t.TempDir(), "large.bin")
+	file, err := os.Create(largePath)
+	if err != nil {
+		t.Fatalf("create large attachment fixture: %v", err)
+	}
+	if err := file.Truncate(gmailMaxOutgoingRawBytes + 1); err != nil {
+		t.Fatalf("resize large attachment fixture: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close large attachment fixture: %v", err)
+	}
+
+	request := makeRequest(map[string]any{
+		"to":          "recipient@example.com",
+		"subject":     "Test Email",
+		"body":        "This is a test email.",
+		"attachments": []any{largePath},
+	})
+
+	result, err := TestableGmailSend(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error for oversized attachment")
+	}
+	if !strings.Contains(getTextResult(result), largePath) {
+		t.Fatalf("expected error to name oversized path %q, got %q", largePath, getTextResult(result))
+	}
+	if fixtures.MockService.WasMethodCalled("SendMessage") {
+		t.Fatal("SendMessage should not be called when attachment validation fails")
+	}
+}
+
 // === gmail_reply tests ===
 
 func TestGmailReply_Success(t *testing.T) {
@@ -714,6 +852,51 @@ func TestGmailReply_MessageNotFound(t *testing.T) {
 	}
 }
 
+func TestGmailReply_WithAttachment(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	attachmentPath := filepath.Join(t.TempDir(), "reply.pdf")
+	attachmentData := []byte("%PDF-1.4 fake pdf data")
+	if err := os.WriteFile(attachmentPath, attachmentData, 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	originalMsg := newTestMessage("msg123", "thread123", "Original Subject", "sender@example.com", "me@example.com", "Original body", []string{"INBOX"})
+	originalMsg.Payload.Headers = append(originalMsg.Payload.Headers, &gmail.MessagePartHeader{Name: "Message-ID", Value: "<msg123@example.com>"})
+	fixtures.MockService.AddMessage(originalMsg)
+
+	request := makeRequest(map[string]any{
+		"message_id":  "msg123",
+		"body":        "Reply with file",
+		"attachments": []any{attachmentPath},
+	})
+
+	result, err := TestableGmailReply(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	message := lastGmailMessageArg(t, fixtures, "SendMessage")
+	if message.ThreadId != "thread123" {
+		t.Fatalf("expected reply to stay in thread123, got %q", message.ThreadId)
+	}
+	raw := decodeRawEmail(t, message.Raw)
+	for _, want := range []string{
+		"In-Reply-To: <msg123@example.com>",
+		"References: <msg123@example.com>",
+		"Content-Type: multipart/mixed;",
+		"Content-Type: application/pdf; name=reply.pdf",
+		"Content-Disposition: attachment; filename=reply.pdf",
+		base64.StdEncoding.EncodeToString(attachmentData),
+	} {
+		if !strings.Contains(raw, want) {
+			t.Errorf("raw reply missing %q:\n%s", want, raw)
+		}
+	}
+}
+
 // === gmail_draft tests ===
 
 func TestGmailDraft_Success(t *testing.T) {
@@ -761,6 +944,46 @@ func TestGmailDraft_ForThread(t *testing.T) {
 	}
 	if result.IsError {
 		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+}
+
+func TestGmailDraft_WithAttachment(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	attachmentPath := filepath.Join(t.TempDir(), "README")
+	attachmentData := []byte("no extension")
+	if err := os.WriteFile(attachmentPath, attachmentData, 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	request := makeRequest(map[string]any{
+		"to":          "recipient@example.com",
+		"subject":     "Draft Subject",
+		"body":        "Draft body content",
+		"attachments": []any{attachmentPath},
+	})
+
+	result, err := TestableGmailDraft(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	draft := lastGmailDraftArg(t, fixtures, "CreateDraft")
+	if draft.Message == nil {
+		t.Fatal("expected draft message")
+	}
+	raw := decodeRawEmail(t, draft.Message.Raw)
+	for _, want := range []string{
+		"Content-Type: multipart/mixed;",
+		"Content-Type: application/octet-stream; name=README",
+		"Content-Disposition: attachment; filename=README",
+		base64.StdEncoding.EncodeToString(attachmentData),
+	} {
+		if !strings.Contains(raw, want) {
+			t.Errorf("raw draft missing %q:\n%s", want, raw)
+		}
 	}
 }
 

--- a/internal/gmail/register.go
+++ b/internal/gmail/register.go
@@ -92,6 +92,7 @@ func registerCoreTools(s *server.MCPServer) {
 		mcp.WithString("body", mcp.Required(), mcp.Description("Email body (plain text)")),
 		mcp.WithString("cc", mcp.Description("CC recipients, comma-separated")),
 		mcp.WithString("bcc", mcp.Description("BCC recipients, comma-separated")),
+		mcp.WithArray("attachments", mcp.Description("Optional local file paths to attach, for example [\"/abs/path/to/resume.pdf\"]. Total outgoing message must stay under about 25 MiB.")),
 		common.WithAccountParam(),
 	), HandleGmailSend)
 
@@ -103,6 +104,7 @@ func registerCoreTools(s *server.MCPServer) {
 		mcp.WithBoolean("reply_all", mcp.Description("Reply to all recipients (default: false)")),
 		mcp.WithString("to", mcp.Description("Override recipient (default: reply to sender)")),
 		mcp.WithString("cc", mcp.Description("Additional CC recipients")),
+		mcp.WithArray("attachments", mcp.Description("Optional local file paths to attach, for example [\"/abs/path/to/resume.pdf\"]. Total outgoing message must stay under about 25 MiB.")),
 		common.WithAccountParam(),
 	), HandleGmailReply)
 
@@ -115,6 +117,7 @@ func registerCoreTools(s *server.MCPServer) {
 		mcp.WithString("cc", mcp.Description("CC recipients")),
 		mcp.WithString("bcc", mcp.Description("BCC recipients")),
 		mcp.WithString("thread_id", mcp.Description("Thread ID for reply drafts")),
+		mcp.WithArray("attachments", mcp.Description("Optional local file paths to attach, for example [\"/abs/path/to/resume.pdf\"]. Total outgoing message must stay under about 25 MiB.")),
 		common.WithAccountParam(),
 	), HandleGmailDraft)
 

--- a/internal/gmail/testable_drafts.go
+++ b/internal/gmail/testable_drafts.go
@@ -175,7 +175,10 @@ func TestableGmailDraft(ctx context.Context, request mcp.CallToolRequest, deps *
 		return errResult, nil
 	}
 
-	message := buildMessageFromArgs(request.GetArguments())
+	message, err := buildMessageFromArgsWithAttachments(request.GetArguments())
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
 	// Support creating draft as reply
 	if threadID := common.ParseStringArg(request.GetArguments(), "thread_id", ""); threadID != "" {

--- a/internal/gmail/testable_messages.go
+++ b/internal/gmail/testable_messages.go
@@ -134,7 +134,10 @@ func TestableGmailSend(ctx context.Context, request mcp.CallToolRequest, deps *G
 		return errResult, nil
 	}
 
-	message := buildMessageFromArgs(request.GetArguments())
+	message, err := buildMessageFromArgsWithAttachments(request.GetArguments())
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
 	sent, err := svc.SendMessage(ctx, message)
 	if err != nil {
@@ -236,7 +239,15 @@ func TestableGmailReply(ctx context.Context, request mcp.CallToolRequest, deps *
 		},
 	}
 
-	raw := buildEmailMessage(emailMsg)
+	attachments, err := loadEmailAttachments(request.GetArguments()["attachments"])
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	raw, err := buildEmailMessageWithAttachments(emailMsg, attachments)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
 	message := &gmail.Message{
 		Raw:      raw,


### PR DESCRIPTION
## Summary
- add optional local file attachments to gmail_send, gmail_reply, and gmail_draft
- build multipart/mixed Gmail raw messages with MIME detection, base64 attachment parts, path validation, and a 25 MiB guard
- document the attachment parameter and cover send/reply/draft behavior in unit tests

## Test plan
- [x] go test ./internal/gmail
- [x] go test ./...
- [x] ax checkin