### PR TITLE
feat(gmail): download attachments to local files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses a patch-first versioning policy — see [RELEASING.md](RELEASING.md) for the full policy.
 
+## [0.4.6] - 2026-07-10
+
+### Added
+
+- Added `gmail_list_attachments` and `gmail_download_attachment` for listing Gmail attachment metadata and saving attachments directly to local files (#192)
+
 ## [0.4.5] - 2026-06-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gsuite-mcp auth personal
 
 ## Tools Overview
 
-### Gmail (45 tools)
+### Gmail (47 tools)
 Full inbox management: search, read, send, reply, archive, trash, labels, filters, drafts, threads, batch operations, vacation responder, send-as aliases, delegation.
 
 ### Calendar (12 tools)
@@ -133,7 +133,9 @@ gmail_resolve_web_id(id="thread-f:1821570065795440641")
 #### Gmail Extended
 | Tool | Description |
 |------|-------------|
-| `gmail_get_attachment` | Download attachment |
+| `gmail_get_attachment` | Download attachment as base64 data |
+| `gmail_list_attachments` | List downloadable attachments on a message |
+| `gmail_download_attachment` | Save a message attachment to a local file |
 | `gmail_list_filters` / `gmail_create_filter` / `gmail_delete_filter` | Filter management |
 | `gmail_create_label` / `gmail_update_label` / `gmail_delete_label` | Label management |
 | `gmail_list_drafts` / `gmail_get_draft` / `gmail_update_draft` / `gmail_delete_draft` / `gmail_send_draft` | Draft management |
@@ -337,6 +339,13 @@ All tools accept an optional `account` parameter:
 2. gmail_get({"message_id": "...", "account": "support"})
 3. gmail_reply({"message_id": "...", "body": "Thanks for reaching out...", "attachments": ["/abs/path/to/form.pdf"]})
 4. gmail_batch_archive({"message_ids": [...]})
+```
+
+To inspect an inbound attachment:
+
+```
+1. gmail_list_attachments({"message_id": "...", "account": "support"})
+2. gmail_download_attachment({"message_id": "...", "attachment_id": "...", "output_dir": "~/Desktop", "account": "support"})
 ```
 
 </details>

--- a/internal/gmail/gmail_extended.go
+++ b/internal/gmail/gmail_extended.go
@@ -9,7 +9,11 @@ import (
 // === Handle functions - generated via WrapHandler ===
 
 // Attachment Tools
-var HandleGmailGetAttachment = common.WrapHandler[GmailService](TestableGmailGetAttachment)
+var (
+	HandleGmailGetAttachment      = common.WrapHandler[GmailService](TestableGmailGetAttachment)
+	HandleGmailListAttachments    = common.WrapHandler[GmailService](TestableGmailListAttachments)
+	HandleGmailDownloadAttachment = common.WrapHandler[GmailService](TestableGmailDownloadAttachment)
+)
 
 // Filter Tools
 var (

--- a/internal/gmail/gmail_extended_test.go
+++ b/internal/gmail/gmail_extended_test.go
@@ -2,6 +2,8 @@ package gmail
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"google.golang.org/api/gmail/v1"
@@ -84,6 +86,168 @@ func TestGmailGetAttachment_MissingAttachmentID(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Error("expected error for missing attachment_id")
+	}
+}
+
+func TestGmailListAttachments_Success(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	fixtures.MockService.AddMessage(newTestMessageWithAttachment("msg-att-1"))
+
+	request := makeRequest(map[string]any{
+		"message_id": "msg-att-1",
+	})
+
+	result, err := TestableGmailListAttachments(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	response := extractResponse(t, result)
+	if got := response["count"]; got != float64(1) {
+		t.Fatalf("count: got %v, want 1", got)
+	}
+	attachments, ok := response["attachments"].([]any)
+	if !ok {
+		t.Fatalf("expected attachments array, got %T", response["attachments"])
+	}
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	attachment := attachments[0].(map[string]any)
+	if got := attachment["attachment_id"]; got != "ATT-PDF-1" {
+		t.Errorf("attachment_id: got %v, want ATT-PDF-1", got)
+	}
+	if got := attachment["filename"]; got != "spec.pdf" {
+		t.Errorf("filename: got %v, want spec.pdf", got)
+	}
+}
+
+func TestGmailDownloadAttachment_SingleAttachmentToOutputDir(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	fixtures.MockService.AddMessage(newTestMessageWithAttachment("msg-att-1"))
+	outputDir := t.TempDir()
+
+	request := makeRequest(map[string]any{
+		"message_id": "msg-att-1",
+		"output_dir": outputDir,
+	})
+
+	result, err := TestableGmailDownloadAttachment(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	response := extractResponse(t, result)
+	outputPath, ok := response["path"].(string)
+	if !ok || outputPath == "" {
+		t.Fatalf("expected output path, got %v", response["path"])
+	}
+	if outputPath != filepath.Join(outputDir, "spec.pdf") {
+		t.Fatalf("path: got %q, want output dir/spec.pdf", outputPath)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(data) != "Hello World!" {
+		t.Fatalf("downloaded data: got %q, want Hello World!", data)
+	}
+	if got := response["bytes_written"]; got != float64(len("Hello World!")) {
+		t.Errorf("bytes_written: got %v, want %d", got, len("Hello World!"))
+	}
+}
+
+func TestGmailDownloadAttachment_SanitizesFilename(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	msg := newTestMessageWithAttachment("msg-att-unsafe")
+	msg.Payload.Parts[1].Filename = "../../secret.txt"
+	fixtures.MockService.AddMessage(msg)
+	outputDir := t.TempDir()
+
+	request := makeRequest(map[string]any{
+		"message_id": "msg-att-unsafe",
+		"output_dir": outputDir,
+	})
+
+	result, err := TestableGmailDownloadAttachment(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	response := extractResponse(t, result)
+	outputPath := response["path"].(string)
+	if outputPath != filepath.Join(outputDir, "secret.txt") {
+		t.Fatalf("path escaped output dir or kept unsafe name: %q", outputPath)
+	}
+}
+
+func TestGmailDownloadAttachment_RefusesOverwriteByDefault(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	fixtures.MockService.AddMessage(newTestMessageWithAttachment("msg-att-1"))
+	outputPath := filepath.Join(t.TempDir(), "existing.pdf")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("write existing fixture: %v", err)
+	}
+
+	request := makeRequest(map[string]any{
+		"message_id":  "msg-att-1",
+		"output_path": outputPath,
+	})
+
+	result, err := TestableGmailDownloadAttachment(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected overwrite protection error")
+	}
+}
+
+func TestGmailDownloadAttachment_RequiresSelectionForMultipleAttachments(t *testing.T) {
+	fixtures := NewGmailTestFixtures()
+	fixtures.MockService.AddMessage(&gmail.Message{
+		Id:       "msg-multi",
+		ThreadId: "thread1",
+		Payload: &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Parts: []*gmail.MessagePart{
+				{
+					PartId:   "1",
+					MimeType: "application/pdf",
+					Filename: "first.pdf",
+					Body:     &gmail.MessagePartBody{AttachmentId: "A1", Size: 100},
+				},
+				{
+					PartId:   "2",
+					MimeType: "image/jpeg",
+					Filename: "second.jpg",
+					Body:     &gmail.MessagePartBody{AttachmentId: "A2", Size: 200},
+				},
+			},
+		},
+	})
+
+	request := makeRequest(map[string]any{
+		"message_id": "msg-multi",
+		"output_dir": t.TempDir(),
+	})
+
+	result, err := TestableGmailDownloadAttachment(context.Background(), request, fixtures.Deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected selection error")
 	}
 }
 

--- a/internal/gmail/register.go
+++ b/internal/gmail/register.go
@@ -186,6 +186,25 @@ func registerExtendedTools(s *server.MCPServer) {
 		common.WithAccountParam(),
 	), HandleGmailGetAttachment)
 
+	// gmail_list_attachments - List attachment metadata
+	s.AddTool(mcp.NewTool("gmail_list_attachments",
+		mcp.WithDescription("List downloadable attachments on a Gmail message, including attachment_id, part_id, filename, MIME type, and size."),
+		mcp.WithString("message_id", mcp.Required(), mcp.Description("Gmail message ID containing the attachment")),
+		common.WithAccountParam(),
+	), HandleGmailListAttachments)
+
+	// gmail_download_attachment - Save attachment to a local file
+	s.AddTool(mcp.NewTool("gmail_download_attachment",
+		mcp.WithDescription("Download a Gmail attachment and write it to a local file. If the message has exactly one attachment, attachment_id/part_id can be omitted."),
+		mcp.WithString("message_id", mcp.Required(), mcp.Description("Gmail message ID containing the attachment")),
+		mcp.WithString("attachment_id", mcp.Description("Attachment ID from gmail_list_attachments or message payload")),
+		mcp.WithString("part_id", mcp.Description("Part ID from gmail_list_attachments; useful when selecting among multiple attachments")),
+		mcp.WithString("output_path", mcp.Description("Optional local file path to write. Parent directories are created. If omitted, writes to a temporary gsuite-mcp-attachments directory.")),
+		mcp.WithString("output_dir", mcp.Description("Optional local directory to write the sanitized attachment filename into. Mutually exclusive with output_path.")),
+		mcp.WithBoolean("overwrite", mcp.Description("Replace an existing output file (default: false)")),
+		common.WithAccountParam(),
+	), HandleGmailDownloadAttachment)
+
 	// gmail_list_filters - List all filters
 	s.AddTool(mcp.NewTool("gmail_list_filters",
 		mcp.WithDescription("List all Gmail filters for an account"),

--- a/internal/gmail/testable_messages.go
+++ b/internal/gmail/testable_messages.go
@@ -2,7 +2,11 @@ package gmail
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aliwatters/gsuite-mcp/internal/common"
@@ -368,6 +372,271 @@ func TestableGmailGetAttachment(ctx context.Context, request mcp.CallToolRequest
 	}
 
 	return common.MarshalToolResult(result)
+}
+
+// TestableGmailListAttachments lists downloadable attachments on a message.
+func TestableGmailListAttachments(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	messageID, errResult := common.RequireStringArg(request.GetArguments(), "message_id")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	msg, err := svc.GetMessage(ctx, messageID, "full")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	attachments := ExtractAttachments(msg.Payload)
+	if attachments == nil {
+		attachments = []map[string]any{}
+	}
+	result := map[string]any{
+		"message_id":   messageID,
+		"count":        len(attachments),
+		"attachments":  attachments,
+		"has_multiple": len(attachments) > 1,
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+// TestableGmailDownloadAttachment decodes a Gmail attachment and writes it to disk.
+func TestableGmailDownloadAttachment(ctx context.Context, request mcp.CallToolRequest, deps *GmailHandlerDeps) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	messageID, errResult := common.RequireStringArg(args, "message_id")
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	svc, errResult, ok := ResolveGmailServiceOrError(ctx, request, deps)
+	if !ok {
+		return errResult, nil
+	}
+
+	msg, err := svc.GetMessage(ctx, messageID, "full")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	attachments := ExtractAttachments(msg.Payload)
+	selected, selectErr := selectAttachment(attachments, common.ParseStringArg(args, "attachment_id", ""), common.ParseStringArg(args, "part_id", ""))
+	if selectErr != nil {
+		return mcp.NewToolResultError(selectErr.Error()), nil
+	}
+
+	attachmentID := attachmentString(selected, "attachment_id")
+	attach, err := svc.GetAttachment(ctx, messageID, attachmentID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Gmail API error: %v", err)), nil
+	}
+
+	data, err := decodeGmailAttachmentData(attach.Data)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	filename := sanitizeAttachmentFilename(attachmentString(selected, "filename"), "attachment-"+attachmentID)
+	outputPath, err := resolveAttachmentOutputPath(args, filename)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if err := writeAttachmentFile(outputPath, data, common.ParseBoolArg(args, "overwrite", false)); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	sum := sha256.Sum256(data)
+	result := map[string]any{
+		"message_id":     messageID,
+		"attachment_id":  attachmentID,
+		"filename":       filename,
+		"mime_type":      attachmentString(selected, "mime_type"),
+		"path":           outputPath,
+		"size":           attach.Size,
+		"bytes_written":  len(data),
+		"sha256":         fmt.Sprintf("%x", sum),
+		"overwrote_file": common.ParseBoolArg(args, "overwrite", false),
+	}
+	if partID := attachmentString(selected, "part_id"); partID != "" {
+		result["part_id"] = partID
+	}
+
+	return common.MarshalToolResult(result)
+}
+
+func selectAttachment(attachments []map[string]any, attachmentID string, partID string) (map[string]any, error) {
+	if len(attachments) == 0 {
+		return nil, fmt.Errorf("message has no downloadable attachments")
+	}
+
+	for _, attachment := range attachments {
+		if attachmentID != "" && attachmentString(attachment, "attachment_id") == attachmentID {
+			if partID != "" && attachmentString(attachment, "part_id") != partID {
+				return nil, fmt.Errorf("attachment_id %q is not on part_id %q", attachmentID, partID)
+			}
+			return attachment, nil
+		}
+		if attachmentID == "" && partID != "" && attachmentString(attachment, "part_id") == partID {
+			return attachment, nil
+		}
+	}
+
+	if attachmentID != "" {
+		return nil, fmt.Errorf("attachment_id %q was not found on message", attachmentID)
+	}
+	if partID != "" {
+		return nil, fmt.Errorf("part_id %q was not found on message", partID)
+	}
+	if len(attachments) > 1 {
+		return nil, fmt.Errorf("message has %d attachments; provide attachment_id or part_id from gmail_list_attachments", len(attachments))
+	}
+
+	return attachments[0], nil
+}
+
+func attachmentString(attachment map[string]any, key string) string {
+	value, _ := attachment[key].(string)
+	return value
+}
+
+func decodeGmailAttachmentData(data string) ([]byte, error) {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return []byte{}, nil
+	}
+
+	encodings := []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.StdEncoding,
+	}
+	var lastErr error
+	for _, encoding := range encodings {
+		decoded, err := encoding.DecodeString(data)
+		if err == nil {
+			return decoded, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("failed to decode attachment data: %w", lastErr)
+}
+
+func resolveAttachmentOutputPath(args map[string]any, filename string) (string, error) {
+	outputPath := common.ParseStringArg(args, "output_path", "")
+	outputDir := common.ParseStringArg(args, "output_dir", "")
+	if outputPath != "" && outputDir != "" {
+		return "", fmt.Errorf("use output_path or output_dir, not both")
+	}
+
+	var path string
+	switch {
+	case outputPath != "":
+		path = outputPath
+	case outputDir != "":
+		path = filepath.Join(outputDir, filename)
+	default:
+		path = filepath.Join(os.TempDir(), "gsuite-mcp-attachments", filename)
+	}
+
+	expanded, err := expandUserPath(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.ContainsRune(expanded, 0) {
+		return "", fmt.Errorf("output path contains an invalid NUL byte")
+	}
+	if expanded == "" {
+		return "", fmt.Errorf("output path is required")
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded, err = filepath.Abs(expanded)
+		if err != nil {
+			return "", fmt.Errorf("resolve output path: %w", err)
+		}
+	}
+	return filepath.Clean(expanded), nil
+}
+
+func expandUserPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		if path == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	return path, nil
+}
+
+func sanitizeAttachmentFilename(filename string, fallback string) string {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		filename = fallback
+	}
+	filename = strings.ReplaceAll(filename, "\\", "/")
+	filename = filepath.Base(filename)
+	filename = strings.Trim(filename, ". ")
+
+	var b strings.Builder
+	for _, r := range filename {
+		switch r {
+		case 0, '/', '\\':
+			b.WriteRune('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	cleaned := strings.TrimSpace(b.String())
+	if cleaned == "" || cleaned == "." {
+		return fallback
+	}
+	return cleaned
+}
+
+func writeAttachmentFile(path string, data []byte, overwrite bool) error {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return fmt.Errorf("output path %q is a directory", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("check output path %q: %w", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	flags := os.O_WRONLY | os.O_CREATE
+	if overwrite {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+
+	file, err := os.OpenFile(path, flags, 0o600)
+	if os.IsExist(err) {
+		return fmt.Errorf("output file %q already exists; pass overwrite=true to replace it", path)
+	}
+	if err != nil {
+		return fmt.Errorf("open output file %q: %w", path, err)
+	}
+
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close output file %q: %w", path, err)
+	}
+	return nil
 }
 
 // TestableGmailArchive archives a message.

--- a/internal/mcptest/mcptest.go
+++ b/internal/mcptest/mcptest.go
@@ -24,7 +24,7 @@ const (
 // ServiceToolCounts maps each service to its expected tool count.
 // Update these when adding/removing tools.
 var ServiceToolCounts = map[string]int{
-	"gmail":    51,
+	"gmail":    53,
 	"calendar": 12,
 	"drive":    23,
 	"docs":     29,


### PR DESCRIPTION
## Summary

- add `gmail_list_attachments` for message attachment metadata
- add `gmail_download_attachment` to decode and write attachments to local files
- preserve `gmail_get_attachment` for raw base64 callers
- document the list/download workflow and update MCP tool-count fixtures

Closes #192

## Test Plan

- `go test ./...`
- `go vet ./...`
- `go build -o gsuite-mcp ./cmd/gsuite-mcp`