### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses a patch-first versioning policy — see [RELEASING.md](RELEASING.md) for the full policy.
 
+## [0.4.7] - 2026-07-10
+
+### Fixed
+
+- Corrected the embedded CLI/server version reported by `gsuite-mcp version`.
+
 ## [0.4.6] - 2026-07-10
 
 ### Added

--- a/cmd/gsuite-mcp/main.go
+++ b/cmd/gsuite-mcp/main.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	serverName    = "gsuite-mcp"
-	serverVersion = "0.4.5"
+	serverVersion = "0.4.7"
 )
 
 // GitCommit is injected at build time via (run from the repo root):


### PR DESCRIPTION
## Summary
- bump embedded gsuite-mcp CLI/server version to 0.4.7
- document the version correction in the changelog

## Validation
- go test ./...
- go vet ./...
- go build -ldflags "-X main.GitCommit=$(git rev-parse --short HEAD)" -o /tmp/gsuite-mcp-versioncheck ./cmd/gsuite-mcp
- /tmp/gsuite-mcp-versioncheck version